### PR TITLE
fix: harden AFA CRUD flow and expose explicit row actions

### DIFF
--- a/src/app/components/compliance/AfaCaseModal.tsx
+++ b/src/app/components/compliance/AfaCaseModal.tsx
@@ -162,8 +162,8 @@ interface AfaCaseModalProps {
   open: boolean;
   vorschlag: AfaVorschlag | null; // null = new case
   onClose: () => void;
-  onSave: (data: AfaVorschlagFormData) => void;
-  onDelete?: (id: string) => void;
+  onSave: (data: AfaVorschlagFormData) => Promise<void>;
+  onDelete?: (id: string) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -179,11 +179,17 @@ export function AfaCaseModal({
 }: AfaCaseModalProps) {
   const isEdit = vorschlag !== null;
   const [form, setForm] = useState<AfaVorschlagFormData>(EMPTY_FORM);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setForm(isEdit ? vorschlagToForm(vorschlag) : EMPTY_FORM);
+    setIsSaving(false);
+    setIsDeleting(false);
+    setSubmitError(null);
   }, [open, vorschlag, isEdit]);
 
   function update<K extends keyof AfaVorschlagFormData>(
@@ -203,10 +209,40 @@ export function AfaCaseModal({
     }));
   }
 
-  function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    onSave(form);
-    onClose();
+    setSubmitError(null);
+    setIsSaving(true);
+    try {
+      await onSave(form);
+      onClose();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to save case.";
+      setSubmitError(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleDeleteClick(): Promise<void> {
+    if (!isEdit || !onDelete) return;
+    const confirmed = window.confirm(
+      "Delete this case permanently? This action cannot be undone."
+    );
+    if (!confirmed) return;
+    setSubmitError(null);
+    setIsDeleting(true);
+    try {
+      await onDelete(vorschlag.id);
+      onClose();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to delete case.";
+      setSubmitError(message);
+    } finally {
+      setIsDeleting(false);
+    }
   }
 
   return (
@@ -231,6 +267,12 @@ export function AfaCaseModal({
               {vorschlag.computed.days_left !== null &&
                 ` (${vorschlag.computed.days_left}d)`}
             </Badge>
+          </div>
+        )}
+
+        {submitError && (
+          <div className="rounded-md border border-red-200 dark:border-red-900/50 bg-red-50 dark:bg-red-950/30 px-3 py-2 text-sm text-red-700 dark:text-red-400">
+            {submitError}
           </div>
         )}
 
@@ -547,21 +589,30 @@ export function AfaCaseModal({
                   type="button"
                   variant="ghost"
                   className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
-                  onClick={() => {
-                    onDelete(vorschlag.id);
-                    onClose();
-                  }}
+                  onClick={handleDeleteClick}
+                  disabled={isSaving || isDeleting}
                 >
-                  Delete Case
+                  {isDeleting ? "Deleting..." : "Delete Case"}
                 </Button>
               )}
             </div>
             <div className="flex gap-3">
-              <Button type="button" variant="outline" onClick={onClose}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={isSaving || isDeleting}
+              >
                 Cancel
               </Button>
-              <Button type="submit">
-                {isEdit ? "Save Changes" : "Create Case"}
+              <Button type="submit" disabled={isSaving || isDeleting}>
+                {isSaving
+                  ? isEdit
+                    ? "Saving..."
+                    : "Creating..."
+                  : isEdit
+                    ? "Save Changes"
+                    : "Create Case"}
               </Button>
             </div>
           </div>

--- a/src/app/components/compliance/AfaTable.tsx
+++ b/src/app/components/compliance/AfaTable.tsx
@@ -90,6 +90,7 @@ interface AfaTableProps {
   onMarkApplied: (id: string) => void;
   onMarkFeedback: (id: string) => void;
   onCloseCase: (id: string) => void;
+  onDeleteCase: (id: string) => void;
 }
 
 const PAGE_SIZE = 10;
@@ -104,6 +105,7 @@ export function AfaTable({
   onMarkApplied,
   onMarkFeedback,
   onCloseCase,
+  onDeleteCase,
 }: AfaTableProps) {
   const [search, setSearch] = useState("");
   const [filterRisk, setFilterRisk] = useState<string>("all");
@@ -342,8 +344,25 @@ export function AfaTable({
                     <Button
                       size="sm"
                       variant="ghost"
+                      className="h-7 text-xs px-2"
+                      onClick={() => onOpenDetails(v)}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 text-xs px-2 text-red-500 hover:text-red-600"
+                      onClick={() => onDeleteCase(v.id)}
+                    >
+                      Delete
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
                       className="h-7 w-7 p-0"
                       onClick={() => onOpenDetails(v)}
+                      aria-label="Open details"
                     >
                       <ExternalLink className="w-3 h-3" />
                     </Button>

--- a/src/app/hooks/useAfaCompliance.ts
+++ b/src/app/hooks/useAfaCompliance.ts
@@ -21,6 +21,7 @@ import type {
 // ---------------------------------------------------------------------------
 
 const LOCAL_STORAGE_KEY_PREFIX = "afa_vorschlaege_local_v2";
+const FIRESTORE_MUTATION_TIMEOUT_MS = 12000;
 
 function localStorageKey(userId: string): string {
   return `${LOCAL_STORAGE_KEY_PREFIX}_${userId}`;
@@ -37,6 +38,39 @@ function loadLocal(userId: string): AfaVorschlag[] {
 
 function saveLocal(userId: string, cases: AfaVorschlag[]): void {
   localStorage.setItem(localStorageKey(userId), JSON.stringify(cases));
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      }
+    );
+  });
+}
+
+function isOfflineLikeError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  return (
+    message.includes("timed out") ||
+    message.includes("offline") ||
+    message.includes("network") ||
+    message.includes("unavailable")
+  );
 }
 
 function generateCaseId(): string {
@@ -90,6 +124,7 @@ export function useAfaCompliance(userId: string | null): UseAfaComplianceReturn 
   const [cases, setCases] = useState<AfaVorschlag[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [localOnlyMode, setLocalOnlyMode] = useState(false);
 
   const firebase = getFirebaseContext();
 
@@ -103,14 +138,15 @@ export function useAfaCompliance(userId: string | null): UseAfaComplianceReturn 
       setCases([]);
       setError(null);
       setLoading(false);
+      setLocalOnlyMode(false);
       return;
     }
 
     const cachedCases = loadLocal(userId).map(computeAll);
     setCases(cachedCases);
-    setError(null);
+    setError(localOnlyMode ? "Cloud sync unavailable. Working in local mode." : null);
 
-    if (!firebase) {
+    if (!firebase || localOnlyMode) {
       // Intentional: set initial state from localStorage in fallback mode.
       setLoading(false);
       return;
@@ -124,19 +160,22 @@ export function useAfaCompliance(userId: string | null): UseAfaComplianceReturn 
         const docs = snapshot.docs.map((d) =>
           docToVorschlag(d.id, d.data() as Record<string, unknown>)
         );
-        const shouldKeepCached =
+        const latestLocal = loadLocal(userId).map(computeAll);
+        const shouldUseLocal =
           docs.length === 0 &&
-          cachedCases.length > 0 &&
+          latestLocal.length > 0 &&
           snapshot.metadata.fromCache;
 
-        const nextCases = shouldKeepCached ? cachedCases : docs;
+        const nextCases = shouldUseLocal ? latestLocal : docs;
         setCases(nextCases);
         saveLocal(userId, nextCases);
         setError(null);
+        setLocalOnlyMode(false);
         setLoading(false);
       },
       (err) => {
-        setError(err.message);
+        setError("Cloud sync unavailable. Working in local mode.");
+        setLocalOnlyMode(true);
         if (cachedCases.length > 0) {
           setCases(cachedCases);
         }
@@ -145,7 +184,7 @@ export function useAfaCompliance(userId: string | null): UseAfaComplianceReturn 
     );
 
     return unsubscribe;
-  }, [userId, firebase]);
+  }, [userId, firebase, localOnlyMode]);
 
   // -------------------------------------------------------------------------
   // Mutations
@@ -164,22 +203,47 @@ export function useAfaCompliance(userId: string | null): UseAfaComplianceReturn 
         audit: { created_at: now, updated_at: now },
       });
 
