### PR TITLE
fix(deps): align @eslint/js to v9 to match eslint@9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "vaul": "1.1.2"
       },
       "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.3",
         "@tailwindcss/vite": "4.1.12",
         "@vitejs/plugin-react": "4.7.0",
         "eslint": "^9.39.3",
@@ -923,24 +923,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -5125,19 +5117,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
-      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "vaul": "1.1.2"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.3",
     "@tailwindcss/vite": "4.1.12",
     "@vitejs/plugin-react": "4.7.0",
     "eslint": "^9.39.3",


### PR DESCRIPTION
@eslint/js@10 requires eslint@10, causing npm ci to fail in CI with a peer-dependency conflict. Pin @eslint/js to ^9 so all ESLint packages are on the same major version.

Closes #N/A

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

