### PR TITLE
feat(ci): add weekly roadmap sync workflow

### DIFF
--- a/.github/workflows/weekly-sync.yml
+++ b/.github/workflows/weekly-sync.yml
@@ -1,0 +1,55 @@
+name: Weekly Roadmap Sync
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Every Monday at 09:00 UTC
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  issues: write
+
+jobs:
+  open-sync-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create weekly roadmap sync issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const today = new Date().toISOString().slice(0, 10);
+
+            const body = `## Weekly Roadmap Sync — ${today}
+
+            Use this issue to review and set direction for the week.
+            Close it once all items are actioned.
+
+            ---
+
+            ### Checklist
+
+            - [ ] **Review open issues & PRs** — triage anything unresolved from last week; add labels, re-assign, or close as needed.
+            - [ ] **Pick the top 3 issues for this week** — comment below with the issue numbers you are committing to shipping.
+            - [ ] **Close or de-scope stale issues** — remove issues that are no longer relevant or have been superseded.
+            - [ ] **Update CHANGELOG / release notes** — record what shipped since the last sync.
+
+            ---
+
+            ### This week's focus (fill in)
+
+            1. #
+            2. #
+            3. #
+
+            ---
+
+            _Opened automatically by the [Weekly Roadmap Sync workflow](../actions/workflows/weekly-sync.yml).
+            Roadmap decisions are owned by the human maintainer — see [CLAUDE.md](../blob/main/CLAUDE.md)._
+            `;
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Weekly Roadmap Sync — ${today}`,
+              body,
+              labels: ["roadmap", "sync"],
+            });


### PR DESCRIPTION
Opens a GitHub issue every Monday at 09:00 UTC with a structured checklist covering open issue triage, top-3 weekly focus selection, stale issue de-scoping, and CHANGELOG updates. Also supports manual trigger via workflow_dispatch.

Closes #N/A

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