-      if (!firebase) {
+      if (!firebase || localOnlyMode) {
         const local: AfaVorschlag = { ...skeleton, id: generateLocalId() };
-        const updated = [...cases, local];
-        saveLocal(userId, updated);
-        setCases(updated);
+        setCases((prev) => {
+          const updated = [...prev, local];
+          saveLocal(userId, updated);
+          return updated;
+        });
+        setError(localOnlyMode ? "Cloud sync unavailable. Working in local mode." : null);
         return;
       }
 
-      const { id: _id, ...payload } = skeleton;
-      const colRef = collection(firebase.db, "users", userId, "afa_vorschlaege");
-      const created = await addDoc(colRef, payload);
-      const nextCases = [...cases, { ...skeleton, id: created.id }];
-      saveLocal(userId, nextCases);
-      setCases(nextCases);
+      try {
+        const { id: _id, ...payload } = skeleton;
+        const colRef = collection(firebase.db, "users", userId, "afa_vorschlaege");
+        const created = await withTimeout(
+          addDoc(colRef, payload),
+          FIRESTORE_MUTATION_TIMEOUT_MS,
+          "Create case"
+        );
+        setCases((prev) => {
+          const nextCases = [...prev, { ...skeleton, id: created.id }];
+          saveLocal(userId, nextCases);
+          return nextCases;
+        });
+        setError(null);
+        setLocalOnlyMode(false);
+      } catch (err) {
+        if (!isOfflineLikeError(err)) {
+          throw err;
+        }
+        const local: AfaVorschlag = { ...skeleton, id: generateLocalId() };
+        setCases((prev) => {
+          const updated = [...prev, local];
+          saveLocal(userId, updated);
+          return updated;
+        });
+        setError("Cloud sync unavailable. Case saved locally.");
+        setLocalOnlyMode(true);
+      }
     },
