### PR TITLE
fix(dashboard): use session.userId (not .uid) when calling useJobOs

### DIFF
--- a/src/app/pages/Dashboard.tsx
+++ b/src/app/pages/Dashboard.tsx
@@ -34,7 +34,7 @@ export default function Dashboard() {
     pendingDeletions,
     session,
   } = useApp();
-  const { roles, companies } = useJobOs(session?.uid ?? null);
+  const { roles, companies } = useJobOs(session?.userId ?? null);
   const roleOptions = useMemo<RoleOption[]>(() => {
     const companyMap = new Map(companies.map((c) => [c.id, c.name]));
     return roles.map((r) => ({


### PR DESCRIPTION
UserSession has `userId`, not `uid` — the typo meant useJobOs was always called with null and never loaded roles or companies from Firestore/localStorage.

Closes #N/A

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

