### PR TITLE
docs: resolve README screenshots and docs consistency pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format follows Keep a Changelog principles and this project uses date-based 
 
 - Added AI Production OS v1 documentation pack in `docs/`.
 - Added reusable workflow setup guide: `docs/WORKFLOW_AUTOMATION_PLAYBOOK.md`.
+- Added README screenshots using committed assets and removed duplicate image blocks.
+- Updated roadmap Week 2 deployment references from generic static hosting to Vercel.
 
 ### Infra
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,6 @@ npm run build
 
 ### Analytics
 ![JobSprint Analytics](./docs/assets/analytics.png)
-![JobSprint Dashboard](docs/assets/dashboard.png)
-
-### Analytics
-![JobSprint Analytics](docs/assets/analytics.png)
-
 
 ## Documentation
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,18 +34,18 @@ Project has deploy and release discipline visible to external reviewers.
 
 - Add CI workflow for build checks.
 - Add issue templates and PR template.
-- Add deploy workflow scaffold for static hosting.
+- Ensure Vercel deployment is active and documented in README.
 - Add changelog with first adoption entry.
 
 ### Definition of Done
 
 - CI runs on pushes and pull requests.
-- Deploy workflow exists and is documented for activation.
+- Vercel deployment URL is live and documented.
 - Changelog updated with dated entry.
 
 ### Demo Artifact
 
-- Screenshot or Loom of successful CI run and deploy workflow file.
+- Screenshot or Loom of successful CI run and live Vercel deploy.
 
 ## Week 3: Add One Signal Feature
 
@@ -109,4 +109,3 @@ Data entry errors decrease and destructive actions are safer.
 - No large-scale component library refactor.
 - No multi-user collaboration features.
 - No ATS integrations before persistence/auth baseline.
-


### PR DESCRIPTION
Closes #9\nCloses #10\n\n## What\n- cleaned duplicated screenshot markdown blocks in README\n- kept screenshot references on committed assets in docs/assets/\n- aligned roadmap Week 2 deployment wording with current Vercel deployment (removed static-hosting wording)\n- updated changelog with these docs consistency updates\n\n## Why\nIssue #9 required making screenshots correctly visible in README. Issue #10 required consistency across docs, and roadmap deployment wording had drifted from the current Vercel reality.\n\n## How To Test\n1. Open README on GitHub and verify exactly one Dashboard and one Analytics screenshot render\n2. Open docs/ROADMAP.md and verify Week 2 references Vercel deployment\n3. Run 
pm run build and confirm it succeeds\n\n## Evidence\n- Issue: #9, #10\n- Demo artifact: README screenshots render from docs/assets/dashboard.png and docs/assets/analytics.png\n\n## Risk and Rollback\n- Risk level: low\n- Rollback plan: revert this PR commit