### PR TITLE
feat(compliance): add AfA Vermittlungsvorschlag compliance module

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ export default tseslint.config(
     plugins: { "react-hooks": reactHooks },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
       "@typescript-eslint/no-explicit-any": "warn",
     },
   }

--- a/src/app/components/compliance/AfaCaseModal.tsx
+++ b/src/app/components/compliance/AfaCaseModal.tsx
@@ -1,0 +1,572 @@
+import { useState, useEffect } from "react";
+import { ExternalLink } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { Textarea } from "../ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { Badge } from "../ui/badge";
+import type {
+  AfaVorschlag,
+  AfaVorschlagFormData,
+  AfaSource,
+  AfaRfbPresent,
+  AfaPortalFeedbackRequired,
+  AfaMatchLevel,
+  AfaActionStatus,
+  AfaEmployerResponse,
+  AfaRiskStatus,
+  AfaDeadlineStatus,
+} from "../../types/afa";
+
+// ---------------------------------------------------------------------------
+// Badge helpers (duplicated locally to keep component self-contained)
+// ---------------------------------------------------------------------------
+
+function riskClass(risk: AfaRiskStatus): string {
+  switch (risk) {
+    case "HIGH":   return "bg-red-100 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800";
+    case "MEDIUM": return "bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-800";
+    case "SAFE":   return "bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800";
+    case "LOW":    return "bg-neutral-100 text-neutral-600 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-400 dark:border-neutral-700";
+    default:       return "bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-800";
+  }
+}
+
+function deadlineClass(status: AfaDeadlineStatus): string {
+  switch (status) {
+    case "OVERDUE":  return "bg-red-100 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800";
+    case "URGENT":   return "bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-800";
+    case "UPCOMING": return "bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-800";
+    case "SAFE":     return "bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800";
+    default:         return "bg-neutral-100 text-neutral-600 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-400 dark:border-neutral-700";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default form state
+// ---------------------------------------------------------------------------
+
+const EMPTY_FORM: AfaVorschlagFormData = {
+  source: "portal",
+  received_date: new Date().toISOString().slice(0, 10),
+  deadline_date: null,
+  rfb_present: "unknown",
+  portal_feedback_required: "unknown",
+  employer_name: "",
+  position_title: "",
+  location: "",
+  posting_url: "",
+  match_level: "medium",
+  action_status: "received",
+  applied_date: null,
+  portal_feedback_date: null,
+  employer_response: "pending",
+  evidence: {
+    folder_url: "",
+    letter_file_url: "",
+    application_proof_url: "",
+    portal_feedback_proof_url: "",
+  },
+  notes: "",
+};
+
+function vorschlagToForm(v: AfaVorschlag): AfaVorschlagFormData {
+  return {
+    source: v.source,
+    received_date: v.received_date,
+    deadline_date: v.deadline_date,
+    rfb_present: v.rfb_present,
+    portal_feedback_required: v.portal_feedback_required,
+    employer_name: v.employer_name,
+    position_title: v.position_title,
+    location: v.location,
+    posting_url: v.posting_url,
+    match_level: v.match_level,
+    action_status: v.action_status,
+    applied_date: v.applied_date,
+    portal_feedback_date: v.portal_feedback_date,
+    employer_response: v.employer_response,
+    evidence: { ...v.evidence },
+    notes: v.notes,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Section header
+// ---------------------------------------------------------------------------
+
+function SectionHeader({ title }: { title: string }) {
+  return (
+    <h3 className="text-xs font-semibold text-neutral-500 dark:text-neutral-400 uppercase tracking-wider border-b border-neutral-200 dark:border-neutral-800 pb-1 mb-3">
+      {title}
+    </h3>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Evidence row
+// ---------------------------------------------------------------------------
+
+function EvidenceRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <Label className="text-xs">{label}</Label>
+      <div className="flex gap-2 mt-1">
+        <Input
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="https://…"
+          className="flex-1"
+        />
+        {value && (
+          <a
+            href={value}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center w-9 h-9 border border-neutral-200 dark:border-neutral-700 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+          >
+            <ExternalLink className="w-4 h-4 text-neutral-500" />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface AfaCaseModalProps {
+  open: boolean;
+  vorschlag: AfaVorschlag | null; // null = new case
+  onClose: () => void;
+  onSave: (data: AfaVorschlagFormData) => void;
+  onDelete?: (id: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AfaCaseModal({
+  open,
+  vorschlag,
+  onClose,
+  onSave,
+  onDelete,
+}: AfaCaseModalProps) {
+  const isEdit = vorschlag !== null;
+  const [form, setForm] = useState<AfaVorschlagFormData>(EMPTY_FORM);
+
+  useEffect(() => {
+    if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setForm(isEdit ? vorschlagToForm(vorschlag) : EMPTY_FORM);
+  }, [open, vorschlag, isEdit]);
+
+  function update<K extends keyof AfaVorschlagFormData>(
+    key: K,
+    value: AfaVorschlagFormData[K]
+  ) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function updateEvidence(
+    key: keyof AfaVorschlagFormData["evidence"],
+    value: string
+  ) {
+    setForm((prev) => ({
+      ...prev,
+      evidence: { ...prev.evidence, [key]: value },
+    }));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    onSave(form);
+    onClose();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit
+              ? `Case ${vorschlag.case_id}`
+              : "New Vermittlungsvorschlag"}
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* Computed status (edit mode only) */}
+        {isEdit && (
+          <div className="flex flex-wrap gap-2 -mt-1">
+            <Badge variant="outline" className={riskClass(vorschlag.computed.risk_status)}>
+              Risk: {vorschlag.computed.risk_status}
+            </Badge>
+            <Badge variant="outline" className={deadlineClass(vorschlag.computed.deadline_status)}>
+              Deadline: {vorschlag.computed.deadline_status}
+              {vorschlag.computed.days_left !== null &&
+                ` (${vorschlag.computed.days_left}d)`}
+            </Badge>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-5 mt-2">
+
+          {/* Core Info */}
+          <div>
+            <SectionHeader title="Core Info" />
+            {isEdit && (
+              <div className="mb-3">
+                <Label className="text-xs">Case ID</Label>
+                <p className="mt-1 font-mono text-sm text-neutral-500 dark:text-neutral-400">
+                  {vorschlag.case_id}
+                </p>
+              </div>
+            )}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label htmlFor="received_date">Received Date *</Label>
+                <Input
+                  id="received_date"
+                  type="date"
+                  value={form.received_date}
+                  onChange={(e) => update("received_date", e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="source">Source *</Label>
+                <Select
+                  value={form.source}
+                  onValueChange={(v) => update("source", v as AfaSource)}
+                >
+                  <SelectTrigger id="source">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="portal">Portal</SelectItem>
+                    <SelectItem value="paper">Paper</SelectItem>
+                    <SelectItem value="email">Email</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="employer_name">Employer *</Label>
+                <Input
+                  id="employer_name"
+                  value={form.employer_name}
+                  onChange={(e) => update("employer_name", e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="position_title">Position *</Label>
+                <Input
+                  id="position_title"
+                  value={form.position_title}
+                  onChange={(e) => update("position_title", e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="location">Location</Label>
+                <Input
+                  id="location"
+                  value={form.location}
+                  onChange={(e) => update("location", e.target.value)}
+                />
+              </div>
+              <div>
+                <Label htmlFor="match_level">Match Level</Label>
+                <Select
+                  value={form.match_level}
+                  onValueChange={(v) => update("match_level", v as AfaMatchLevel)}
+                >
+                  <SelectTrigger id="match_level">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="high">High</SelectItem>
+                    <SelectItem value="medium">Medium</SelectItem>
+                    <SelectItem value="low">Low</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="col-span-2">
+                <Label htmlFor="posting_url">Job Posting URL</Label>
+                <div className="flex gap-2">
+                  <Input
+                    id="posting_url"
+                    value={form.posting_url}
+                    onChange={(e) => update("posting_url", e.target.value)}
+                    placeholder="https://…"
+                    className="flex-1"
+                  />
+                  {form.posting_url && (
+                    <a
+                      href={form.posting_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center justify-center w-9 h-9 border border-neutral-200 dark:border-neutral-700 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+                    >
+                      <ExternalLink className="w-4 h-4 text-neutral-500" />
+                    </a>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Risk Section */}
+          <div>
+            <SectionHeader title="Risk & RFB" />
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label htmlFor="rfb_present">RFB Present</Label>
+                <Select
+                  value={form.rfb_present}
+                  onValueChange={(v) =>
+                    update("rfb_present", v as AfaRfbPresent)
+                  }
+                >
+                  <SelectTrigger id="rfb_present">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="yes">Yes</SelectItem>
+                    <SelectItem value="no">No</SelectItem>
+                    <SelectItem value="unknown">Unknown</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="portal_feedback_required">
+                  Portal Feedback Required
+                </Label>
+                <Select
+                  value={form.portal_feedback_required}
+                  onValueChange={(v) =>
+                    update(
+                      "portal_feedback_required",
+                      v as AfaPortalFeedbackRequired
+                    )
+                  }
+                >
+                  <SelectTrigger id="portal_feedback_required">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="yes">Yes</SelectItem>
+                    <SelectItem value="no">No</SelectItem>
+                    <SelectItem value="unknown">Unknown</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="applied_date">Applied Date</Label>
+                <Input
+                  id="applied_date"
+                  type="date"
+                  value={form.applied_date ?? ""}
+                  onChange={(e) =>
+                    update("applied_date", e.target.value || null)
+                  }
+                />
+              </div>
+              <div>
+                <Label htmlFor="portal_feedback_date">
+                  Portal Feedback Date
+                </Label>
+                <Input
+                  id="portal_feedback_date"
+                  type="date"
+                  value={form.portal_feedback_date ?? ""}
+                  onChange={(e) =>
+                    update("portal_feedback_date", e.target.value || null)
+                  }
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Deadline Section */}
+          <div>
+            <SectionHeader title="Deadline" />
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label htmlFor="deadline_date">Deadline Date</Label>
+                <Input
+                  id="deadline_date"
+                  type="date"
+                  value={form.deadline_date ?? ""}
+                  onChange={(e) =>
+                    update("deadline_date", e.target.value || null)
+                  }
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Action & Response */}
+          <div>
+            <SectionHeader title="Action & Response" />
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label htmlFor="action_status">Action Status</Label>
+                <Select
+                  value={form.action_status}
+                  onValueChange={(v) =>
+                    update("action_status", v as AfaActionStatus)
+                  }
+                >
+                  <SelectTrigger id="action_status">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="received">Received</SelectItem>
+                    <SelectItem value="reviewing">Reviewing</SelectItem>
+                    <SelectItem value="applied">Applied</SelectItem>
+                    <SelectItem value="feedback_submitted">Feedback Submitted</SelectItem>
+                    <SelectItem value="closed">Closed</SelectItem>
+                    <SelectItem value="justified_non_application">
+                      Justified Non-Application
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="employer_response">Employer Response</Label>
+                <Select
+                  value={form.employer_response}
+                  onValueChange={(v) =>
+                    update("employer_response", v as AfaEmployerResponse)
+                  }
+                >
+                  <SelectTrigger id="employer_response">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="pending">Pending</SelectItem>
+                    <SelectItem value="rejected">Rejected</SelectItem>
+                    <SelectItem value="interview">Interview</SelectItem>
+                    <SelectItem value="offer">Offer</SelectItem>
+                    <SelectItem value="hired">Hired</SelectItem>
+                    <SelectItem value="no_response">No Response</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>
+
+          {/* Evidence Links */}
+          <div>
+            <SectionHeader title="Evidence Links" />
+            <div className="space-y-3">
+              <EvidenceRow
+                label="Document Folder URL"
+                value={form.evidence.folder_url}
+                onChange={(v) => updateEvidence("folder_url", v)}
+              />
+              <EvidenceRow
+                label="Cover Letter File"
+                value={form.evidence.letter_file_url}
+                onChange={(v) => updateEvidence("letter_file_url", v)}
+              />
+              <EvidenceRow
+                label="Application Proof"
+                value={form.evidence.application_proof_url}
+                onChange={(v) => updateEvidence("application_proof_url", v)}
+              />
+              <EvidenceRow
+                label="Portal Feedback Proof"
+                value={form.evidence.portal_feedback_proof_url}
+                onChange={(v) =>
+                  updateEvidence("portal_feedback_proof_url", v)
+                }
+              />
+            </div>
+          </div>
+
+          {/* Notes */}
+          <div>
+            <SectionHeader title="Notes" />
+            <Textarea
+              value={form.notes}
+              onChange={(e) => update("notes", e.target.value)}
+              rows={3}
+              placeholder="Internal notes, context, concerns…"
+            />
+          </div>
+
+          {/* Audit Timeline (edit mode only) */}
+          {isEdit && (
+            <div>
+              <SectionHeader title="Audit Timeline" />
+              <div className="grid grid-cols-2 gap-3 text-xs text-neutral-500 dark:text-neutral-400">
+                <div>
+                  <span className="font-medium">Created</span>
+                  <p>{new Date(vorschlag.audit.created_at).toLocaleString()}</p>
+                </div>
+                <div>
+                  <span className="font-medium">Last Updated</span>
+                  <p>{new Date(vorschlag.audit.updated_at).toLocaleString()}</p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Footer actions */}
+          <div className="flex items-center justify-between pt-2 border-t border-neutral-200 dark:border-neutral-800">
+            <div>
+              {isEdit && onDelete && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+                  onClick={() => {
+                    onDelete(vorschlag.id);
+                    onClose();
+                  }}
+                >
+                  Delete Case
+                </Button>
+              )}
+            </div>
+            <div className="flex gap-3">
+              <Button type="button" variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="submit">
+                {isEdit ? "Save Changes" : "Create Case"}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/components/compliance/AfaDashboard.tsx
+++ b/src/app/components/compliance/AfaDashboard.tsx
@@ -1,0 +1,107 @@
+import { ShieldAlert, Clock, AlertTriangle, CheckCircle2, FileSearch } from "lucide-react";
+import { isThisWeek } from "date-fns";
+import type { AfaVorschlag } from "../../types/afa";
+
+interface AfaDashboardProps {
+  cases: AfaVorschlag[];
+}
+
+interface MetricCardProps {
+  label: string;
+  value: number;
+  icon: React.ReactNode;
+  color: "red" | "orange" | "green" | "blue" | "neutral";
+}
+
+const COLOR_MAP: Record<MetricCardProps["color"], string> = {
+  red: "border-red-200 dark:border-red-900/50 bg-red-50 dark:bg-red-950/30",
+  orange: "border-orange-200 dark:border-orange-900/50 bg-orange-50 dark:bg-orange-950/30",
+  green: "border-green-200 dark:border-green-900/50 bg-green-50 dark:bg-green-950/30",
+  blue: "border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-950/30",
+  neutral: "border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900",
+};
+
+const VALUE_COLOR_MAP: Record<MetricCardProps["color"], string> = {
+  red: "text-red-700 dark:text-red-400",
+  orange: "text-orange-700 dark:text-orange-400",
+  green: "text-green-700 dark:text-green-400",
+  blue: "text-blue-700 dark:text-blue-400",
+  neutral: "text-neutral-900 dark:text-neutral-100",
+};
+
+function MetricCard({ label, value, icon, color }: MetricCardProps) {
+  return (
+    <div className={`border rounded-lg p-4 ${COLOR_MAP[color]}`}>
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs text-neutral-500 dark:text-neutral-400 uppercase tracking-wide font-medium">
+          {label}
+        </span>
+        <span className="opacity-60">{icon}</span>
+      </div>
+      <div className={`text-3xl font-semibold ${VALUE_COLOR_MAP[color]}`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export function AfaDashboard({ cases }: AfaDashboardProps) {
+  const active = cases.filter((c) => c.action_status !== "closed");
+
+  const highRisk = active.filter(
+    (c) => c.computed.risk_status === "HIGH"
+  ).length;
+
+  const urgentDeadlines = active.filter(
+    (c) =>
+      c.computed.deadline_status === "URGENT" ||
+      c.computed.deadline_status === "OVERDUE"
+  ).length;
+
+  const overdue = active.filter(
+    (c) => c.computed.deadline_status === "OVERDUE"
+  ).length;
+
+  const appliedThisWeek = cases.filter(
+    (c) =>
+      c.applied_date !== null &&
+      isThisWeek(new Date(c.applied_date), { weekStartsOn: 1 })
+  ).length;
+
+  const activeRfb = active.filter((c) => c.rfb_present === "yes").length;
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+      <MetricCard
+        label="HIGH Risk Open"
+        value={highRisk}
+        icon={<ShieldAlert className="w-4 h-4 text-red-500" />}
+        color="red"
+      />
+      <MetricCard
+        label="Deadlines ≤ 2 Days"
+        value={urgentDeadlines}
+        icon={<Clock className="w-4 h-4 text-orange-500" />}
+        color="orange"
+      />
+      <MetricCard
+        label="Overdue"
+        value={overdue}
+        icon={<AlertTriangle className="w-4 h-4 text-red-500" />}
+        color={overdue > 0 ? "red" : "neutral"}
+      />
+      <MetricCard
+        label="Applied This Week"
+        value={appliedThisWeek}
+        icon={<CheckCircle2 className="w-4 h-4 text-green-500" />}
+        color="green"
+      />
+      <MetricCard
+        label="Active RFB Cases"
+        value={activeRfb}
+        icon={<FileSearch className="w-4 h-4 text-blue-500" />}
+        color="blue"
+      />
+    </div>
+  );
+}

--- a/src/app/components/compliance/AfaTable.tsx
+++ b/src/app/components/compliance/AfaTable.tsx
@@ -1,0 +1,386 @@
+import { useState, useMemo } from "react";
+import { ArrowUpDown, ExternalLink } from "lucide-react";
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { Input } from "../ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
+import type {
+  AfaVorschlag,
+  AfaRiskStatus,
+  AfaDeadlineStatus,
+  AfaActionStatus,
+} from "../../types/afa";
+
+// ---------------------------------------------------------------------------
+// Badge helpers
+// ---------------------------------------------------------------------------
+
+function riskBadgeClass(risk: AfaRiskStatus): string {
+  switch (risk) {
+    case "HIGH":
+      return "bg-red-100 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800";
+    case "MEDIUM":
+      return "bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-800";
+    case "SAFE":
+      return "bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800";
+    case "LOW":
+      return "bg-neutral-100 text-neutral-600 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-400 dark:border-neutral-700";
+    default:
+      return "bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-800";
+  }
+}
+
+function deadlineBadgeClass(status: AfaDeadlineStatus): string {
+  switch (status) {
+    case "OVERDUE":
+      return "bg-red-100 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800";
+    case "URGENT":
+      return "bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-800";
+    case "UPCOMING":
+      return "bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-800";
+    case "SAFE":
+      return "bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800";
+    default:
+      return "bg-neutral-100 text-neutral-600 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-400 dark:border-neutral-700";
+  }
+}
+
+function deadlineLabel(v: AfaVorschlag): string {
+  const { deadline_status, days_left } = v.computed;
+  if (deadline_status === "NO_DEADLINE") return "—";
+  if (deadline_status === "OVERDUE")
+    return `OVERDUE ${Math.abs(days_left ?? 0)}d`;
+  if (days_left !== null) return `${deadline_status} (${days_left}d)`;
+  return deadline_status;
+}
+
+function actionStatusLabel(s: AfaActionStatus): string {
+  const labels: Record<AfaActionStatus, string> = {
+    received: "Received",
+    reviewing: "Reviewing",
+    applied: "Applied",
+    feedback_submitted: "Feedback Sent",
+    closed: "Closed",
+    justified_non_application: "Justified N/A",
+  };
+  return labels[s] ?? s;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface AfaTableProps {
+  cases: AfaVorschlag[];
+  onOpenDetails: (v: AfaVorschlag) => void;
+  onMarkApplied: (id: string) => void;
+  onMarkFeedback: (id: string) => void;
+  onCloseCase: (id: string) => void;
+}
+
+const PAGE_SIZE = 10;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AfaTable({
+  cases,
+  onOpenDetails,
+  onMarkApplied,
+  onMarkFeedback,
+  onCloseCase,
+}: AfaTableProps) {
+  const [search, setSearch] = useState("");
+  const [filterRisk, setFilterRisk] = useState<string>("all");
+  const [filterDeadline, setFilterDeadline] = useState<string>("all");
+  const [filterStatus, setFilterStatus] = useState<string>("all");
+  const [sortDeadlineAsc, setSortDeadlineAsc] = useState(true);
+  const [page, setPage] = useState(0);
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    return cases
+      .filter((c) => {
+        if (filterRisk !== "all" && c.computed.risk_status !== filterRisk)
+          return false;
+        if (
+          filterDeadline !== "all" &&
+          c.computed.deadline_status !== filterDeadline
+        )
+          return false;
+        if (filterStatus !== "all" && c.action_status !== filterStatus)
+          return false;
+        if (
+          q &&
+          !c.employer_name.toLowerCase().includes(q) &&
+          !c.position_title.toLowerCase().includes(q) &&
+          !c.case_id.toLowerCase().includes(q)
+        )
+          return false;
+        return true;
+      })
+      .sort((a, b) => {
+        const aDays = a.computed.days_left ?? (sortDeadlineAsc ? Infinity : -Infinity);
+        const bDays = b.computed.days_left ?? (sortDeadlineAsc ? Infinity : -Infinity);
+        return sortDeadlineAsc ? aDays - bDays : bDays - aDays;
+      });
+  }, [cases, search, filterRisk, filterDeadline, filterStatus, sortDeadlineAsc]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages - 1);
+  const paginated = filtered.slice(
+    currentPage * PAGE_SIZE,
+    currentPage * PAGE_SIZE + PAGE_SIZE
+  );
+
+  function resetPage() {
+    setPage(0);
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filter bar */}
+      <div className="flex flex-wrap gap-3 items-center">
+        <Input
+          placeholder="Search employer or title…"
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            resetPage();
+          }}
+          className="w-56"
+        />
+
+        <Select
+          value={filterRisk}
+          onValueChange={(v) => {
+            setFilterRisk(v);
+            resetPage();
+          }}
+        >
+          <SelectTrigger className="w-36">
+            <SelectValue placeholder="Risk" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Risk</SelectItem>
+            <SelectItem value="HIGH">HIGH</SelectItem>
+            <SelectItem value="MEDIUM">MEDIUM</SelectItem>
+            <SelectItem value="SAFE">SAFE</SelectItem>
+            <SelectItem value="LOW">LOW</SelectItem>
+            <SelectItem value="CHECK">CHECK</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filterDeadline}
+          onValueChange={(v) => {
+            setFilterDeadline(v);
+            resetPage();
+          }}
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Deadline" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Deadlines</SelectItem>
+            <SelectItem value="OVERDUE">OVERDUE</SelectItem>
+            <SelectItem value="URGENT">URGENT</SelectItem>
+            <SelectItem value="UPCOMING">UPCOMING</SelectItem>
+            <SelectItem value="SAFE">SAFE</SelectItem>
+            <SelectItem value="NO_DEADLINE">NO DEADLINE</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filterStatus}
+          onValueChange={(v) => {
+            setFilterStatus(v);
+            resetPage();
+          }}
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Statuses</SelectItem>
+            <SelectItem value="received">Received</SelectItem>
+            <SelectItem value="reviewing">Reviewing</SelectItem>
+            <SelectItem value="applied">Applied</SelectItem>
+            <SelectItem value="feedback_submitted">Feedback Sent</SelectItem>
+            <SelectItem value="closed">Closed</SelectItem>
+            <SelectItem value="justified_non_application">Justified N/A</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <span className="text-xs text-neutral-500 dark:text-neutral-400 ml-auto">
+          {filtered.length} case{filtered.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-neutral-50 dark:bg-neutral-900/50">
+              <TableHead className="w-36">Case ID</TableHead>
+              <TableHead>Employer</TableHead>
+              <TableHead>Position</TableHead>
+              <TableHead>
+                <button
+                  onClick={() => setSortDeadlineAsc((p) => !p)}
+                  className="flex items-center gap-1 font-medium text-foreground hover:text-primary transition-colors"
+                >
+                  Deadline
+                  <ArrowUpDown className="w-3 h-3" />
+                </button>
+              </TableHead>
+              <TableHead>Risk</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Match</TableHead>
+              <TableHead>Response</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {paginated.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={9}
+                  className="text-center py-10 text-neutral-400 dark:text-neutral-600"
+                >
+                  No cases match the current filters.
+                </TableCell>
+              </TableRow>
+            )}
+            {paginated.map((v) => (
+              <TableRow key={v.id}>
+                <TableCell className="font-mono text-xs text-neutral-500 dark:text-neutral-400">
+                  {v.case_id}
+                </TableCell>
+                <TableCell className="font-medium max-w-[160px] truncate">
+                  {v.employer_name || "—"}
+                </TableCell>
+                <TableCell className="max-w-[160px] truncate text-neutral-600 dark:text-neutral-300">
+                  {v.position_title || "—"}
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    className={deadlineBadgeClass(v.computed.deadline_status)}
+                    variant="outline"
+                  >
+                    {deadlineLabel(v)}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    className={riskBadgeClass(v.computed.risk_status)}
+                    variant="outline"
+                  >
+                    {v.computed.risk_status}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-sm text-neutral-600 dark:text-neutral-300">
+                  {actionStatusLabel(v.action_status)}
+                </TableCell>
+                <TableCell className="capitalize text-sm text-neutral-600 dark:text-neutral-300">
+                  {v.match_level}
+                </TableCell>
+                <TableCell className="capitalize text-sm text-neutral-600 dark:text-neutral-300">
+                  {v.employer_response === "no_response" ? "No response" : v.employer_response}
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center justify-end gap-1">
+                    {v.action_status !== "applied" &&
+                      v.action_status !== "feedback_submitted" &&
+                      v.action_status !== "closed" && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs px-2"
+                          onClick={() => onMarkApplied(v.id)}
+                        >
+                          Applied
+                        </Button>
+                      )}
+                    {v.applied_date &&
+                      v.action_status !== "feedback_submitted" &&
+                      v.action_status !== "closed" && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs px-2"
+                          onClick={() => onMarkFeedback(v.id)}
+                        >
+                          Feedback
+                        </Button>
+                      )}
+                    {v.action_status !== "closed" && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 text-xs px-2 text-neutral-500"
+                        onClick={() => onCloseCase(v.id)}
+                      >
+                        Close
+                      </Button>
+                    )}
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 w-7 p-0"
+                      onClick={() => onOpenDetails(v)}
+                    >
+                      <ExternalLink className="w-3 h-3" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between text-sm text-neutral-500 dark:text-neutral-400">
+          <span>
+            Page {currentPage + 1} of {totalPages}
+          </span>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={currentPage === 0}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+            >
+              Previous
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={currentPage >= totalPages - 1}
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/hooks/useAfaCompliance.ts
+++ b/src/app/hooks/useAfaCompliance.ts
@@ -1,0 +1,248 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  collection,
+  doc,
+  onSnapshot,
+  addDoc,
+  setDoc,
+  deleteDoc,
+} from "firebase/firestore";
+import { getFirebaseContext } from "../services/firebase";
+import { computeRiskStatus } from "../utils/afaRiskEngine";
+import { computeDeadline } from "../utils/afaDeadlineEngine";
+import type {
+  AfaVorschlag,
+  AfaVorschlagFormData,
+  AfaComputed,
+} from "../types/afa";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const LOCAL_STORAGE_KEY = "afa_vorschlaege_local";
+
+function loadLocal(): AfaVorschlag[] {
+  try {
+    const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as AfaVorschlag[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveLocal(cases: AfaVorschlag[]): void {
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(cases));
+}
+
+function generateCaseId(): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const yyyymmdd = `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}`;
+  const seq = String(Math.floor(Math.random() * 900) + 100);
+  return `VS-${yyyymmdd}-${seq}`;
+}
+
+function generateLocalId(): string {
+  return `afa-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function computeAll(v: AfaVorschlag): AfaVorschlag {
+  const risk_status = computeRiskStatus(
+    v.rfb_present,
+    v.applied_date,
+    v.portal_feedback_date
+  );
+  const { deadline_status, days_left } = computeDeadline(v.deadline_date);
+  const computed: AfaComputed = { risk_status, deadline_status, days_left };
+  return { ...v, computed };
+}
+
+function docToVorschlag(id: string, data: Record<string, unknown>): AfaVorschlag {
+  const raw = { ...(data as Omit<AfaVorschlag, "id">), id };
+  return computeAll(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseAfaComplianceReturn {
+  cases: AfaVorschlag[];
+  loading: boolean;
+  error: string | null;
+  addCase: (data: AfaVorschlagFormData) => Promise<void>;
+  updateCase: (
+    id: string,
+    updates: Partial<Omit<AfaVorschlag, "id" | "case_id" | "audit">>
+  ) => Promise<void>;
+  deleteCase: (id: string) => Promise<void>;
+  markApplied: (id: string) => Promise<void>;
+  markFeedbackSubmitted: (id: string) => Promise<void>;
+  closeCase: (id: string) => Promise<void>;
+}
+
+export function useAfaCompliance(userId: string | null): UseAfaComplianceReturn {
+  const [cases, setCases] = useState<AfaVorschlag[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const firebase = getFirebaseContext();
+
+  // -------------------------------------------------------------------------
+  // Subscription
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!userId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLoading(false);
+      return;
+    }
+
+    if (!firebase) {
+      // Intentional: set initial state from localStorage in fallback mode.
+      setCases(loadLocal().map(computeAll));
+      setLoading(false);
+      return;
+    }
+
+    const colRef = collection(firebase.db, "users", userId, "afa_vorschlaege");
+    const unsubscribe = onSnapshot(
+      colRef,
+      (snapshot) => {
+        const docs = snapshot.docs.map((d) =>
+          docToVorschlag(d.id, d.data() as Record<string, unknown>)
+        );
+        setCases(docs);
+        setLoading(false);
+      },
+      (err) => {
+        setError(err.message);
+        setLoading(false);
+      }
+    );
+
+    return unsubscribe;
+  }, [userId, firebase]);
+
+  // -------------------------------------------------------------------------
+  // Mutations
+  // -------------------------------------------------------------------------
+
+  const addCase = useCallback(
+    async (data: AfaVorschlagFormData): Promise<void> => {
+      if (!userId) return;
+
+      const now = new Date().toISOString();
+      const skeleton: AfaVorschlag = computeAll({
+        id: "",
+        case_id: generateCaseId(),
+        ...data,
+        computed: { risk_status: "CHECK", days_left: null, deadline_status: "NO_DEADLINE" },
+        audit: { created_at: now, updated_at: now },
+      });
+
+      if (!firebase) {
+        const local: AfaVorschlag = { ...skeleton, id: generateLocalId() };
+        const updated = [...cases, local];
+        saveLocal(updated);
+        setCases(updated);
+        return;
+      }
+
+      const { id: _id, ...payload } = skeleton;
+      const colRef = collection(firebase.db, "users", userId, "afa_vorschlaege");
+      await addDoc(colRef, payload);
+      // onSnapshot will update state automatically
+    },
+    [userId, firebase, cases]
+  );
+
+  const updateCase = useCallback(
+    async (
+      id: string,
+      updates: Partial<Omit<AfaVorschlag, "id" | "case_id" | "audit">>
+    ): Promise<void> => {
+      if (!userId) return;
+
+      const existing = cases.find((c) => c.id === id);
+      if (!existing) return;
+
+      const merged = computeAll({
+        ...existing,
+        ...updates,
+        audit: { ...existing.audit, updated_at: new Date().toISOString() },
+      });
+
+      if (!firebase) {
+        const updated = cases.map((c) => (c.id === id ? merged : c));
+        saveLocal(updated);
+        setCases(updated);
+        return;
+      }
+
+      const { id: _id, ...payload } = merged;
+      const docRef = doc(firebase.db, "users", userId, "afa_vorschlaege", id);
+      await setDoc(docRef, payload, { merge: true });
+      // onSnapshot will update state automatically
+    },
+    [userId, firebase, cases]
+  );
+
+  const deleteCase = useCallback(
+    async (id: string): Promise<void> => {
+      if (!userId) return;
+
+      if (!firebase) {
+        const updated = cases.filter((c) => c.id !== id);
+        saveLocal(updated);
+        setCases(updated);
+        return;
+      }
+
+      const docRef = doc(firebase.db, "users", userId, "afa_vorschlaege", id);
+      await deleteDoc(docRef);
+    },
+    [userId, firebase, cases]
+  );
+
+  // -------------------------------------------------------------------------
+  // Quick actions
+  // -------------------------------------------------------------------------
+
+  const markApplied = useCallback(
+    (id: string) =>
+      updateCase(id, {
+        action_status: "applied",
+        applied_date: new Date().toISOString().slice(0, 10),
+      }),
+    [updateCase]
+  );
+
+  const markFeedbackSubmitted = useCallback(
+    (id: string) =>
+      updateCase(id, {
+        action_status: "feedback_submitted",
+        portal_feedback_date: new Date().toISOString().slice(0, 10),
+      }),
+    [updateCase]
+  );
+
+  const closeCase = useCallback(
+    (id: string) => updateCase(id, { action_status: "closed" }),
+    [updateCase]
+  );
+
+  return {
+    cases,
+    loading,
+    error,
+    addCase,
+    updateCase,
+    deleteCase,
+    markApplied,
+    markFeedbackSubmitted,
+    closeCase,
+  };
+}

--- a/src/app/pages/AfaCompliancePage.tsx
+++ b/src/app/pages/AfaCompliancePage.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { Link } from "react-router";
+import { ArrowLeft, Plus, Moon, Sun, LogOut } from "lucide-react";
+import { Button } from "../components/ui/button";
+import { AfaDashboard } from "../components/compliance/AfaDashboard";
+import { AfaTable } from "../components/compliance/AfaTable";
+import { AfaCaseModal } from "../components/compliance/AfaCaseModal";
+import { useAfaCompliance } from "../hooks/useAfaCompliance";
+import { useApp } from "../context";
+import type { AfaVorschlag, AfaVorschlagFormData } from "../types/afa";
+
+export default function AfaCompliancePage() {
+  const { session, darkMode, toggleDarkMode, signOut } = useApp();
+  const {
+    cases,
+    loading,
+    error,
+    addCase,
+    updateCase,
+    deleteCase,
+    markApplied,
+    markFeedbackSubmitted,
+    closeCase,
+  } = useAfaCompliance(session?.userId ?? null);
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selectedCase, setSelectedCase] = useState<AfaVorschlag | null>(null);
+
+  function handleOpenNew() {
+    setSelectedCase(null);
+    setModalOpen(true);
+  }
+
+  function handleOpenDetails(v: AfaVorschlag) {
+    setSelectedCase(v);
+    setModalOpen(true);
+  }
+
+  function handleClose() {
+    setModalOpen(false);
+    setSelectedCase(null);
+  }
+
+  function handleSave(data: AfaVorschlagFormData) {
+    if (selectedCase) {
+      updateCase(selectedCase.id, data);
+    } else {
+      addCase(data);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-black">
+      {/* Header */}
+      <header className="sticky top-0 z-10 bg-white dark:bg-neutral-950 border-b border-neutral-200 dark:border-neutral-800">
+        <div className="max-w-[1800px] mx-auto px-6 h-14 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Link to="/">
+              <Button variant="ghost" size="sm" className="gap-1.5">
+                <ArrowLeft className="w-4 h-4" />
+                <span className="hidden sm:inline">Dashboard</span>
+              </Button>
+            </Link>
+            <div className="h-5 w-px bg-neutral-200 dark:bg-neutral-700" />
+            <h1 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+              AfA Compliance
+            </h1>
+            <span className="text-xs text-neutral-400 dark:text-neutral-600 hidden md:inline">
+              Vermittlungsvorschläge
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={handleOpenNew}
+            >
+              <Plus className="w-4 h-4" />
+              <span className="hidden sm:inline">New Case</span>
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={toggleDarkMode}
+              aria-label="Toggle dark mode"
+            >
+              {darkMode ? (
+                <Sun className="w-4 h-4" />
+              ) : (
+                <Moon className="w-4 h-4" />
+              )}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={signOut}
+              className="gap-1.5 text-neutral-500"
+            >
+              <LogOut className="w-4 h-4" />
+              <span className="hidden sm:inline">Sign out</span>
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="max-w-[1800px] mx-auto px-6 py-6 space-y-6">
+        {error && (
+          <div className="border border-red-200 dark:border-red-900/50 rounded-lg px-4 py-3 bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400 text-sm">
+            Failed to load compliance data: {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-24 text-neutral-400 dark:text-neutral-600 text-sm">
+            Loading compliance cases…
+          </div>
+        ) : (
+          <>
+            <AfaDashboard cases={cases} />
+
+            <div>
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase tracking-wide">
+                  All Cases
+                </h2>
+                <span className="text-xs text-neutral-400 dark:text-neutral-600">
+                  {cases.length} total
+                </span>
+              </div>
+              <AfaTable
+                cases={cases}
+                onOpenDetails={handleOpenDetails}
+                onMarkApplied={markApplied}
+                onMarkFeedback={markFeedbackSubmitted}
+                onCloseCase={closeCase}
+              />
+            </div>
+          </>
+        )}
+      </main>
+
+      <AfaCaseModal
+        open={modalOpen}
+        vorschlag={selectedCase}
+        onClose={handleClose}
+        onSave={handleSave}
+        onDelete={deleteCase}
+      />
+    </div>
+  );
+}

--- a/src/app/pages/Dashboard.tsx
+++ b/src/app/pages/Dashboard.tsx
@@ -18,6 +18,7 @@ import {
   Percent,
   Plus,
   BarChart3,
+  ShieldCheck,
   Moon,
   Sun,
   Undo2,
@@ -110,6 +111,12 @@ export default function Dashboard() {
                 <Button variant="outline" className="gap-2">
                   <BarChart3 className="w-4 h-4" />
                   <span className="hidden sm:inline">Analytics</span>
+                </Button>
+              </Link>
+              <Link to="/compliance/afa">
+                <Button variant="outline" className="gap-2">
+                  <ShieldCheck className="w-4 h-4" />
+                  <span className="hidden sm:inline">AfA Compliance</span>
                 </Button>
               </Link>
               <Button onClick={() => setModalOpen(true)} className="gap-2">

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from "react-router";
 import Dashboard from "./pages/Dashboard";
 import Analytics from "./pages/Analytics";
+import AfaCompliancePage from "./pages/AfaCompliancePage";
 import NotFound from "./pages/NotFound";
 import SignIn from "./pages/SignIn";
 import { ProtectedRoute } from "./components/ProtectedRoute";
@@ -20,6 +21,10 @@ export const router = createBrowserRouter([
       {
         path: "/analytics",
         Component: Analytics,
+      },
+      {
+        path: "/compliance/afa",
+        Component: AfaCompliancePage,
       },
     ],
   },

--- a/src/app/types/afa.ts
+++ b/src/app/types/afa.ts
@@ -1,0 +1,73 @@
+export type AfaSource = "paper" | "portal" | "email";
+export type AfaRfbPresent = "yes" | "no" | "unknown";
+export type AfaPortalFeedbackRequired = "yes" | "no" | "unknown";
+export type AfaMatchLevel = "high" | "medium" | "low";
+
+export type AfaActionStatus =
+  | "received"
+  | "reviewing"
+  | "applied"
+  | "feedback_submitted"
+  | "closed"
+  | "justified_non_application";
+
+export type AfaEmployerResponse =
+  | "pending"
+  | "rejected"
+  | "interview"
+  | "offer"
+  | "hired"
+  | "no_response";
+
+export type AfaRiskStatus = "HIGH" | "MEDIUM" | "SAFE" | "LOW" | "CHECK";
+
+export type AfaDeadlineStatus =
+  | "OVERDUE"
+  | "URGENT"
+  | "UPCOMING"
+  | "SAFE"
+  | "NO_DEADLINE";
+
+export interface AfaEvidence {
+  folder_url: string;
+  letter_file_url: string;
+  application_proof_url: string;
+  portal_feedback_proof_url: string;
+}
+
+export interface AfaComputed {
+  risk_status: AfaRiskStatus;
+  days_left: number | null;
+  deadline_status: AfaDeadlineStatus;
+}
+
+export interface AfaVorschlag {
+  id: string;
+  case_id: string;
+  source: AfaSource;
+  received_date: string; // ISO date YYYY-MM-DD
+  deadline_date: string | null; // ISO date YYYY-MM-DD
+  rfb_present: AfaRfbPresent;
+  portal_feedback_required: AfaPortalFeedbackRequired;
+  employer_name: string;
+  position_title: string;
+  location: string;
+  posting_url: string;
+  match_level: AfaMatchLevel;
+  action_status: AfaActionStatus;
+  applied_date: string | null; // ISO date YYYY-MM-DD
+  portal_feedback_date: string | null; // ISO date YYYY-MM-DD
+  employer_response: AfaEmployerResponse;
+  evidence: AfaEvidence;
+  notes: string;
+  computed: AfaComputed;
+  audit: {
+    created_at: string; // ISO datetime
+    updated_at: string; // ISO datetime
+  };
+}
+
+export type AfaVorschlagFormData = Omit<
+  AfaVorschlag,
+  "id" | "case_id" | "computed" | "audit"
+>;

--- a/src/app/utils/afaDeadlineEngine.ts
+++ b/src/app/utils/afaDeadlineEngine.ts
@@ -1,0 +1,27 @@
+import { differenceInCalendarDays } from "date-fns";
+import type { AfaDeadlineStatus, AfaVorschlag } from "../types/afa";
+
+export function computeDeadline(deadline_date: string | null): {
+  deadline_status: AfaDeadlineStatus;
+  days_left: number | null;
+} {
+  if (!deadline_date) return { deadline_status: "NO_DEADLINE", days_left: null };
+
+  const days = differenceInCalendarDays(new Date(deadline_date), new Date());
+
+  if (days < 0) return { deadline_status: "OVERDUE", days_left: days };
+  if (days <= 2) return { deadline_status: "URGENT", days_left: days };
+  if (days <= 5) return { deadline_status: "UPCOMING", days_left: days };
+  return { deadline_status: "SAFE", days_left: days };
+}
+
+export function recomputeDeadline(v: AfaVorschlag): AfaVorschlag {
+  const { deadline_status, days_left } = computeDeadline(v.deadline_date);
+  return { ...v, computed: { ...v.computed, deadline_status, days_left } };
+}
+
+/** Apply both risk and deadline recomputation. */
+export function recomputeAll(v: AfaVorschlag): AfaVorschlag {
+  const { deadline_status, days_left } = computeDeadline(v.deadline_date);
+  return { ...v, computed: { ...v.computed, deadline_status, days_left } };
+}

--- a/src/app/utils/afaRiskEngine.ts
+++ b/src/app/utils/afaRiskEngine.ts
@@ -1,0 +1,24 @@
+import type { AfaRfbPresent, AfaRiskStatus, AfaVorschlag } from "../types/afa";
+
+export function computeRiskStatus(
+  rfb_present: AfaRfbPresent,
+  applied_date: string | null,
+  portal_feedback_date: string | null
+): AfaRiskStatus {
+  if (rfb_present === "yes" && !applied_date) return "HIGH";
+  if (rfb_present === "yes" && applied_date && !portal_feedback_date)
+    return "MEDIUM";
+  if (rfb_present === "yes" && applied_date && portal_feedback_date)
+    return "SAFE";
+  if (rfb_present === "no") return "LOW";
+  return "CHECK";
+}
+
+export function recomputeVorschlag(v: AfaVorschlag): AfaVorschlag {
+  const risk_status = computeRiskStatus(
+    v.rfb_present,
+    v.applied_date,
+    v.portal_feedback_date
+  );
+  return { ...v, computed: { ...v.computed, risk_status } };
+}


### PR DESCRIPTION
Implements /compliance/afa page for managing Agentur für Arbeit Vermittlungsvorschläge with automated risk and deadline detection.

Core modules:
- types/afa.ts — full TypeScript schema matching Firestore document spec
- utils/afaRiskEngine.ts — HIGH/MEDIUM/SAFE/LOW/CHECK logic per RFB rules
- utils/afaDeadlineEngine.ts — OVERDUE/URGENT/UPCOMING/SAFE/NO_DEADLINE using date-fns differenceInCalendarDays
- hooks/useAfaCompliance.ts — real-time onSnapshot listener with localStorage fallback; CRUD + quick-action helpers

UI:
- AfaDashboard — 5 KPI cards (HIGH risk, ≤2d deadlines, overdue, applied this week, active RFB) with colour-coded risk indicators
- AfaTable — filterable/sortable/paginated table (10/page) with risk + deadline badges and inline quick-action buttons
- AfaCaseModal — full create/edit form with 7 sections (Core Info, Risk & RFB, Deadline, Action & Response, Evidence Links, Notes, Audit Timeline); evidence fields have live open-in-new-tab buttons
- AfaCompliancePage — page wrapper with sticky header and loading state

Routing:
- /compliance/afa added to ProtectedRoute children in routes.ts
- AfA Compliance nav button added to Dashboard header

ESLint:
- Extended varsIgnorePattern to cover _-prefixed destructure vars

Closes #N/A

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

