### PR TITLE
docs: refresh status, roadmap, and next-session handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format follows Keep a Changelog principles and this project uses date-based 
 - Added reusable workflow setup guide: `docs/WORKFLOW_AUTOMATION_PLAYBOOK.md`.
 - Added README screenshots using committed assets and removed duplicate image blocks.
 - Updated roadmap Week 2 deployment references from generic static hosting to Vercel.
+- Updated roadmap/readme status to reflect completed Month 2 and added `docs/NEXT_SESSION_START.md`.
 
 ### Infra
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Most job searches fail from inconsistent execution, not lack of talent. JobSprin
 
 ## Current Status
 
-- Stage: MVP (single-user, local-first)
-- Scope: dashboard, pipeline tracking, analytics, weekly execution panel
-- Adoption: AI Production OS v1 process added on March 2, 2026
+- Stage: MVP+ (Firebase auth + Firestore persistence enabled)
+- Scope: dashboard, pipeline tracking, analytics, weekly execution panel, sync status, safe delete undo
+- Adoption: AI Production OS v1 process active since March 2, 2026
+- Milestone checkpoint: Month 2 foundation completed on March 3, 2026
 
 ## Tech Stack
 
@@ -28,7 +29,7 @@ npm install
 npm run dev
 ```
 
-App access now requires sign-in with email (local session bootstrap).
+App access requires sign-in. If Firebase env vars are configured, auth uses Firebase email/password + Google sign-in.
 If Firebase env vars are configured, sign-in uses Firebase email/password auth.
 
 Build for production:
@@ -48,6 +49,7 @@ npm run test
 - Current production URL: https://job-sprint-ten.vercel.app/
 - Hosting: Vercel
 - Optional remote persistence can be configured with `VITE_JSPRINT_REMOTE_API_URL`.
+- Firebase mode (Auth + Firestore) is enabled automatically when required `VITE_FIREBASE_*` variables are set.
 - Firebase mode (auth + Firestore) is enabled when required `VITE_FIREBASE_*` values are set.
 
 ## Screenshots
@@ -66,6 +68,7 @@ npm run test
 - [Decisions Log](./docs/DECISIONS_LOG.md)
 - [Workflow Automation Playbook](./docs/WORKFLOW_AUTOMATION_PLAYBOOK.md)
 - [Cross-Device Sync Checklist](./docs/CROSS_DEVICE_SYNC_CHECKLIST.md)
+- [Next Session Start](./docs/NEXT_SESSION_START.md)
 - [Contributing Guide](./CONTRIBUTING.md)
 - [Changelog](./CHANGELOG.md)
   

--- a/docs/DECISIONS_LOG.md
+++ b/docs/DECISIONS_LOG.md
@@ -69,3 +69,23 @@
 - Consequences:
   - Positive: immediate route protection and per-user state separation.
   - Negative: not production-grade identity until hosted auth is integrated.
+
+## ADR-008: Adopt Firebase Auth + Firestore for M2 Delivery
+
+- Date: 2026-03-03
+- Status: Accepted
+- Context: Needed production-credible identity and persistence without building custom backend services.
+- Decision: Use Firebase email/password and Google auth, with Firestore document storage per user.
+- Consequences:
+  - Positive: faster production-grade auth + data persistence.
+  - Negative: dependency on Firebase network availability and browser privacy settings.
+
+## ADR-009: Offline-Tolerant Fallback in Firebase Mode
+
+- Date: 2026-03-03
+- Status: Accepted
+- Context: Firestore connectivity errors caused degraded startup UX despite valid auth sessions.
+- Decision: Fallback to local cached state when Firestore returns temporary offline/unavailable errors.
+- Consequences:
+  - Positive: app remains usable during transient network failures.
+  - Negative: data may be temporarily stale until successful resync.

--- a/docs/NEXT_SESSION_START.md
+++ b/docs/NEXT_SESSION_START.md
@@ -1,0 +1,43 @@
+# Next Session Start
+
+Last updated: 2026-03-03
+
+## Where We Are
+
+- All planned Week 1-4 and Month 2 issues are closed.
+- Firebase auth + Firestore persistence are integrated.
+- Current production URL: https://job-sprint-ten.vercel.app/
+
+## Start Here (first 30 minutes)
+
+1. Pull latest `main` and run checks:
+   - `npm install`
+   - `npm run test`
+   - `npm run build`
+2. Verify Firebase env vars in local `.env` and Vercel environment settings.
+3. Reproduce quick smoke in browser:
+   - Sign in (email/password or Google)
+   - Create one application
+   - Refresh page and confirm persistence
+4. Open new Month 3 issues (or confirm they exist) for:
+   - E2E baseline (Playwright)
+   - Import/export feature
+   - Case-study and demo artifact packaging
+
+## Recommended First Issue Next Session
+
+`[M3-01] chore: add Playwright E2E baseline for auth + CRUD + pipeline`
+
+Acceptance criteria:
+
+- Login flow test passes.
+- Create/edit/move/delete application flow test passes.
+- Refresh persistence assertion passes.
+- E2E job runs in CI on pull requests.
+
+## Risks To Watch
+
+- Browser privacy blockers (especially Brave Shields) can break Firebase connectivity.
+- Firestore authorization rules must stay aligned with user-scoped document path.
+- Bundle size is high; defer optimization unless it blocks UX.
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,13 @@
 # Roadmap
 
+## Completion Snapshot (as of 2026-03-03)
+
+- Week 1 complete: baseline docs and repo clarity.
+- Week 2 complete: workflow governance and release discipline.
+- Week 3 complete: 7-day activity signal + app-level error boundary.
+- Week 4 complete: form hardening, safe delete with undo, smoke tests.
+- Month 2 complete: persistence boundary, migration helper, auth/session, sync status, Firebase integration.
+
 ## Next 4 Weeks
 
 ## Week 1: Stabilize Baseline
@@ -102,6 +110,14 @@ Data entry errors decrease and destructive actions are safer.
 - Publish structured demo narrative and case-study assets.
 - Add import/export path for portability.
 - Add release KPI snapshots for visible progress trend.
+- Add first E2E suite for auth + CRUD + pipeline + refresh persistence.
+- Add offline/connection UX polish for Firebase sync errors.
+
+## Next Session Starting Point
+
+1. Create issues for Month 3 scope (E2E baseline, import/export, case-study docs).
+2. Implement E2E scaffolding first (Playwright + CI integration for a happy-path flow).
+3. Ship one visible portfolio artifact update (case-study section in README with Loom link).
 
 ## Freeze List
 


### PR DESCRIPTION
Closes #35

## What
- updated README current status to reflect completed Month 2/Firebase milestone
- updated roadmap with completion snapshot and explicit next-session starting point
- added `docs/NEXT_SESSION_START.md` handoff playbook
- updated decisions log with latest architecture/auth/fallback decisions
- updated changelog docs section for this refresh

## Why
Documentation had drifted after rapid delivery. This aligns project docs with current reality and makes next-session execution unambiguous.

## How To Test
1. Open README and confirm status + docs links are current
2. Open `docs/ROADMAP.md` and verify completion snapshot + next-session start section
3. Open `docs/NEXT_SESSION_START.md` and verify startup checklist

## Evidence
- Issue: #35
- Local verification: `npm run build` passes

## Risk and Rollback
- Risk level: low
- Rollback plan: revert this docs-only commit