### PR TITLE
fix(compliance): prevent blank dashboard during auth bootstrap and na…

### DIFF
--- a/src/app/hooks/useAfaCompliance.ts
+++ b/src/app/hooks/useAfaCompliance.ts
@@ -107,6 +107,7 @@ export function useAfaCompliance(userId: string | null): UseAfaComplianceReturn 
       return;
     }
 
+    setLoading(true);
     const colRef = collection(firebase.db, "users", userId, "afa_vorschlaege");
     const unsubscribe = onSnapshot(
       colRef,

--- a/src/app/pages/AfaCompliancePage.tsx
+++ b/src/app/pages/AfaCompliancePage.tsx
@@ -10,7 +10,7 @@ import { useApp } from "../context";
 import type { AfaVorschlag, AfaVorschlagFormData } from "../types/afa";
 
 export default function AfaCompliancePage() {
-  const { session, darkMode, toggleDarkMode, signOut } = useApp();
+  const { session, authLoading, darkMode, toggleDarkMode, signOut } = useApp();
   const {
     cases,
     loading,
@@ -113,7 +113,7 @@ export default function AfaCompliancePage() {
           </div>
         )}
 
-        {loading ? (
+        {authLoading || loading ? (
           <div className="flex items-center justify-center py-24 text-neutral-400 dark:text-neutral-600 text-sm">
             Loading compliance cases…
           </div>


### PR DESCRIPTION
…vigation

Two related bugs:
1. useAfaCompliance set loading=false immediately when userId was null (auth not yet resolved), then never reset it to true when the valid userId arrived — Firestore snapshot loaded silently with no spinner, showing 0s until data arrived.
2. AfaCompliancePage did not gate on authLoading, so the empty-cases render was visible before the session was established.

Fix: add setLoading(true) before the Firestore subscription starts, and gate the page body on authLoading||loading so a spinner is shown the whole time auth + data are in flight.

Closes #N/A

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