-    [userId, firebase, cases]
+    [userId, firebase, localOnlyMode]
   );
 
   const updateCase = useCallback(
@@ -198,41 +262,89 @@ export function useAfaCompliance(userId: string | null): UseAfaComplianceReturn 
         audit: { ...existing.audit, updated_at: new Date().toISOString() },
       });
 
-      if (!firebase) {
-        const updated = cases.map((c) => (c.id === id ? merged : c));
-        saveLocal(userId, updated);
-        setCases(updated);
+      if (!firebase || localOnlyMode) {
+        setCases((prev) => {
+          const updated = prev.map((c) => (c.id === id ? merged : c));
+          saveLocal(userId, updated);
+          return updated;
+        });
+        setError(localOnlyMode ? "Cloud sync unavailable. Working in local mode." : null);
         return;
       }
 
-      const { id: _id, ...payload } = merged;
-      const docRef = doc(firebase.db, "users", userId, "afa_vorschlaege", id);
-      await setDoc(docRef, payload, { merge: true });
-      const updated = cases.map((c) => (c.id === id ? merged : c));
-      saveLocal(userId, updated);
-      setCases(updated);
+      try {
+        const { id: _id, ...payload } = merged;
+        const docRef = doc(firebase.db, "users", userId, "afa_vorschlaege", id);
+        await withTimeout(
+          setDoc(docRef, payload, { merge: true }),
+          FIRESTORE_MUTATION_TIMEOUT_MS,
+          "Update case"
+        );
+        setCases((prev) => {
+          const updated = prev.map((c) => (c.id === id ? merged : c));
+          saveLocal(userId, updated);
+          return updated;
+        });
+        setError(null);
+        setLocalOnlyMode(false);
+      } catch (err) {
+        if (!isOfflineLikeError(err)) {
+          throw err;
+        }
+        setCases((prev) => {
+          const updated = prev.map((c) => (c.id === id ? merged : c));
+          saveLocal(userId, updated);
+          return updated;
+        });
+        setError("Cloud sync unavailable. Case updated locally.");
+        setLocalOnlyMode(true);
+      }
     },
