### PR TITLE
feat(ui): Revolut-style redesign with brand colour palette

### DIFF
--- a/src/app/components/AppNavbar.tsx
+++ b/src/app/components/AppNavbar.tsx
@@ -9,7 +9,6 @@ import {
   ShieldCheck,
   Sun,
 } from "lucide-react";
-import { Button } from "./ui/button";
 import { useApp } from "../context";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 import { trackPageView } from "../services/analytics";
@@ -42,50 +41,77 @@ export function AppNavbar({
   }, [location.pathname, location.search]);
 
   return (
-    <header className="sticky top-0 z-20 border-b border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
-      <div className="max-w-[1800px] mx-auto px-6 py-3">
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100">
+    <header
+      className="sticky top-0 z-20"
+      style={{ background: "var(--brand-navy)" }}
+    >
+      <div className="max-w-[1800px] mx-auto px-6">
+        <div className="flex items-center justify-between gap-4 h-14">
+          {/* Logo + Nav */}
+          <div className="flex items-center gap-8">
+            <span className="text-base font-bold text-white tracking-tight">
               {title}
-            </h1>
-            {subtitle && (
-              <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
-                {subtitle}
-              </p>
-            )}
+            </span>
+
+            <nav className="hidden md:flex items-center gap-0.5">
+              {NAV_ITEMS.map((item) => {
+                const Icon = item.icon;
+                const active =
+                  location.pathname === item.to ||
+                  (item.to !== "/" &&
+                    location.pathname.startsWith(item.to));
+                return (
+                  <Link
+                    key={item.to}
+                    to={item.to}
+                    className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                      active
+                        ? "bg-[#124BE6] text-white"
+                        : "text-white/65 hover:text-white hover:bg-white/10"
+                    }`}
+                  >
+                    <Icon className="w-3.5 h-3.5" />
+                    <span>{item.label}</span>
+                  </Link>
+                );
+              })}
+            </nav>
           </div>
+
+          {/* Right actions */}
           <div className="flex items-center gap-2">
-            {showSync && <SyncStatusBadge />}
-            {NAV_ITEMS.map((item) => {
-              const Icon = item.icon;
-              const active =
-                location.pathname === item.to ||
-                (item.to !== "/" && location.pathname.startsWith(item.to));
-              return (
-                <Link key={item.to} to={item.to}>
-                  <Button variant={active ? "default" : "outline"} className="gap-2">
-                    <Icon className="w-4 h-4" />
-                    <span className="hidden sm:inline">{item.label}</span>
-                  </Button>
-                </Link>
-              );
-            })}
+            {showSync && (
+              <div className="opacity-75">
+                <SyncStatusBadge />
+              </div>
+            )}
             {rightActions}
-            <Button
-              variant="ghost"
-              size="icon"
+            <button
               onClick={toggleDarkMode}
               aria-label="Toggle dark mode"
+              className="w-8 h-8 flex items-center justify-center rounded-md text-white/65 hover:text-white hover:bg-white/10 transition-colors"
             >
-              {darkMode ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
-            </Button>
-            <Button variant="outline" size="sm" onClick={() => void signOut()} className="gap-2">
-              <LogOut className="w-4 h-4" />
+              {darkMode ? (
+                <Sun className="w-4 h-4" />
+              ) : (
+                <Moon className="w-4 h-4" />
+              )}
+            </button>
+            <button
+              onClick={() => void signOut()}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-white/65 hover:text-white hover:bg-white/10 transition-colors"
+            >
+              <LogOut className="w-3.5 h-3.5" />
               <span className="hidden sm:inline">Sign Out</span>
-            </Button>
+            </button>
           </div>
         </div>
+
+        {subtitle && (
+          <div className="pb-1.5 -mt-1 text-xs text-white/45 truncate">
+            {subtitle}
+          </div>
+        )}
       </div>
     </header>
   );

--- a/src/app/components/ApplicationCard.tsx
+++ b/src/app/components/ApplicationCard.tsx
@@ -3,9 +3,9 @@ import { StickyNote, ExternalLink } from "lucide-react";
 import type { Application, PipelineStatus } from "../types";
 
 const PRIORITY_COLORS = {
-  high: "border-l-red-500",
-  medium: "border-l-blue-500",
-  backup: "border-l-neutral-400",
+  high: "border-l-[#E6AA12]",
+  medium: "border-l-[#124BE6]",
+  backup: "border-l-[#91783C]",
 };
 
 interface ApplicationCardProps {
@@ -31,9 +31,9 @@ export function ApplicationCard({
     <div
       ref={drag}
       onClick={onClick}
-      className={`border border-neutral-200 dark:border-neutral-700 rounded-lg p-3 bg-white dark:bg-neutral-900 cursor-pointer hover:border-neutral-300 dark:hover:border-neutral-600 transition-colors border-l-4 ${
+      className={`border border-border rounded-lg p-3 bg-card cursor-pointer hover:shadow-sm transition-all border-l-4 ${
         PRIORITY_COLORS[application.priority]
-      } ${isDragging ? "opacity-50" : "opacity-100"}`}
+      } ${isDragging ? "opacity-40 scale-95" : "opacity-100"}`}
     >
       <div className="flex items-start justify-between gap-2 mb-2">
         <div className="flex-1 min-w-0">

--- a/src/app/components/KPICard.tsx
+++ b/src/app/components/KPICard.tsx
@@ -1,4 +1,4 @@
-import { TrendingUp, TrendingDown } from "lucide-react";
+import { TrendingDown, TrendingUp } from "lucide-react";
 
 interface KPICardProps {
   label: string;
@@ -9,12 +9,15 @@ interface KPICardProps {
   tone?: "red" | "orange" | "green" | "blue" | "neutral";
 }
 
-const CARD_TONES = {
-  red: "border-red-200 dark:border-red-900/50 bg-red-50 dark:bg-red-950/30",
-  orange: "border-orange-200 dark:border-orange-900/50 bg-orange-50 dark:bg-orange-950/30",
-  green: "border-green-200 dark:border-green-900/50 bg-green-50 dark:bg-green-950/30",
-  blue: "border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-950/30",
-  neutral: "border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900",
+const ICON_TONE: Record<
+  NonNullable<KPICardProps["tone"]>,
+  { bg: string; color: string }
+> = {
+  blue:    { bg: "rgba(18,75,230,0.10)",  color: "#124BE6" },
+  orange:  { bg: "rgba(230,170,18,0.12)", color: "#E6AA12" },
+  green:   { bg: "rgba(16,185,129,0.10)", color: "#059669" },
+  red:     { bg: "rgba(212,24,61,0.10)",  color: "#d4183d" },
+  neutral: { bg: "rgba(59,71,102,0.10)",  color: "#3B4766" },
 };
 
 export function KPICard({
@@ -25,25 +28,40 @@ export function KPICard({
   trendValue,
   tone = "neutral",
 }: KPICardProps) {
+  const { bg, color } = ICON_TONE[tone];
+
   return (
-    <div className={`border rounded-lg p-4 ${CARD_TONES[tone]}`}>
-      <div className="flex items-center justify-between mb-2">
-        <span className="text-xs text-neutral-500 dark:text-neutral-400 uppercase tracking-wide">
+    <div className="bg-card border border-border rounded-lg p-5 flex flex-col gap-3">
+      <div className="flex items-start justify-between">
+        <span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
           {label}
         </span>
-        {icon && <span className="text-neutral-400 dark:text-neutral-600">{icon}</span>}
+        {icon && (
+          <span
+            className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+            style={{ background: bg, color }}
+          >
+            {icon}
+          </span>
+        )}
       </div>
-      <div className="text-3xl font-semibold text-neutral-900 dark:text-neutral-100">
+
+      <div className="text-[2rem] font-bold text-foreground leading-none tracking-tight">
         {value}
       </div>
+
       {trend && trendValue && (
-        <div className="flex items-center gap-1 mt-2">
+        <div className="flex items-center gap-1">
           {trend === "up" ? (
-            <TrendingUp className="w-3 h-3 text-green-500" />
+            <TrendingUp className="w-3 h-3 text-emerald-500" />
           ) : (
             <TrendingDown className="w-3 h-3 text-red-500" />
           )}
-          <span className={`text-xs ${trend === "up" ? "text-green-500" : "text-red-500"}`}>
+          <span
+            className={`text-xs font-medium ${
+              trend === "up" ? "text-emerald-500" : "text-red-500"
+            }`}
+          >
             {trendValue}
           </span>
         </div>

--- a/src/app/components/PipelineColumn.tsx
+++ b/src/app/components/PipelineColumn.tsx
@@ -28,12 +28,12 @@ export function PipelineColumn({
   }));
 
   return (
-    <div className="flex flex-col min-w-[280px] flex-shrink-0">
-      <div className="mb-3 px-2">
-        <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300 uppercase tracking-wide">
+    <div className="flex flex-col min-w-[260px] flex-shrink-0">
+      <div className="mb-3 px-1 flex items-center justify-between">
+        <span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
           {title}
-        </h3>
-        <span className="text-xs text-neutral-500 dark:text-neutral-400">
+        </span>
+        <span className="text-[11px] font-semibold text-muted-foreground/60 tabular-nums">
           {applications.length}
         </span>
       </div>
@@ -42,8 +42,8 @@ export function PipelineColumn({
         ref={drop}
         className={`flex-1 space-y-2 min-h-[200px] rounded-lg p-2 transition-colors ${
           isOver
-            ? "bg-neutral-100 dark:bg-neutral-800"
-            : "bg-neutral-50 dark:bg-neutral-900/50"
+            ? "bg-[#124BE6]/5 dark:bg-[#124BE6]/10"
+            : "bg-black/[0.03] dark:bg-white/[0.03]"
         }`}
       >
         {applications.map((app) => (

--- a/src/app/pages/Dashboard.tsx
+++ b/src/app/pages/Dashboard.tsx
@@ -85,7 +85,7 @@ export default function Dashboard() {
   };
 
   return (
-    <div className="min-h-screen bg-neutral-50 dark:bg-black text-neutral-900 dark:text-neutral-100">
+    <div className="min-h-screen bg-background text-foreground app-bg-pattern">
       {/* Header */}
       <AppNavbar
         title="JobSprint"
@@ -164,8 +164,8 @@ export default function Dashboard() {
         </div>
 
         {/* Pipeline Full Width */}
-        <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-950 mb-6">
-          <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100 uppercase tracking-wide mb-6">
+        <div className="border border-border rounded-lg p-6 bg-card mb-6">
+          <h2 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-widest mb-6">
             Application Pipeline
           </h2>
           <PipelineBoard

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,0 +1,1 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -28,3 +28,13 @@
 .dark ::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.3);
 }
+
+/* Subtle dot-grid background pattern — applied to the app shell */
+.app-bg-pattern {
+  background-image: radial-gradient(circle, rgba(18, 75, 230, 0.07) 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
+.dark .app-bg-pattern {
+  background-image: radial-gradient(circle, rgba(18, 75, 230, 0.12) 1px, transparent 1px);
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,124 +1,173 @@
 @custom-variant dark (&:is(.dark *));
 
+/* ─── Brand palette ─────────────────────────────────────────────────── */
+:root {
+  --brand-blue:     #124BE6;
+  --brand-blue-mid: #3754A6;
+  --brand-amber:    #E6AA12;
+  --brand-gold:     #91783C;
+  --brand-navy:     #3B4766;
+  --brand-dark:     #3C372C;
+}
+
+/* ─── Light mode ────────────────────────────────────────────────────── */
 :root {
   --font-size: 16px;
-  --background: #ffffff;
-  --foreground: oklch(0.145 0 0);
-  --card: #ffffff;
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: #030213;
-  --primary-foreground: oklch(1 0 0);
-  --secondary: oklch(0.95 0.0058 264.53);
-  --secondary-foreground: #030213;
-  --muted: #ececf0;
-  --muted-foreground: #717182;
-  --accent: #e9ebef;
-  --accent-foreground: #030213;
-  --destructive: #d4183d;
+
+  --background:          #F4F6FB;
+  --foreground:          #0f172a;
+  --card:                #ffffff;
+  --card-foreground:     #0f172a;
+  --popover:             #ffffff;
+  --popover-foreground:  #0f172a;
+
+  --primary:             #124BE6;
+  --primary-foreground:  #ffffff;
+
+  --secondary:           #EEF2FF;
+  --secondary-foreground: #3754A6;
+
+  --muted:               #EDF0F7;
+  --muted-foreground:    #6b7280;
+
+  --accent:              #FFF8E6;
+  --accent-foreground:   #91783C;
+
+  --destructive:         #d4183d;
   --destructive-foreground: #ffffff;
-  --border: rgba(0, 0, 0, 0.1);
-  --input: transparent;
-  --input-background: #f3f3f5;
-  --switch-background: #cbced4;
-  --font-weight-medium: 500;
-  --font-weight-normal: 400;
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: #030213;
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+
+  --border:              rgba(0, 0, 0, 0.08);
+  --input:               transparent;
+  --input-background:    #EDF0F7;
+  --switch-background:   #c8cdd8;
+
+  --font-weight-medium:  500;
+  --font-weight-normal:  400;
+
+  --ring:                #124BE6;
+
+  /* Chart colours mapped to brand palette */
+  --chart-1: #124BE6;
+  --chart-2: #3754A6;
+  --chart-3: #91783C;
+  --chart-4: #E6AA12;
+  --chart-5: #3B4766;
+
+  --radius: 0.5rem;
+
+  --sidebar:                    #3B4766;
+  --sidebar-foreground:         #ffffff;
+  --sidebar-primary:            #124BE6;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent:             rgba(255,255,255,0.1);
+  --sidebar-accent-foreground:  #ffffff;
+  --sidebar-border:             rgba(255,255,255,0.1);
+  --sidebar-ring:               #124BE6;
 }
 
+/* ─── Dark mode ─────────────────────────────────────────────────────── */
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.145 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.145 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
-  --border: oklch(0.269 0 0);
-  --input: oklch(0.269 0 0);
-  --ring: oklch(0.439 0 0);
-  --font-weight-medium: 500;
-  --font-weight-normal: 400;
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(0.269 0 0);
-  --sidebar-ring: oklch(0.439 0 0);
+  --background:          #0f1523;
+  --foreground:          #f1f5f9;
+  --card:                #182236;
+  --card-foreground:     #f1f5f9;
+  --popover:             #182236;
+  --popover-foreground:  #f1f5f9;
+
+  --primary:             #124BE6;
+  --primary-foreground:  #ffffff;
+
+  --secondary:           #1e2f4a;
+  --secondary-foreground: #93c5fd;
+
+  --muted:               #1e2f4a;
+  --muted-foreground:    #94a3b8;
+
+  --accent:              #2a2000;
+  --accent-foreground:   #E6AA12;
+
+  --destructive:         #b91c1c;
+  --destructive-foreground: #fca5a5;
+
+  --border:              rgba(255, 255, 255, 0.08);
+  --input:               rgba(255, 255, 255, 0.08);
+  --input-background:    rgba(255, 255, 255, 0.06);
+  --switch-background:   #334155;
+
+  --font-weight-medium:  500;
+  --font-weight-normal:  400;
+
+  --ring:                #124BE6;
+
+  --chart-1: #124BE6;
+  --chart-2: #3754A6;
+  --chart-3: #91783C;
+  --chart-4: #E6AA12;
+  --chart-5: #3B4766;
+
+  --sidebar:                    #0a1020;
+  --sidebar-foreground:         #f1f5f9;
+  --sidebar-primary:            #124BE6;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent:             rgba(255,255,255,0.05);
+  --sidebar-accent-foreground:  #f1f5f9;
+  --sidebar-border:             rgba(255,255,255,0.05);
+  --sidebar-ring:               #124BE6;
 }
 
+/* ─── Tailwind colour tokens ────────────────────────────────────────── */
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-destructive-foreground: var(--destructive-foreground);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-input-background: var(--input-background);
-  --color-switch-background: var(--switch-background);
-  --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
+  --color-background:                var(--background);
+  --color-foreground:                var(--foreground);
+  --color-card:                      var(--card);
+  --color-card-foreground:           var(--card-foreground);
+  --color-popover:                   var(--popover);
+  --color-popover-foreground:        var(--popover-foreground);
+  --color-primary:                   var(--primary);
+  --color-primary-foreground:        var(--primary-foreground);
+  --color-secondary:                 var(--secondary);
+  --color-secondary-foreground:      var(--secondary-foreground);
+  --color-muted:                     var(--muted);
+  --color-muted-foreground:          var(--muted-foreground);
+  --color-accent:                    var(--accent);
+  --color-accent-foreground:         var(--accent-foreground);
+  --color-destructive:               var(--destructive);
+  --color-destructive-foreground:    var(--destructive-foreground);
+  --color-border:                    var(--border);
+  --color-input:                     var(--input);
+  --color-input-background:          var(--input-background);
+  --color-switch-background:         var(--switch-background);
+  --color-ring:                      var(--ring);
+  --color-chart-1:                   var(--chart-1);
+  --color-chart-2:                   var(--chart-2);
+  --color-chart-3:                   var(--chart-3);
+  --color-chart-4:                   var(--chart-4);
+  --color-chart-5:                   var(--chart-5);
+
+  /* Brand tokens available as Tailwind utilities */
+  --color-brand-blue:     var(--brand-blue);
+  --color-brand-blue-mid: var(--brand-blue-mid);
+  --color-brand-amber:    var(--brand-amber);
+  --color-brand-gold:     var(--brand-gold);
+  --color-brand-navy:     var(--brand-navy);
+  --color-brand-dark:     var(--brand-dark);
+
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
+
+  --color-sidebar:                    var(--sidebar);
+  --color-sidebar-foreground:         var(--sidebar-foreground);
+  --color-sidebar-primary:            var(--sidebar-primary);
   --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-accent:             var(--sidebar-accent);
+  --color-sidebar-accent-foreground:  var(--sidebar-accent-foreground);
+  --color-sidebar-border:             var(--sidebar-border);
+  --color-sidebar-ring:               var(--sidebar-ring);
 }
 
+/* ─── Base layer ────────────────────────────────────────────────────── */
 @layer base {
   * {
     @apply border-border outline-ring/50;
@@ -126,12 +175,10 @@
 
   body {
     @apply bg-background text-foreground;
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
-
-  /**
-  * Default typography styles for HTML elements (h1-h4, p, label, button, input).
-  * These are in @layer base, so Tailwind utility classes (like text-sm, text-lg) automatically override them.
-  */
 
   html {
     font-size: var(--font-size);
@@ -139,20 +186,22 @@
 
   h1 {
     font-size: var(--text-2xl);
-    font-weight: var(--font-weight-medium);
-    line-height: 1.5;
+    font-weight: 700;
+    line-height: 1.25;
+    letter-spacing: -0.02em;
   }
 
   h2 {
     font-size: var(--text-xl);
-    font-weight: var(--font-weight-medium);
-    line-height: 1.5;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
   }
 
   h3 {
     font-size: var(--text-lg);
-    font-weight: var(--font-weight-medium);
-    line-height: 1.5;
+    font-weight: 600;
+    line-height: 1.4;
   }
 
   h4 {
@@ -162,13 +211,13 @@
   }
 
   label {
-    font-size: var(--text-base);
+    font-size: var(--text-sm);
     font-weight: var(--font-weight-medium);
     line-height: 1.5;
   }
 
   button {
-    font-size: var(--text-base);
+    font-size: var(--text-sm);
     font-weight: var(--font-weight-medium);
     line-height: 1.5;
   }


### PR DESCRIPTION
Colours: #124BE6 (electric blue), #3754A6, #E6AA12 (amber),
         #91783C (gold), #3B4766 (navy), #3C372C.

- theme.css: new CSS design tokens — primary = #124BE6, page bg = #F4F6FB dark bg = #0f1523, card = #182236, sharper --radius (0.5rem), chart colours mapped to brand palette, Inter font stack
- fonts.css: add Inter from Google Fonts
- index.css: subtle 28px dot-grid pattern via radial-gradient (.app-bg-pattern)
- AppNavbar: dark navy (#3B4766) sticky bar; active link = #124BE6 pill; inactive links as ghost text/icons — Revolut-style horizontal nav
- KPICard: flat white card, coloured icon badge (bg tint + brand colour), bold 2rem stat number, tight tracking
- ApplicationCard: priority colours → amber (high), #124BE6 (medium), gold (backup); drag opacity + scale transition
- PipelineColumn: tighter uppercase label, blue tint drop-zone highlight
- Dashboard: bg-background + app-bg-pattern; section heading uses tracking-widest muted style

Closes #N/A

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

