### PR TITLE
feat: add Job OS module for execution-first job search workflows

### DIFF
--- a/src/app/components/compliance/AfaCaseModal.tsx
+++ b/src/app/components/compliance/AfaCaseModal.tsx
@@ -185,7 +185,6 @@ export function AfaCaseModal({
 
   useEffect(() => {
     if (!open) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setForm(isEdit ? vorschlagToForm(vorschlag) : EMPTY_FORM);
     setIsSaving(false);
     setIsDeleting(false);

--- a/src/app/components/job-os/JobOsLayout.tsx
+++ b/src/app/components/job-os/JobOsLayout.tsx
@@ -1,0 +1,88 @@
+import { Link, NavLink } from "react-router";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "../ui/button";
+import { useApp } from "../../context";
+
+const NAV_ITEMS = [
+  { to: "/job-os/dashboard", label: "Dashboard" },
+  { to: "/job-os/assets", label: "Assets" },
+  { to: "/job-os/companies", label: "Companies" },
+  { to: "/job-os/roles", label: "Roles" },
+  { to: "/job-os/applications", label: "Applications" },
+  { to: "/job-os/outreach", label: "Outreach" },
+];
+
+export function JobOsLayout({
+  title,
+  subtitle,
+  notice,
+  children,
+  actions,
+}: {
+  title: string;
+  subtitle?: string;
+  notice?: string | null;
+  children: React.ReactNode;
+  actions?: React.ReactNode;
+}) {
+  const { darkMode, toggleDarkMode } = useApp();
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-black">
+      <header className="sticky top-0 z-20 border-b border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
+        <div className="max-w-[1800px] mx-auto px-6 py-3">
+          <div className="flex items-center justify-between gap-4 mb-3">
+            <div className="flex items-center gap-3">
+              <Link to="/">
+                <Button variant="ghost" size="sm" className="gap-1.5">
+                  <ArrowLeft className="w-4 h-4" />
+                  Dashboard
+                </Button>
+              </Link>
+              <div>
+                <h1 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+                  {title}
+                </h1>
+                {subtitle && (
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                    {subtitle}
+                  </p>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {actions}
+              <Button variant="outline" size="sm" onClick={toggleDarkMode}>
+                {darkMode ? "Light" : "Dark"}
+              </Button>
+            </div>
+          </div>
+          <nav className="flex flex-wrap gap-2">
+            {NAV_ITEMS.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  `text-xs px-3 py-1.5 rounded-md border transition-colors ${
+                    isActive
+                      ? "bg-neutral-900 text-white border-neutral-900 dark:bg-neutral-100 dark:text-black dark:border-neutral-100"
+                      : "bg-white text-neutral-600 border-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:border-neutral-700 dark:hover:bg-neutral-800"
+                  }`
+                }
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+      </header>
+      <main className="max-w-[1800px] mx-auto px-6 py-6 space-y-4">
+        {notice && (
+          <div className="rounded-lg border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/20 px-4 py-3 text-sm text-amber-800 dark:text-amber-300">
+            {notice}
+          </div>
+        )}
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/app/hooks/useAfaCompliance.ts
+++ b/src/app/hooks/useAfaCompliance.ts
@@ -173,7 +173,7 @@ export function useAfaCompliance(userId: string | null): UseAfaComplianceReturn 
         setLocalOnlyMode(false);
         setLoading(false);
       },
-      (err) => {
+      (_err) => {
         setError("Cloud sync unavailable. Working in local mode.");
         setLocalOnlyMode(true);
         if (cachedCases.length > 0) {

--- a/src/app/hooks/useJobOs.ts
+++ b/src/app/hooks/useJobOs.ts
@@ -1,0 +1,650 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  serverTimestamp,
+  setDoc,
+  type DocumentData,
+} from "firebase/firestore";
+import { getFirebaseContext } from "../services/firebase";
+import type {
+  JobOsApplication,
+  JobOsCompany,
+  JobOsCvAsset,
+  JobOsOutreach,
+  JobOsRole,
+  JobOsScriptAsset,
+  JobOsState,
+  JobOsTemplateAsset,
+} from "../types/jobOs";
+
+const LOCAL_KEY_PREFIX = "job_os_v1";
+const MUTATION_TIMEOUT_MS = 12000;
+
+const DEFAULT_CVS: JobOsCvAsset[] = [
+  {
+    id: "cv-tpm",
+    name: "CV - Technical Product Manager",
+    version: "v1.0",
+    fileUrl: "",
+    locked: true,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  },
+  {
+    id: "cv-product-engineer",
+    name: "CV - Product Engineer",
+    version: "v1.0",
+    fileUrl: "",
+    locked: true,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  },
+  {
+    id: "cv-systems-pm",
+    name: "CV - Systems / Platform PM",
+    version: "v1.0",
+    fileUrl: "",
+    locked: true,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  },
+];
+
+const EMPTY_STATE: JobOsState = {
+  assets: { cvs: DEFAULT_CVS, scripts: [], templates: [] },
+  companies: [],
+  roles: [],
+  applications: [],
+  outreach: [],
+};
+
+function localKey(userId: string): string {
+  return `${LOCAL_KEY_PREFIX}_${userId}`;
+}
+
+function asIso(value: unknown): string {
+  if (
+    value &&
+    typeof value === "object" &&
+    "toDate" in value &&
+    typeof (value as { toDate: () => Date }).toDate === "function"
+  ) {
+    return (value as { toDate: () => Date }).toDate().toISOString();
+  }
+  if (typeof value === "string") return value;
+  return new Date().toISOString();
+}
+
+function withTimestamps<T extends Record<string, unknown>>(record: T): T {
+  return {
+    ...record,
+    createdAt: asIso(record.createdAt),
+    updatedAt: asIso(record.updatedAt),
+  };
+}
+
+function normalizeState(raw: unknown): JobOsState {
+  if (!raw || typeof raw !== "object") return EMPTY_STATE;
+  const maybe = raw as Partial<JobOsState>;
+  const cvs = Array.isArray(maybe.assets?.cvs)
+    ? maybe.assets?.cvs.map((v) =>
+        withTimestamps(v as Record<string, unknown>)
+      )
+    : DEFAULT_CVS;
+  const completeCvs = DEFAULT_CVS.map((base) => {
+    const found = cvs.find((c) => c.id === base.id);
+    if (!found) return base;
+    return {
+      ...base,
+      ...found,
+      locked: true,
+    };
+  });
+
+  return {
+    assets: {
+      cvs: completeCvs as JobOsCvAsset[],
+      scripts: Array.isArray(maybe.assets?.scripts)
+        ? (maybe.assets.scripts.map((v) =>
+            withTimestamps(v as Record<string, unknown>)
+          ) as JobOsScriptAsset[])
+        : [],
+      templates: Array.isArray(maybe.assets?.templates)
+        ? (maybe.assets.templates.map((v) =>
+            withTimestamps(v as Record<string, unknown>)
+          ) as JobOsTemplateAsset[])
+        : [],
+    },
+    companies: Array.isArray(maybe.companies)
+      ? (maybe.companies.map((v) =>
+          withTimestamps(v as Record<string, unknown>)
+        ) as JobOsCompany[])
+      : [],
+    roles: Array.isArray(maybe.roles)
+      ? (maybe.roles.map((v) =>
+          withTimestamps(v as Record<string, unknown>)
+        ) as JobOsRole[])
+      : [],
+    applications: Array.isArray(maybe.applications)
+      ? (maybe.applications.map((v) =>
+          withTimestamps(v as Record<string, unknown>)
+        ) as JobOsApplication[])
+      : [],
+    outreach: Array.isArray(maybe.outreach)
+      ? (maybe.outreach.map((v) =>
+          withTimestamps(v as Record<string, unknown>)
+        ) as JobOsOutreach[])
+      : [],
+  };
+}
+
+function readLocal(userId: string): JobOsState {
+  try {
+    const raw = localStorage.getItem(localKey(userId));
+    if (!raw) return EMPTY_STATE;
+    return normalizeState(JSON.parse(raw));
+  } catch {
+    return EMPTY_STATE;
+  }
+}
+
+function writeLocal(userId: string, state: JobOsState): void {
+  localStorage.setItem(localKey(userId), JSON.stringify(state));
+}
+
+function randomId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${MUTATION_TIMEOUT_MS}ms`));
+    }, MUTATION_TIMEOUT_MS);
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      }
+    );
+  });
+}
+
+function isOfflineLike(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  return (
+    message.includes("timed out") ||
+    message.includes("offline") ||
+    message.includes("network") ||
+    message.includes("unavailable")
+  );
+}
+
+function collectionDoc<T extends { id: string }>(
+  state: JobOsState,
+  key: "companies" | "roles" | "applications" | "outreach",
+  id: string,
+  updater: (existing: T) => T
+): JobOsState {
+  return {
+    ...state,
+    [key]: (state[key] as T[]).map((item) =>
+      item.id === id ? updater(item) : item
+    ),
+  } as JobOsState;
+}
+
+interface UseJobOsReturn extends JobOsState {
+  loading: boolean;
+  syncNotice: string | null;
+  updateCv: (
+    id: string,
+    updates: Partial<Pick<JobOsCvAsset, "version" | "fileUrl">>
+  ) => Promise<void>;
+  addScript: (payload: Omit<JobOsScriptAsset, "id" | "createdAt" | "updatedAt" | "lastUpdated">) => Promise<void>;
+  addTemplate: (payload: Omit<JobOsTemplateAsset, "id" | "createdAt" | "updatedAt">) => Promise<void>;
+  addCompany: (payload: Omit<JobOsCompany, "id" | "createdAt" | "updatedAt">) => Promise<void>;
+  updateCompany: (id: string, updates: Partial<JobOsCompany>) => Promise<void>;
+  addRole: (payload: Omit<JobOsRole, "id" | "createdAt" | "updatedAt">) => Promise<void>;
+  updateRole: (id: string, updates: Partial<JobOsRole>) => Promise<void>;
+  addApplication: (payload: Omit<JobOsApplication, "id" | "createdAt" | "updatedAt">) => Promise<void>;
+  updateApplication: (id: string, updates: Partial<JobOsApplication>) => Promise<void>;
+  addOutreach: (payload: Omit<JobOsOutreach, "id" | "createdAt" | "updatedAt">) => Promise<void>;
+  updateOutreach: (id: string, updates: Partial<JobOsOutreach>) => Promise<void>;
+  removeCompany: (id: string) => Promise<void>;
+  removeRole: (id: string) => Promise<void>;
+  removeApplication: (id: string) => Promise<void>;
+  removeOutreach: (id: string) => Promise<void>;
+}
+
+export function useJobOs(userId: string | null): UseJobOsReturn {
+  const firebase = getFirebaseContext();
+  const [state, setState] = useState<JobOsState>(EMPTY_STATE);
+  const [loading, setLoading] = useState(true);
+  const [syncNotice, setSyncNotice] = useState<string | null>(null);
+  const [localOnly, setLocalOnly] = useState(false);
+
+  const applyLocal = useCallback(
+    (nextState: JobOsState) => {
+      if (!userId) return;
+      writeLocal(userId, nextState);
+      setState(nextState);
+    },
+    [userId]
+  );
+
+  useEffect(() => {
+    if (!userId) {
+      setState(EMPTY_STATE);
+      setLoading(false);
+      setSyncNotice(null);
+      setLocalOnly(false);
+      return;
+    }
+
+    const localState = readLocal(userId);
+    setState(localState);
+    setLoading(false);
+
+    if (!firebase || localOnly) {
+      if (!firebase) {
+        setSyncNotice("Cloud unavailable. Using local Job OS storage.");
+      }
+      return;
+    }
+
+    const unsubscribers: Array<() => void> = [];
+    let snapshotCount = 0;
+    const markLoaded = () => {
+      snapshotCount += 1;
+      if (snapshotCount >= 5) {
+        setLoading(false);
+      }
+    };
+    const subscribeCollection = (
+      name: "companies" | "roles" | "applications" | "outreach",
+      mapper: (id: string, data: DocumentData) => unknown
+    ) => {
+      const ref = collection(firebase.db, "users", userId, name);
+      const unsubscribe = onSnapshot(
+        ref,
+        (snapshot) => {
+          setState((prev) => {
+            const items = snapshot.docs.map((d) =>
+              mapper(d.id, d.data())
+            ) as JobOsState[typeof name];
+            const next = { ...prev, [name]: items } as JobOsState;
+            writeLocal(userId, next);
+            return next;
+          });
+          setSyncNotice(null);
+          setLocalOnly(false);
+          markLoaded();
+        },
+        () => {
+          setSyncNotice("Cloud sync unavailable. Working in local mode.");
+          setLocalOnly(true);
+          markLoaded();
+        }
+      );
+      unsubscribers.push(unsubscribe);
+    };
+
+    const assetsRef = doc(firebase.db, "users", userId, "assets", "vault");
+    const assetsUnsub = onSnapshot(
+      assetsRef,
+      (snapshot) => {
+        setState((prev) => {
+          const remote = snapshot.exists()
+            ? normalizeState({
+                assets: snapshot.data() as JobOsState["assets"],
+                companies: prev.companies,
+                roles: prev.roles,
+                applications: prev.applications,
+                outreach: prev.outreach,
+              })
+            : prev;
+          const next: JobOsState = {
+            ...prev,
+            assets: remote.assets,
+          };
+          writeLocal(userId, next);
+          return next;
+        });
+        setSyncNotice(null);
+        setLocalOnly(false);
+        markLoaded();
+      },
+      () => {
+        setSyncNotice("Cloud sync unavailable. Working in local mode.");
+        setLocalOnly(true);
+        markLoaded();
+      }
+    );
+    unsubscribers.push(assetsUnsub);
+
+    subscribeCollection("companies", (id, data) =>
+      withTimestamps({ ...(data as Record<string, unknown>), id })
+    );
+    subscribeCollection("roles", (id, data) =>
+      withTimestamps({ ...(data as Record<string, unknown>), id })
+    );
+    subscribeCollection("applications", (id, data) =>
+      withTimestamps({ ...(data as Record<string, unknown>), id })
+    );
+    subscribeCollection("outreach", (id, data) =>
+      withTimestamps({ ...(data as Record<string, unknown>), id })
+    );
+
+    return () => {
+      unsubscribers.forEach((fn) => fn());
+    };
+  }, [firebase, localOnly, userId]);
+
+  const mutate = useCallback(
+    async <T>(
+      label: string,
+      localMutation: (prev: JobOsState) => JobOsState,
+      remoteMutation: (() => Promise<T>) | null
+    ): Promise<void> => {
+      if (!userId || !remoteMutation || localOnly) {
+        setState((prev) => {
+          const next = localMutation(prev);
+          writeLocal(userId || "", next);
+          return next;
+        });
+        return;
+      }
+      try {
+        await withTimeout(remoteMutation(), label);
+      } catch (error) {
+        if (!isOfflineLike(error)) {
+          throw error;
+        }
+        setLocalOnly(true);
+        setSyncNotice("Cloud sync unavailable. Working in local mode.");
+        setState((prev) => {
+          const next = localMutation(prev);
+          writeLocal(userId, next);
+          return next;
+        });
+      }
+    },
+    [localOnly, userId]
+  );
+
+  const updateCv = useCallback(
+    async (
+      id: string,
+      updates: Partial<Pick<JobOsCvAsset, "version" | "fileUrl">>
+    ) => {
+      const now = new Date().toISOString();
+      await mutate(
+        "Update CV",
+        (prev) => {
+          const next: JobOsState = {
+            ...prev,
+            assets: {
+              ...prev.assets,
+              cvs: prev.assets.cvs.map((cv) =>
+                cv.id === id ? { ...cv, ...updates, updatedAt: now } : cv
+              ),
+            },
+          };
+          return next;
+        },
+        firebase && userId && !localOnly
+          ? async () => {
+              const assetDoc = doc(firebase.db, "users", userId, "assets", "vault");
+              const nextCvs = state.assets.cvs.map((cv) =>
+                cv.id === id ? { ...cv, ...updates, updatedAt: now } : cv
+              );
+              await setDoc(
+                assetDoc,
+                {
+                  cvs: nextCvs,
+                  scripts: state.assets.scripts,
+                  templates: state.assets.templates,
+                  updatedAt: serverTimestamp(),
+                },
+                { merge: true }
+              );
+            }
+          : null
+      );
+    },
+    [firebase, localOnly, mutate, state.assets, userId]
+  );
+
+  const addScript = useCallback(
+    async (
+      payload: Omit<
+        JobOsScriptAsset,
+        "id" | "createdAt" | "updatedAt" | "lastUpdated"
+      >
+    ) => {
+      const now = new Date().toISOString();
+      const localItem: JobOsScriptAsset = {
+        id: randomId("script"),
+        ...payload,
+        lastUpdated: now,
+        createdAt: now,
+        updatedAt: now,
+      };
+      await mutate(
+        "Add script",
+        (prev) => ({
+          ...prev,
+          assets: {
+            ...prev.assets,
+            scripts: [localItem, ...prev.assets.scripts],
+          },
+        }),
+        firebase && userId && !localOnly
+          ? async () => {
+              const assetDoc = doc(firebase.db, "users", userId, "assets", "vault");
+              await setDoc(
+                assetDoc,
+                {
+                  cvs: state.assets.cvs,
+                  scripts: [localItem, ...state.assets.scripts],
+                  templates: state.assets.templates,
+                  updatedAt: serverTimestamp(),
+                },
+                { merge: true }
+              );
+            }
+          : null
+      );
+    },
+    [firebase, localOnly, mutate, state.assets, userId]
+  );
+
+  const addTemplate = useCallback(
+    async (
+      payload: Omit<JobOsTemplateAsset, "id" | "createdAt" | "updatedAt">
+    ) => {
+      const now = new Date().toISOString();
+      const localItem: JobOsTemplateAsset = {
+        id: randomId("template"),
+        ...payload,
+        createdAt: now,
+        updatedAt: now,
+      };
+      await mutate(
+        "Add template",
+        (prev) => ({
+          ...prev,
+          assets: {
+            ...prev.assets,
+            templates: [localItem, ...prev.assets.templates],
+          },
+        }),
+        firebase && userId && !localOnly
+          ? async () => {
+              const assetDoc = doc(firebase.db, "users", userId, "assets", "vault");
+              await setDoc(
+                assetDoc,
+                {
+                  cvs: state.assets.cvs,
+                  scripts: state.assets.scripts,
+                  templates: [localItem, ...state.assets.templates],
+                  updatedAt: serverTimestamp(),
+                },
+                { merge: true }
+              );
+            }
+          : null
+      );
+    },
+    [firebase, localOnly, mutate, state.assets, userId]
+  );
+
+  const addCollectionItem = useCallback(
+    async <T extends { id: string; createdAt: string; updatedAt: string }>(
+      key: "companies" | "roles" | "applications" | "outreach",
+      prefix: string,
+      payload: Omit<T, "id" | "createdAt" | "updatedAt">
+    ) => {
+      const now = new Date().toISOString();
+      const localItem = {
+        id: randomId(prefix),
+        ...payload,
+        createdAt: now,
+        updatedAt: now,
+      } as T;
+      await mutate(
+        `Add ${key}`,
+        (prev) => ({
+          ...prev,
+          [key]: [localItem, ...(prev[key] as T[])],
+        } as JobOsState),
+        firebase && userId && !localOnly
+          ? async () => {
+              const colRef = collection(
+                firebase.db,
+                "users",
+                userId,
+                key
+              );
+              await addDoc(colRef, {
+                ...payload,
+                createdAt: serverTimestamp(),
+                updatedAt: serverTimestamp(),
+              });
+            }
+          : null
+      );
+    },
+    [firebase, localOnly, mutate, userId]
+  );
+
+  const updateCollectionItem = useCallback(
+    async <T extends { id: string }>(
+      key: "companies" | "roles" | "applications" | "outreach",
+      id: string,
+      updates: Partial<T>
+    ) => {
+      const now = new Date().toISOString();
+      await mutate(
+        `Update ${key}`,
+        (prev) =>
+          collectionDoc<T>(prev, key, id, (existing) => ({
+            ...existing,
+            ...updates,
+            updatedAt: now,
+          })),
+        firebase && userId && !localOnly
+          ? async () => {
+              const ref = doc(
+                firebase.db,
+                "users",
+                userId,
+                key,
+                id
+              );
+              await setDoc(ref, { ...updates, updatedAt: serverTimestamp() }, { merge: true });
+            }
+          : null
+      );
+    },
+    [firebase, localOnly, mutate, userId]
+  );
+
+  const removeCollectionItem = useCallback(
+    async (key: "companies" | "roles" | "applications" | "outreach", id: string) => {
+      await mutate(
+        `Delete ${key}`,
+        (prev) => ({
+          ...prev,
+          [key]: (prev[key] as Array<{ id: string }>).filter((v) => v.id !== id),
+        } as JobOsState),
+        firebase && userId && !localOnly
+          ? async () => {
+              const ref = doc(
+                firebase.db,
+                "users",
+                userId,
+                key,
+                id
+              );
+              await deleteDoc(ref);
+            }
+          : null
+      );
+    },
+    [firebase, localOnly, mutate, userId]
+  );
+
+  const actions = useMemo(
+    () => ({
+      updateCv,
+      addScript,
+      addTemplate,
+      addCompany: (payload: Omit<JobOsCompany, "id" | "createdAt" | "updatedAt">) =>
+        addCollectionItem<JobOsCompany>("companies", "company", payload),
+      updateCompany: (id: string, updates: Partial<JobOsCompany>) =>
+        updateCollectionItem<JobOsCompany>("companies", id, updates),
+      addRole: (payload: Omit<JobOsRole, "id" | "createdAt" | "updatedAt">) =>
+        addCollectionItem<JobOsRole>("roles", "role", payload),
+      updateRole: (id: string, updates: Partial<JobOsRole>) =>
+        updateCollectionItem<JobOsRole>("roles", id, updates),
+      addApplication: (
+        payload: Omit<JobOsApplication, "id" | "createdAt" | "updatedAt">
+      ) => addCollectionItem<JobOsApplication>("applications", "app", payload),
+      updateApplication: (id: string, updates: Partial<JobOsApplication>) =>
+        updateCollectionItem<JobOsApplication>("applications", id, updates),
+      addOutreach: (payload: Omit<JobOsOutreach, "id" | "createdAt" | "updatedAt">) =>
+        addCollectionItem<JobOsOutreach>("outreach", "outreach", payload),
+      updateOutreach: (id: string, updates: Partial<JobOsOutreach>) =>
+        updateCollectionItem<JobOsOutreach>("outreach", id, updates),
+      removeCompany: (id: string) => removeCollectionItem("companies", id),
+      removeRole: (id: string) => removeCollectionItem("roles", id),
+      removeApplication: (id: string) => removeCollectionItem("applications", id),
+      removeOutreach: (id: string) => removeCollectionItem("outreach", id),
+    }),
+    [
+      addCollectionItem,
+      addScript,
+      addTemplate,
+      removeCollectionItem,
+      updateCollectionItem,
+      updateCv,
+    ]
+  );
+
+  return {
+    ...state,
+    loading,
+    syncNotice,
+    ...actions,
+  };
+}

--- a/src/app/hooks/useJobOs.ts
+++ b/src/app/hooks/useJobOs.ts
@@ -232,17 +232,9 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
   const [syncNotice, setSyncNotice] = useState<string | null>(null);
   const [localOnly, setLocalOnly] = useState(false);
 
-  const applyLocal = useCallback(
-    (nextState: JobOsState) => {
-      if (!userId) return;
-      writeLocal(userId, nextState);
-      setState(nextState);
-    },
-    [userId]
-  );
-
   useEffect(() => {
     if (!userId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setState(EMPTY_STATE);
       setLoading(false);
       setSyncNotice(null);

--- a/src/app/pages/Dashboard.tsx
+++ b/src/app/pages/Dashboard.tsx
@@ -19,6 +19,7 @@ import {
   Plus,
   BarChart3,
   ShieldCheck,
+  BriefcaseBusiness,
   Moon,
   Sun,
   Undo2,
@@ -117,6 +118,12 @@ export default function Dashboard() {
                 <Button variant="outline" className="gap-2">
                   <ShieldCheck className="w-4 h-4" />
                   <span className="hidden sm:inline">AfA Compliance</span>
+                </Button>
+              </Link>
+              <Link to="/job-os/dashboard">
+                <Button variant="outline" className="gap-2">
+                  <BriefcaseBusiness className="w-4 h-4" />
+                  <span className="hidden sm:inline">Job OS</span>
                 </Button>
               </Link>
               <Button onClick={() => setModalOpen(true)} className="gap-2">

--- a/src/app/pages/job-os/JobOsApplicationsPage.tsx
+++ b/src/app/pages/job-os/JobOsApplicationsPage.tsx
@@ -1,0 +1,169 @@
+import { useMemo, useState } from "react";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { Input } from "../../components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { Textarea } from "../../components/ui/textarea";
+import { useApp } from "../../context";
+import { useJobOs } from "../../hooks/useJobOs";
+import { JobOsLayout } from "../../components/job-os/JobOsLayout";
+import type { ApplicationStatus, JobOsApplication } from "../../types/jobOs";
+
+const STATUS_VALUES: ApplicationStatus[] = [
+  "sent",
+  "screen",
+  "case",
+  "interview",
+  "final",
+  "offer",
+  "rejected",
+  "ghosted",
+];
+
+export default function JobOsApplicationsPage() {
+  const { session } = useApp();
+  const { applications, companies, roles, assets, addApplication, updateApplication, removeApplication, syncNotice } = useJobOs(
+    session?.userId ?? null
+  );
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [draft, setDraft] = useState<Omit<JobOsApplication, "id" | "createdAt" | "updatedAt">>({
+    dateApplied: new Date().toISOString().slice(0, 10),
+    companyId: "",
+    roleId: "",
+    channel: "LinkedIn",
+    cvVersion: assets.cvs[0]?.name ?? "CV - Technical Product Manager",
+    status: "sent",
+    nextAction: "",
+    notes: "",
+  });
+
+  const byId = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  function toggle(id: string): void {
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((v) => v !== id) : [...prev, id]));
+  }
+
+  async function applyBulkStatus(status: ApplicationStatus): Promise<void> {
+    await Promise.all(selectedIds.map((id) => updateApplication(id, { status })));
+    setSelectedIds([]);
+  }
+
+  async function bulkFollowUp(): Promise<void> {
+    await Promise.all(
+      selectedIds.map((id) =>
+        updateApplication(id, {
+          nextAction: "Follow up",
+        })
+      )
+    );
+    setSelectedIds([]);
+  }
+
+  return (
+    <JobOsLayout title="Applications" subtitle="Master tracking sheet for all submitted applications" notice={syncNotice}>
+      <Card>
+        <CardHeader><CardTitle className="text-sm">Log Application</CardTitle></CardHeader>
+        <CardContent className="grid md:grid-cols-4 gap-3">
+          <Input type="date" value={draft.dateApplied} onChange={(e) => setDraft((p) => ({ ...p, dateApplied: e.target.value }))} />
+          <Select value={draft.companyId} onValueChange={(v) => setDraft((p) => ({ ...p, companyId: v }))}>
+            <SelectTrigger><SelectValue placeholder="Company" /></SelectTrigger>
+            <SelectContent>{companies.map((c) => <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>)}</SelectContent>
+          </Select>
+          <Select value={draft.roleId} onValueChange={(v) => setDraft((p) => ({ ...p, roleId: v }))}>
+            <SelectTrigger><SelectValue placeholder="Role" /></SelectTrigger>
+            <SelectContent>{roles.filter((r) => !draft.companyId || r.companyId === draft.companyId).map((r) => <SelectItem key={r.id} value={r.id}>{r.title}</SelectItem>)}</SelectContent>
+          </Select>
+          <Input value={draft.channel} onChange={(e) => setDraft((p) => ({ ...p, channel: e.target.value }))} placeholder="Channel" />
+          <Select value={draft.cvVersion} onValueChange={(v) => setDraft((p) => ({ ...p, cvVersion: v }))}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>{assets.cvs.map((cv) => <SelectItem key={cv.id} value={cv.name}>{cv.name}</SelectItem>)}</SelectContent>
+          </Select>
+          <Select value={draft.status} onValueChange={(v) => setDraft((p) => ({ ...p, status: v as ApplicationStatus }))}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>{STATUS_VALUES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}</SelectContent>
+          </Select>
+          <Input value={draft.nextAction} onChange={(e) => setDraft((p) => ({ ...p, nextAction: e.target.value }))} placeholder="Next action" />
+          <Button
+            onClick={() => {
+              if (!draft.companyId) return;
+              void addApplication(draft);
+              setDraft((p) => ({ ...p, nextAction: "", notes: "" }));
+            }}
+          >
+            Save
+          </Button>
+          <div className="md:col-span-4">
+            <Textarea value={draft.notes} onChange={(e) => setDraft((p) => ({ ...p, notes: e.target.value }))} rows={2} placeholder="Notes" />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Bulk Actions</CardTitle>
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" variant="outline" disabled={selectedIds.length === 0} onClick={() => void bulkFollowUp()}>
+              Set Follow-up
+            </Button>
+            <Button size="sm" variant="outline" disabled={selectedIds.length === 0} onClick={() => void applyBulkStatus("rejected")}>
+              Mark Rejected
+            </Button>
+            <Button size="sm" variant="outline" disabled={selectedIds.length === 0} onClick={() => void applyBulkStatus("screen")}>
+              Update Status
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead />
+                <TableHead>Date Applied</TableHead>
+                <TableHead>Company</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Channel</TableHead>
+                <TableHead>CV Version</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Next Action</TableHead>
+                <TableHead>Notes</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {applications.map((app) => (
+                <TableRow key={app.id}>
+                  <TableCell>
+                    <input
+                      type="checkbox"
+                      checked={byId.has(app.id)}
+                      onChange={() => toggle(app.id)}
+                    />
+                  </TableCell>
+                  <TableCell>{app.dateApplied}</TableCell>
+                  <TableCell>{companies.find((c) => c.id === app.companyId)?.name ?? "-"}</TableCell>
+                  <TableCell>{roles.find((r) => r.id === app.roleId)?.title ?? "-"}</TableCell>
+                  <TableCell>{app.channel}</TableCell>
+                  <TableCell>{app.cvVersion}</TableCell>
+                  <TableCell>
+                    <Select value={app.status} onValueChange={(v) => void updateApplication(app.id, { status: v as ApplicationStatus })}>
+                      <SelectTrigger className="w-36"><SelectValue /></SelectTrigger>
+                      <SelectContent>{STATUS_VALUES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}</SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell>{app.nextAction || "-"}</TableCell>
+                  <TableCell className="max-w-[260px] truncate">{app.notes || "-"}</TableCell>
+                  <TableCell>
+                    <Button size="sm" variant="ghost" className="text-red-500" onClick={() => void removeApplication(app.id)}>
+                      Delete
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </JobOsLayout>
+  );
+}

--- a/src/app/pages/job-os/JobOsAssetsPage.tsx
+++ b/src/app/pages/job-os/JobOsAssetsPage.tsx
@@ -1,0 +1,227 @@
+import { useState } from "react";
+import { Copy, Download } from "lucide-react";
+import { useApp } from "../../context";
+import { useJobOs } from "../../hooks/useJobOs";
+import { JobOsLayout } from "../../components/job-os/JobOsLayout";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../components/ui/tabs";
+import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { Input } from "../../components/ui/input";
+import { Button } from "../../components/ui/button";
+import { Textarea } from "../../components/ui/textarea";
+import type { JobOsScriptAsset, JobOsTemplateAsset } from "../../types/jobOs";
+
+async function copyText(value: string): Promise<void> {
+  if (!value) return;
+  await navigator.clipboard.writeText(value);
+}
+
+export default function JobOsAssetsPage() {
+  const { session } = useApp();
+  const { assets, updateCv, addScript, addTemplate, syncNotice } = useJobOs(
+    session?.userId ?? null
+  );
+
+  const [scriptDraft, setScriptDraft] = useState<Omit<JobOsScriptAsset, "id" | "lastUpdated" | "createdAt" | "updatedAt">>({
+    title: "",
+    scriptText: "",
+    tags: [],
+  });
+  const [templateDraft, setTemplateDraft] = useState<Omit<JobOsTemplateAsset, "id" | "createdAt" | "updatedAt">>({
+    title: "",
+    templateText: "",
+    tags: [],
+  });
+
+  return (
+    <JobOsLayout
+      title="Assets Vault"
+      subtitle="Reusable CVs, scripts, and templates"
+      notice={syncNotice}
+    >
+      <Tabs defaultValue="cvs" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="cvs">CVs</TabsTrigger>
+          <TabsTrigger value="scripts">Scripts</TabsTrigger>
+          <TabsTrigger value="templates">Templates</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="cvs" className="space-y-4">
+          <div className="grid md:grid-cols-3 gap-4">
+            {assets.cvs.map((cv) => (
+              <Card key={cv.id}>
+                <CardHeader>
+                  <CardTitle className="text-sm">{cv.name}</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <Input
+                    value={cv.version}
+                    onChange={(e) => {
+                      void updateCv(cv.id, { version: e.target.value });
+                    }}
+                    placeholder="Version"
+                  />
+                  <Input
+                    value={cv.fileUrl}
+                    onChange={(e) => {
+                      void updateCv(cv.id, { fileUrl: e.target.value });
+                    }}
+                    placeholder="File URL"
+                  />
+                  <div className="flex items-center justify-between text-xs text-neutral-500">
+                    <span>{cv.locked ? "Locked CV" : "Unlocked"}</span>
+                    <span>{new Date(cv.updatedAt).toLocaleDateString()}</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="gap-1.5"
+                      disabled={!cv.fileUrl}
+                      onClick={() => window.open(cv.fileUrl, "_blank", "noopener,noreferrer")}
+                    >
+                      <Download className="w-3 h-3" /> Download
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="gap-1.5"
+                      disabled={!cv.fileUrl}
+                      onClick={() => {
+                        void copyText(cv.fileUrl);
+                      }}
+                    >
+                      <Copy className="w-3 h-3" /> Copy Link
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </TabsContent>
+
+        <TabsContent value="scripts" className="space-y-4">
+          <Card>
+            <CardHeader><CardTitle className="text-sm">Add Script</CardTitle></CardHeader>
+            <CardContent className="grid md:grid-cols-3 gap-3">
+              <Input
+                value={scriptDraft.title}
+                onChange={(e) => setScriptDraft((p) => ({ ...p, title: e.target.value }))}
+                placeholder="Script title"
+              />
+              <Input
+                value={scriptDraft.tags.join(", ")}
+                onChange={(e) =>
+                  setScriptDraft((p) => ({
+                    ...p,
+                    tags: e.target.value.split(",").map((t) => t.trim()).filter(Boolean),
+                  }))
+                }
+                placeholder="tags: referral, recruiter"
+              />
+              <Button
+                onClick={() => {
+                  if (!scriptDraft.title || !scriptDraft.scriptText) return;
+                  void addScript(scriptDraft);
+                  setScriptDraft({ title: "", scriptText: "", tags: [] });
+                }}
+              >
+                Save Script
+              </Button>
+              <div className="md:col-span-3">
+                <Textarea
+                  value={scriptDraft.scriptText}
+                  onChange={(e) =>
+                    setScriptDraft((p) => ({ ...p, scriptText: e.target.value }))
+                  }
+                  rows={5}
+                  placeholder="Write outreach script..."
+                />
+              </div>
+            </CardContent>
+          </Card>
+          <div className="space-y-3">
+            {assets.scripts.map((script) => (
+              <Card key={script.id}>
+                <CardContent className="pt-6 space-y-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="font-medium">{script.title}</p>
+                      <p className="text-xs text-neutral-500">{script.tags.join(", ") || "No tags"}</p>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button size="sm" variant="outline" onClick={() => void copyText(script.scriptText)}>Copy</Button>
+                      <Button size="sm" variant="outline" onClick={() => void copyText(`${script.title}\n\n${script.scriptText}`)}>Quick Insert</Button>
+                    </div>
+                  </div>
+                  <p className="text-sm whitespace-pre-wrap text-neutral-700 dark:text-neutral-300">{script.scriptText}</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </TabsContent>
+
+        <TabsContent value="templates" className="space-y-4">
+          <Card>
+            <CardHeader><CardTitle className="text-sm">Add Template</CardTitle></CardHeader>
+            <CardContent className="grid md:grid-cols-3 gap-3">
+              <Input
+                value={templateDraft.title}
+                onChange={(e) => setTemplateDraft((p) => ({ ...p, title: e.target.value }))}
+                placeholder="Template title"
+              />
+              <Input
+                value={templateDraft.tags.join(", ")}
+                onChange={(e) =>
+                  setTemplateDraft((p) => ({
+                    ...p,
+                    tags: e.target.value.split(",").map((t) => t.trim()).filter(Boolean),
+                  }))
+                }
+                placeholder="tags"
+              />
+              <Button
+                onClick={() => {
+                  if (!templateDraft.title || !templateDraft.templateText) return;
+                  void addTemplate(templateDraft);
+                  setTemplateDraft({ title: "", templateText: "", tags: [] });
+                }}
+              >
+                Save Template
+              </Button>
+              <div className="md:col-span-3">
+                <Textarea
+                  value={templateDraft.templateText}
+                  onChange={(e) =>
+                    setTemplateDraft((p) => ({ ...p, templateText: e.target.value }))
+                  }
+                  rows={5}
+                  placeholder="Reusable template..."
+                />
+              </div>
+            </CardContent>
+          </Card>
+          <div className="space-y-3">
+            {assets.templates.map((template) => (
+              <Card key={template.id}>
+                <CardContent className="pt-6 space-y-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="font-medium">{template.title}</p>
+                      <p className="text-xs text-neutral-500">{template.tags.join(", ") || "No tags"}</p>
+                    </div>
+                    <Button size="sm" variant="outline" onClick={() => void copyText(template.templateText)}>
+                      Copy
+                    </Button>
+                  </div>
+                  <p className="text-sm whitespace-pre-wrap text-neutral-700 dark:text-neutral-300">{template.templateText}</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </TabsContent>
+      </Tabs>
+    </JobOsLayout>
+  );
+}

--- a/src/app/pages/job-os/JobOsCompaniesPage.tsx
+++ b/src/app/pages/job-os/JobOsCompaniesPage.tsx
@@ -1,0 +1,168 @@
+import { useMemo, useState } from "react";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { Input } from "../../components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { Textarea } from "../../components/ui/textarea";
+import { useApp } from "../../context";
+import { useJobOs } from "../../hooks/useJobOs";
+import { JobOsLayout } from "../../components/job-os/JobOsLayout";
+import type { CompanyPriority, CompanyStatus, JobOsCompany } from "../../types/jobOs";
+
+const STATUS_VALUES: CompanyStatus[] = [
+  "Research",
+  "Target",
+  "Active",
+  "Applied",
+  "Interviewing",
+  "Closed",
+];
+
+export default function JobOsCompaniesPage() {
+  const { session } = useApp();
+  const { companies, roles, outreach, applications, addCompany, addRole, addOutreach, addApplication, removeCompany, syncNotice } =
+    useJobOs(session?.userId ?? null);
+
+  const [search, setSearch] = useState("");
+  const [selectedCompanyId, setSelectedCompanyId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<Omit<JobOsCompany, "id" | "createdAt" | "updatedAt">>({
+    name: "",
+    industry: "",
+    size: "",
+    remotePolicy: "",
+    priority: "B",
+    status: "Research",
+    notes: "",
+  });
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    return companies.filter((c) =>
+      [c.name, c.industry, c.notes].join(" ").toLowerCase().includes(q)
+    );
+  }, [companies, search]);
+
+  const selectedCompany = companies.find((c) => c.id === selectedCompanyId) ?? null;
+
+  return (
+    <JobOsLayout title="Company Engine" subtitle="Account-based target company tracking" notice={syncNotice}>
+      <Card>
+        <CardHeader><CardTitle className="text-sm">Add Company</CardTitle></CardHeader>
+        <CardContent className="grid md:grid-cols-4 gap-3">
+          <Input value={draft.name} onChange={(e) => setDraft((p) => ({ ...p, name: e.target.value }))} placeholder="Company" />
+          <Input value={draft.industry} onChange={(e) => setDraft((p) => ({ ...p, industry: e.target.value }))} placeholder="Industry" />
+          <Input value={draft.size} onChange={(e) => setDraft((p) => ({ ...p, size: e.target.value }))} placeholder="Size" />
+          <Input value={draft.remotePolicy} onChange={(e) => setDraft((p) => ({ ...p, remotePolicy: e.target.value }))} placeholder="Remote policy" />
+          <Select value={draft.priority} onValueChange={(v) => setDraft((p) => ({ ...p, priority: v as CompanyPriority }))}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="A">A</SelectItem>
+              <SelectItem value="B">B</SelectItem>
+              <SelectItem value="C">C</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={draft.status} onValueChange={(v) => setDraft((p) => ({ ...p, status: v as CompanyStatus }))}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>{STATUS_VALUES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}</SelectContent>
+          </Select>
+          <div className="md:col-span-2">
+            <Button
+              className="w-full"
+              onClick={() => {
+                if (!draft.name) return;
+                void addCompany(draft);
+                setDraft({
+                  name: "",
+                  industry: "",
+                  size: "",
+                  remotePolicy: "",
+                  priority: "B",
+                  status: "Research",
+                  notes: "",
+                });
+              }}
+            >
+              Add Company
+            </Button>
+          </div>
+          <div className="md:col-span-4">
+            <Textarea value={draft.notes} onChange={(e) => setDraft((p) => ({ ...p, notes: e.target.value }))} rows={2} placeholder="Research notes" />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid lg:grid-cols-3 gap-4">
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="text-sm">Target Companies</CardTitle>
+            <Input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Filter company..." />
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Company</TableHead>
+                  <TableHead>Industry</TableHead>
+                  <TableHead>Size</TableHead>
+                  <TableHead>Remote</TableHead>
+                  <TableHead>Priority</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Notes</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((company) => (
+                  <TableRow key={company.id}>
+                    <TableCell className="font-medium">{company.name}</TableCell>
+                    <TableCell>{company.industry}</TableCell>
+                    <TableCell>{company.size}</TableCell>
+                    <TableCell>{company.remotePolicy}</TableCell>
+                    <TableCell>{company.priority}</TableCell>
+                    <TableCell>{company.status}</TableCell>
+                    <TableCell className="max-w-[240px] truncate">{company.notes || "-"}</TableCell>
+                    <TableCell className="flex gap-2">
+                      <Button size="sm" variant="outline" onClick={() => setSelectedCompanyId(company.id)}>View</Button>
+                      <Button size="sm" variant="ghost" className="text-red-500" onClick={() => void removeCompany(company.id)}>Delete</Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader><CardTitle className="text-sm">Company Detail</CardTitle></CardHeader>
+          <CardContent className="space-y-4">
+            {!selectedCompany && <p className="text-sm text-neutral-500">Select a company to view detail.</p>}
+            {selectedCompany && (
+              <>
+                <div>
+                  <p className="font-medium">{selectedCompany.name}</p>
+                  <p className="text-xs text-neutral-500">{selectedCompany.industry} · {selectedCompany.size}</p>
+                </div>
+                <div className="text-sm space-y-1">
+                  <p><span className="text-neutral-500">Status:</span> {selectedCompany.status}</p>
+                  <p><span className="text-neutral-500">Priority:</span> {selectedCompany.priority}</p>
+                  <p><span className="text-neutral-500">Notes:</span> {selectedCompany.notes || "-"}</p>
+                </div>
+                <div className="grid grid-cols-2 gap-2 text-xs">
+                  <div className="rounded border p-2">Roles: {roles.filter((r) => r.companyId === selectedCompany.id).length}</div>
+                  <div className="rounded border p-2">Outreach: {outreach.filter((o) => o.companyId === selectedCompany.id).length}</div>
+                  <div className="rounded border p-2">Applications: {applications.filter((a) => a.companyId === selectedCompany.id).length}</div>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <Button size="sm" variant="outline" onClick={() => void addRole({ companyId: selectedCompany.id, title: "New Role", url: "", location: "", seniority: "", track: "TPM", fitScore: 3, status: "to_apply" })}>Add Role</Button>
+                  <Button size="sm" variant="outline" onClick={() => void addOutreach({ companyId: selectedCompany.id, roleId: null, contactName: "", contactRole: "", linkedinURL: "", scriptUsed: "", sentDate: new Date().toISOString().slice(0, 10), status: "sent", followUpCount: 0, nextFollowUpDate: null, notes: "" })}>Add Outreach</Button>
+                  <Button size="sm" variant="outline" className="col-span-2" onClick={() => void addApplication({ companyId: selectedCompany.id, roleId: "", dateApplied: new Date().toISOString().slice(0, 10), channel: "LinkedIn", cvVersion: "CV - Technical Product Manager", status: "sent", nextAction: "Follow up in 5 days", notes: "" })}>Log Application</Button>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </JobOsLayout>
+  );
+}

--- a/src/app/pages/job-os/JobOsDashboardPage.tsx
+++ b/src/app/pages/job-os/JobOsDashboardPage.tsx
@@ -1,0 +1,120 @@
+import { Link } from "react-router";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { useApp } from "../../context";
+import { useJobOs } from "../../hooks/useJobOs";
+import { JobOsLayout } from "../../components/job-os/JobOsLayout";
+
+function daysAgo(dateValue: string): number {
+  const date = new Date(dateValue).getTime();
+  const now = Date.now();
+  return Math.floor((now - date) / (24 * 60 * 60 * 1000));
+}
+
+export default function JobOsDashboardPage() {
+  const { session } = useApp();
+  const { applications, outreach, companies, roles, syncNotice } = useJobOs(
+    session?.userId ?? null
+  );
+
+  const appsLast7Days = applications.filter((a) => daysAgo(a.dateApplied) <= 7).length;
+  const outreachLast7Days = outreach.filter((o) => daysAgo(o.sentDate) <= 7).length;
+  const activeInterviews = applications.filter((a) =>
+    a.status === "interview" || a.status === "final" || a.status === "case"
+  ).length;
+
+  const today = new Date().toISOString().slice(0, 10);
+  const followUpsDueToday = outreach.filter(
+    (o) => o.nextFollowUpDate && o.nextFollowUpDate <= today && o.status !== "closed"
+  );
+
+  const pipeline = {
+    applied: applications.filter((a) => a.status === "sent").length,
+    screen: applications.filter((a) => a.status === "screen").length,
+    interview: applications.filter((a) => a.status === "interview").length,
+    final: applications.filter((a) => a.status === "final").length,
+    offer: applications.filter((a) => a.status === "offer").length,
+    rejected: applications.filter((a) => a.status === "rejected").length,
+  };
+
+  const followUpRows = followUpsDueToday.map((o) => {
+    const company = companies.find((c) => c.id === o.companyId)?.name ?? "Unknown";
+    const role = roles.find((r) => r.id === o.roleId)?.title ?? "-";
+    return {
+      id: o.id,
+      company,
+      role,
+      nextAction: o.followUpCount > 0 ? `Follow-up #${o.followUpCount + 1}` : "First follow-up",
+      date: o.nextFollowUpDate ?? today,
+    };
+  });
+
+  return (
+    <JobOsLayout
+      title="Job OS Dashboard"
+      subtitle="Weekly execution overview for high-volume applications"
+      notice={syncNotice}
+      actions={
+        <div className="flex items-center gap-2">
+          <Link to="/job-os/companies"><Button size="sm">Add Company</Button></Link>
+          <Link to="/job-os/roles"><Button size="sm" variant="outline">Add Role</Button></Link>
+          <Link to="/job-os/applications"><Button size="sm" variant="outline">Log Application</Button></Link>
+          <Link to="/job-os/outreach"><Button size="sm" variant="outline">Add Outreach</Button></Link>
+        </div>
+      }
+    >
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <Card><CardHeader><CardTitle className="text-xs">Applications (7d)</CardTitle></CardHeader><CardContent className="text-3xl font-semibold">{appsLast7Days}</CardContent></Card>
+        <Card><CardHeader><CardTitle className="text-xs">Outreach Sent (7d)</CardTitle></CardHeader><CardContent className="text-3xl font-semibold">{outreachLast7Days}</CardContent></Card>
+        <Card><CardHeader><CardTitle className="text-xs">Active Interviews</CardTitle></CardHeader><CardContent className="text-3xl font-semibold">{activeInterviews}</CardContent></Card>
+        <Card><CardHeader><CardTitle className="text-xs">Follow-ups Due Today</CardTitle></CardHeader><CardContent className="text-3xl font-semibold">{followUpsDueToday.length}</CardContent></Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Pipeline Summary</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 md:grid-cols-6 gap-3 text-sm">
+          <div className="rounded border border-blue-200 bg-blue-50 px-3 py-2 text-blue-700">Applied: {pipeline.applied}</div>
+          <div className="rounded border border-sky-200 bg-sky-50 px-3 py-2 text-sky-700">Screen: {pipeline.screen}</div>
+          <div className="rounded border border-purple-200 bg-purple-50 px-3 py-2 text-purple-700">Interview: {pipeline.interview}</div>
+          <div className="rounded border border-violet-200 bg-violet-50 px-3 py-2 text-violet-700">Final: {pipeline.final}</div>
+          <div className="rounded border border-green-200 bg-green-50 px-3 py-2 text-green-700">Offer: {pipeline.offer}</div>
+          <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-red-700">Rejected: {pipeline.rejected}</div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Follow-ups Due</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Company</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Next Action</TableHead>
+                <TableHead>Date</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {followUpRows.length === 0 && (
+                <TableRow><TableCell colSpan={4} className="text-center text-neutral-500">No follow-ups due today.</TableCell></TableRow>
+              )}
+              {followUpRows.map((row) => (
+                <TableRow key={row.id}>
+                  <TableCell>{row.company}</TableCell>
+                  <TableCell>{row.role}</TableCell>
+                  <TableCell>{row.nextAction}</TableCell>
+                  <TableCell>{row.date}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </JobOsLayout>
+  );
+}

--- a/src/app/pages/job-os/JobOsOutreachPage.tsx
+++ b/src/app/pages/job-os/JobOsOutreachPage.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { Input } from "../../components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { Textarea } from "../../components/ui/textarea";
+import { useApp } from "../../context";
+import { useJobOs } from "../../hooks/useJobOs";
+import { JobOsLayout } from "../../components/job-os/JobOsLayout";
+import type { JobOsOutreach, OutreachStatus } from "../../types/jobOs";
+
+const OUTREACH_STATUSES: OutreachStatus[] = ["sent", "replied", "meeting", "no_reply", "closed"];
+
+export default function JobOsOutreachPage() {
+  const { session } = useApp();
+  const { outreach, companies, roles, assets, addOutreach, updateOutreach, removeOutreach, syncNotice } = useJobOs(
+    session?.userId ?? null
+  );
+  const [draft, setDraft] = useState<Omit<JobOsOutreach, "id" | "createdAt" | "updatedAt">>({
+    companyId: "",
+    roleId: null,
+    contactName: "",
+    contactRole: "",
+    linkedinURL: "",
+    scriptUsed: assets.scripts[0]?.title ?? "Hiring Manager Outreach",
+    sentDate: new Date().toISOString().slice(0, 10),
+    status: "sent",
+    followUpCount: 0,
+    nextFollowUpDate: null,
+    notes: "",
+  });
+
+  return (
+    <JobOsLayout title="Outreach" subtitle="Networking and follow-up execution" notice={syncNotice}>
+      <Card>
+        <CardHeader><CardTitle className="text-sm">Log Outreach</CardTitle></CardHeader>
+        <CardContent className="grid md:grid-cols-4 gap-3">
+          <Select value={draft.companyId} onValueChange={(v) => setDraft((p) => ({ ...p, companyId: v }))}>
+            <SelectTrigger><SelectValue placeholder="Company" /></SelectTrigger>
+            <SelectContent>{companies.map((c) => <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>)}</SelectContent>
+          </Select>
+          <Select value={draft.roleId ?? "none"} onValueChange={(v) => setDraft((p) => ({ ...p, roleId: v === "none" ? null : v }))}>
+            <SelectTrigger><SelectValue placeholder="Role (optional)" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">No role linked</SelectItem>
+              {roles.filter((r) => !draft.companyId || r.companyId === draft.companyId).map((r) => <SelectItem key={r.id} value={r.id}>{r.title}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <Input value={draft.contactName} onChange={(e) => setDraft((p) => ({ ...p, contactName: e.target.value }))} placeholder="Contact name" />
+          <Input value={draft.contactRole} onChange={(e) => setDraft((p) => ({ ...p, contactRole: e.target.value }))} placeholder="Contact role" />
+          <Input value={draft.linkedinURL} onChange={(e) => setDraft((p) => ({ ...p, linkedinURL: e.target.value }))} placeholder="LinkedIn URL" />
+          <Select value={draft.scriptUsed} onValueChange={(v) => setDraft((p) => ({ ...p, scriptUsed: v }))}>
+            <SelectTrigger><SelectValue placeholder="Script used" /></SelectTrigger>
+            <SelectContent>
+              {assets.scripts.length === 0 ? (
+                <SelectItem value="Hiring Manager Outreach">Hiring Manager Outreach</SelectItem>
+              ) : (
+                assets.scripts.map((s) => <SelectItem key={s.id} value={s.title}>{s.title}</SelectItem>)
+              )}
+            </SelectContent>
+          </Select>
+          <Input type="date" value={draft.sentDate} onChange={(e) => setDraft((p) => ({ ...p, sentDate: e.target.value }))} />
+          <Select value={draft.status} onValueChange={(v) => setDraft((p) => ({ ...p, status: v as OutreachStatus }))}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>{OUTREACH_STATUSES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}</SelectContent>
+          </Select>
+          <Input type="date" value={draft.nextFollowUpDate ?? ""} onChange={(e) => setDraft((p) => ({ ...p, nextFollowUpDate: e.target.value || null }))} />
+          <Button
+            onClick={() => {
+              if (!draft.companyId) return;
+              void addOutreach(draft);
+              setDraft((p) => ({
+                ...p,
+                contactName: "",
+                contactRole: "",
+                linkedinURL: "",
+                notes: "",
+                followUpCount: 0,
+              }));
+            }}
+          >
+            Save Outreach
+          </Button>
+          <div className="md:col-span-4">
+            <Textarea value={draft.notes} onChange={(e) => setDraft((p) => ({ ...p, notes: e.target.value }))} rows={2} placeholder="Notes" />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader><CardTitle className="text-sm">Outreach Log</CardTitle></CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Company</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Contact</TableHead>
+                <TableHead>Script</TableHead>
+                <TableHead>Sent</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Follow-ups</TableHead>
+                <TableHead>Next Follow-up</TableHead>
+                <TableHead>Notes</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {outreach.map((item) => (
+                <TableRow key={item.id}>
+                  <TableCell>{companies.find((c) => c.id === item.companyId)?.name ?? "-"}</TableCell>
+                  <TableCell>{roles.find((r) => r.id === item.roleId)?.title ?? "-"}</TableCell>
+                  <TableCell>{item.contactName || "-"}</TableCell>
+                  <TableCell className="max-w-[220px] truncate">{item.scriptUsed}</TableCell>
+                  <TableCell>{item.sentDate}</TableCell>
+                  <TableCell>
+                    <Select value={item.status} onValueChange={(v) => void updateOutreach(item.id, { status: v as OutreachStatus })}>
+                      <SelectTrigger className="w-32"><SelectValue /></SelectTrigger>
+                      <SelectContent>{OUTREACH_STATUSES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}</SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell>{item.followUpCount}</TableCell>
+                  <TableCell>{item.nextFollowUpDate || "-"}</TableCell>
+                  <TableCell className="max-w-[220px] truncate">{item.notes || "-"}</TableCell>
+                  <TableCell className="flex gap-2">
+                    <Button size="sm" variant="outline" onClick={() => void navigator.clipboard.writeText(item.scriptUsed)}>
+                      Copy script
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        void updateOutreach(item.id, {
+                          followUpCount: item.followUpCount + 1,
+                          nextFollowUpDate: new Date(Date.now() + 4 * 24 * 60 * 60 * 1000)
+                            .toISOString()
+                            .slice(0, 10),
+                        })
+                      }
+                    >
+                      Schedule follow-up
+                    </Button>
+                    <Button size="sm" variant="ghost" className="text-red-500" onClick={() => void removeOutreach(item.id)}>
+                      Delete
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </JobOsLayout>
+  );
+}

--- a/src/app/pages/job-os/JobOsRolesPage.tsx
+++ b/src/app/pages/job-os/JobOsRolesPage.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from "react";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { Input } from "../../components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { useApp } from "../../context";
+import { useJobOs } from "../../hooks/useJobOs";
+import { JobOsLayout } from "../../components/job-os/JobOsLayout";
+import type { JobOsRole, JobTrack, RoleStatus } from "../../types/jobOs";
+
+const ROLE_STATUSES: RoleStatus[] = ["to_apply", "applied", "interview", "rejected", "offer", "closed"];
+
+export default function JobOsRolesPage() {
+  const { session } = useApp();
+  const { roles, companies, addRole, updateRole, addApplication, removeRole, syncNotice } = useJobOs(
+    session?.userId ?? null
+  );
+
+  const [filterTrack, setFilterTrack] = useState<string>("all");
+  const [filterStatus, setFilterStatus] = useState<string>("all");
+  const [draft, setDraft] = useState<Omit<JobOsRole, "id" | "createdAt" | "updatedAt">>({
+    companyId: "",
+    title: "",
+    url: "",
+    location: "",
+    seniority: "",
+    track: "TPM",
+    fitScore: 3,
+    status: "to_apply",
+  });
+
+  const filtered = useMemo(
+    () =>
+      roles.filter((r) => {
+        if (filterTrack !== "all" && r.track !== filterTrack) return false;
+        if (filterStatus !== "all" && r.status !== filterStatus) return false;
+        return true;
+      }),
+    [roles, filterStatus, filterTrack]
+  );
+
+  return (
+    <JobOsLayout title="Roles" subtitle="Track discovered opportunities and route into applications" notice={syncNotice}>
+      <Card>
+        <CardHeader><CardTitle className="text-sm">Add Role</CardTitle></CardHeader>
+        <CardContent className="grid md:grid-cols-4 gap-3">
+          <Select value={draft.companyId} onValueChange={(v) => setDraft((p) => ({ ...p, companyId: v }))}>
+            <SelectTrigger><SelectValue placeholder="Company" /></SelectTrigger>
+            <SelectContent>
+              {companies.map((c) => <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <Input value={draft.title} onChange={(e) => setDraft((p) => ({ ...p, title: e.target.value }))} placeholder="Role title" />
+          <Input value={draft.url} onChange={(e) => setDraft((p) => ({ ...p, url: e.target.value }))} placeholder="Role URL" />
+          <Input value={draft.location} onChange={(e) => setDraft((p) => ({ ...p, location: e.target.value }))} placeholder="Location" />
+          <Input value={draft.seniority} onChange={(e) => setDraft((p) => ({ ...p, seniority: e.target.value }))} placeholder="Seniority" />
+          <Select value={draft.track} onValueChange={(v) => setDraft((p) => ({ ...p, track: v as JobTrack }))}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="TPM">TPM</SelectItem>
+              <SelectItem value="Product Engineer">Product Engineer</SelectItem>
+              <SelectItem value="Systems PM">Systems PM</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={String(draft.fitScore)} onValueChange={(v) => setDraft((p) => ({ ...p, fitScore: Number(v) as 1 | 2 | 3 | 4 | 5 }))}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>{[1, 2, 3, 4, 5].map((n) => <SelectItem key={n} value={String(n)}>{n}</SelectItem>)}</SelectContent>
+          </Select>
+          <Button
+            onClick={() => {
+              if (!draft.companyId || !draft.title) return;
+              void addRole(draft);
+              setDraft({
+                companyId: "",
+                title: "",
+                url: "",
+                location: "",
+                seniority: "",
+                track: "TPM",
+                fitScore: 3,
+                status: "to_apply",
+              });
+            }}
+          >
+            Add Role
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Roles Pipeline</CardTitle>
+          <div className="flex gap-2">
+            <Select value={filterTrack} onValueChange={setFilterTrack}>
+              <SelectTrigger className="w-52"><SelectValue placeholder="Track" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Tracks</SelectItem>
+                <SelectItem value="TPM">TPM</SelectItem>
+                <SelectItem value="Product Engineer">Product Engineer</SelectItem>
+                <SelectItem value="Systems PM">Systems PM</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={filterStatus} onValueChange={setFilterStatus}>
+              <SelectTrigger className="w-52"><SelectValue placeholder="Status" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Statuses</SelectItem>
+                {ROLE_STATUSES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Company</TableHead>
+                <TableHead>Title</TableHead>
+                <TableHead>Location</TableHead>
+                <TableHead>Seniority</TableHead>
+                <TableHead>Track</TableHead>
+                <TableHead>Fit</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filtered.map((role) => (
+                <TableRow key={role.id}>
+                  <TableCell>{companies.find((c) => c.id === role.companyId)?.name ?? "-"}</TableCell>
+                  <TableCell className="font-medium">{role.title}</TableCell>
+                  <TableCell>{role.location}</TableCell>
+                  <TableCell>{role.seniority}</TableCell>
+                  <TableCell>{role.track}</TableCell>
+                  <TableCell>{role.fitScore}/5</TableCell>
+                  <TableCell>
+                    <Select value={role.status} onValueChange={(v) => void updateRole(role.id, { status: v as RoleStatus })}>
+                      <SelectTrigger className="w-36"><SelectValue /></SelectTrigger>
+                      <SelectContent>{ROLE_STATUSES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}</SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        void addApplication({
+                          companyId: role.companyId,
+                          roleId: role.id,
+                          dateApplied: new Date().toISOString().slice(0, 10),
+                          channel: "Company Site",
+                          cvVersion: role.track === "TPM" ? "CV - Technical Product Manager" : role.track === "Product Engineer" ? "CV - Product Engineer" : "CV - Systems / Platform PM",
+                          status: "sent",
+                          nextAction: "Send follow-up in 5 days",
+                          notes: "",
+                        })
+                      }
+                    >
+                      Add application
+                    </Button>
+                    <Button size="sm" variant="ghost" onClick={() => window.open(role.url, "_blank", "noopener,noreferrer")}>Quick apply</Button>
+                    <Button size="sm" variant="ghost" className="text-red-500" onClick={() => void removeRole(role.id)}>Delete</Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </JobOsLayout>
+  );
+}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -2,6 +2,12 @@ import { createBrowserRouter } from "react-router";
 import Dashboard from "./pages/Dashboard";
 import Analytics from "./pages/Analytics";
 import AfaCompliancePage from "./pages/AfaCompliancePage";
+import JobOsDashboardPage from "./pages/job-os/JobOsDashboardPage";
+import JobOsAssetsPage from "./pages/job-os/JobOsAssetsPage";
+import JobOsCompaniesPage from "./pages/job-os/JobOsCompaniesPage";
+import JobOsRolesPage from "./pages/job-os/JobOsRolesPage";
+import JobOsApplicationsPage from "./pages/job-os/JobOsApplicationsPage";
+import JobOsOutreachPage from "./pages/job-os/JobOsOutreachPage";
 import NotFound from "./pages/NotFound";
 import SignIn from "./pages/SignIn";
 import { ProtectedRoute } from "./components/ProtectedRoute";
@@ -25,6 +31,34 @@ export const router = createBrowserRouter([
       {
         path: "/compliance/afa",
         Component: AfaCompliancePage,
+      },
+      {
+        path: "/job-os",
+        Component: JobOsDashboardPage,
+      },
+      {
+        path: "/job-os/dashboard",
+        Component: JobOsDashboardPage,
+      },
+      {
+        path: "/job-os/assets",
+        Component: JobOsAssetsPage,
+      },
+      {
+        path: "/job-os/companies",
+        Component: JobOsCompaniesPage,
+      },
+      {
+        path: "/job-os/roles",
+        Component: JobOsRolesPage,
+      },
+      {
+        path: "/job-os/applications",
+        Component: JobOsApplicationsPage,
+      },
+      {
+        path: "/job-os/outreach",
+        Component: JobOsOutreachPage,
       },
     ],
   },

--- a/src/app/types/jobOs.ts
+++ b/src/app/types/jobOs.ts
@@ -1,0 +1,134 @@
+export type JobTrack = "TPM" | "Product Engineer" | "Systems PM";
+
+export type CompanyPriority = "A" | "B" | "C";
+export type CompanyStatus =
+  | "Research"
+  | "Target"
+  | "Active"
+  | "Applied"
+  | "Interviewing"
+  | "Closed";
+
+export type RoleStatus =
+  | "to_apply"
+  | "applied"
+  | "interview"
+  | "rejected"
+  | "offer"
+  | "closed";
+
+export type ApplicationStatus =
+  | "sent"
+  | "screen"
+  | "case"
+  | "interview"
+  | "final"
+  | "offer"
+  | "rejected"
+  | "ghosted";
+
+export type OutreachStatus =
+  | "sent"
+  | "replied"
+  | "meeting"
+  | "no_reply"
+  | "closed";
+
+export interface JobOsCvAsset {
+  id: string;
+  name: string;
+  version: string;
+  fileUrl: string;
+  locked: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JobOsScriptAsset {
+  id: string;
+  title: string;
+  scriptText: string;
+  tags: string[];
+  lastUpdated: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JobOsTemplateAsset {
+  id: string;
+  title: string;
+  templateText: string;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JobOsCompany {
+  id: string;
+  name: string;
+  industry: string;
+  size: string;
+  remotePolicy: string;
+  priority: CompanyPriority;
+  status: CompanyStatus;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JobOsRole {
+  id: string;
+  companyId: string;
+  title: string;
+  url: string;
+  location: string;
+  seniority: string;
+  track: JobTrack;
+  fitScore: 1 | 2 | 3 | 4 | 5;
+  status: RoleStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JobOsApplication {
+  id: string;
+  roleId: string;
+  companyId: string;
+  dateApplied: string;
+  channel: string;
+  cvVersion: string;
+  status: ApplicationStatus;
+  nextAction: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JobOsOutreach {
+  id: string;
+  companyId: string;
+  roleId: string | null;
+  contactName: string;
+  contactRole: string;
+  linkedinURL: string;
+  scriptUsed: string;
+  sentDate: string;
+  status: OutreachStatus;
+  followUpCount: number;
+  nextFollowUpDate: string | null;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JobOsState {
+  assets: {
+    cvs: JobOsCvAsset[];
+    scripts: JobOsScriptAsset[];
+    templates: JobOsTemplateAsset[];
+  };
+  companies: JobOsCompany[];
+  roles: JobOsRole[];
+  applications: JobOsApplication[];
+  outreach: JobOsOutreach[];
+}


### PR DESCRIPTION
## Summary
- add Job OS routes and shared module layout
- implement Job OS dashboard, assets, companies, roles, applications, and outreach pages
- add Firestore-backed useJobOs hook with local fallback and sync notices
- wire Job OS entrypoint from main dashboard navigation
- address lint policy blockers in hooks and compliance modal

## Data model
Per-user collections:
- ssets (doc ault)
- companies
- oles
- pplications
- outreach

## Validation
- npm run lint
- npm run build
- npm run test

Closes #45