-    [userId, firebase, cases]
+    [userId, firebase, cases, localOnlyMode]
   );
 
   const deleteCase = useCallback(
     async (id: string): Promise<void> => {
       if (!userId) return;
 
-      if (!firebase) {
-        const updated = cases.filter((c) => c.id !== id);
-        saveLocal(userId, updated);
-        setCases(updated);
+      if (!firebase || localOnlyMode) {
+        setCases((prev) => {
+          const updated = prev.filter((c) => c.id !== id);
+          saveLocal(userId, updated);
+          return updated;
+        });
+        setError(localOnlyMode ? "Cloud sync unavailable. Working in local mode." : null);
         return;
       }
 
-      const docRef = doc(firebase.db, "users", userId, "afa_vorschlaege", id);
-      await deleteDoc(docRef);
-      const updated = cases.filter((c) => c.id !== id);
-      saveLocal(userId, updated);
-      setCases(updated);
+      try {
+        const docRef = doc(firebase.db, "users", userId, "afa_vorschlaege", id);
+        await withTimeout(
+          deleteDoc(docRef),
+          FIRESTORE_MUTATION_TIMEOUT_MS,
+          "Delete case"
+        );
+        setCases((prev) => {
+          const updated = prev.filter((c) => c.id !== id);
+          saveLocal(userId, updated);
+          return updated;
+        });
+        setError(null);
+        setLocalOnlyMode(false);
+      } catch (err) {
+        if (!isOfflineLikeError(err)) {
+          throw err;
+        }
+        setCases((prev) => {
+          const updated = prev.filter((c) => c.id !== id);
+          saveLocal(userId, updated);
+          return updated;
+        });
+        setError("Cloud sync unavailable. Case deleted locally.");
+        setLocalOnlyMode(true);
+      }
     },
-    [userId, firebase, cases]
+    [userId, firebase, localOnlyMode]
   );
 
   // -------------------------------------------------------------------------

--- a/src/app/pages/AfaCompliancePage.tsx
+++ b/src/app/pages/AfaCompliancePage.tsx
@@ -41,12 +41,16 @@ export default function AfaCompliancePage() {
     setSelectedCase(null);
   }
 
-  function handleSave(data: AfaVorschlagFormData) {
+  async function handleSave(data: AfaVorschlagFormData): Promise<void> {
     if (selectedCase) {
-      updateCase(selectedCase.id, data);
-    } else {
-      addCase(data);
+      await updateCase(selectedCase.id, data);
+      return;
     }
+    await addCase(data);
+  }
+
+  async function handleDelete(id: string): Promise<void> {
+    await deleteCase(id);
   }
 
   return (
@@ -109,7 +113,7 @@ export default function AfaCompliancePage() {
       <main className="max-w-[1800px] mx-auto px-6 py-6 space-y-6">
         {error && (
           <div className="border border-red-200 dark:border-red-900/50 rounded-lg px-4 py-3 bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400 text-sm">
-            Failed to load compliance data: {error}
+            Compliance sync notice: {error}
           </div>
         )}
 
@@ -136,6 +140,9 @@ export default function AfaCompliancePage() {
                 onMarkApplied={markApplied}
                 onMarkFeedback={markFeedbackSubmitted}
                 onCloseCase={closeCase}
+                onDeleteCase={(id) => {
+                  void handleDelete(id);
+                }}
               />
             </div>
           </>
@@ -147,7 +154,7 @@ export default function AfaCompliancePage() {
         vorschlag={selectedCase}
         onClose={handleClose}
         onSave={handleSave}
-        onDelete={deleteCase}
+        onDelete={handleDelete}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- harden AFA case mutations with Firestore write timeouts and offline/network fallback
- switch to stable local-only mode when cloud sync is unavailable
- prevent local state from being overwritten by stale cached snapshots
- add explicit row-level Edit and Delete actions in the AFA table
- make compliance banner wording reflect sync notice instead of load failure
- make case modal save/delete async-safe with pending states and inline error feedback

## Validation
- npm run build
- npm run test