### PR TITLE
fix(afa): correct three CRUD bugs in AfA Compliance

### DIFF
--- a/src/app/components/compliance/AfaCaseModal.tsx
+++ b/src/app/components/compliance/AfaCaseModal.tsx
@@ -59,29 +59,35 @@ function deadlineClass(status: AfaDeadlineStatus): string {
 // Default form state
 // ---------------------------------------------------------------------------
 
-const EMPTY_FORM: AfaVorschlagFormData = {
-  source: "portal",
-  received_date: new Date().toISOString().slice(0, 10),
-  deadline_date: null,
-  rfb_present: "unknown",
-  portal_feedback_required: "unknown",
-  employer_name: "",
-  position_title: "",
-  location: "",
-  posting_url: "",
-  match_level: "medium",
-  action_status: "received",
-  applied_date: null,
-  portal_feedback_date: null,
-  employer_response: "pending",
-  evidence: {
-    folder_url: "",
-    letter_file_url: "",
-    application_proof_url: "",
-    portal_feedback_proof_url: "",
-  },
-  notes: "",
-};
+// ---------------------------------------------------------------------------
+// Default form state — factory function so received_date is always today
+// ---------------------------------------------------------------------------
+
+function emptyForm(): AfaVorschlagFormData {
+  return {
+    source: "portal",
+    received_date: new Date().toISOString().slice(0, 10),
+    deadline_date: null,
+    rfb_present: "unknown",
+    portal_feedback_required: "unknown",
+    employer_name: "",
+    position_title: "",
+    location: "",
+    posting_url: "",
+    match_level: "medium",
+    action_status: "received",
+    applied_date: null,
+    portal_feedback_date: null,
+    employer_response: "pending",
+    evidence: {
+      folder_url: "",
+      letter_file_url: "",
+      application_proof_url: "",
+      portal_feedback_proof_url: "",
+    },
+    notes: "",
+  };
+}
 
 function vorschlagToForm(v: AfaVorschlag): AfaVorschlagFormData {
   return {
@@ -178,14 +184,14 @@ export function AfaCaseModal({
   onDelete,
 }: AfaCaseModalProps) {
   const isEdit = vorschlag !== null;
-  const [form, setForm] = useState<AfaVorschlagFormData>(EMPTY_FORM);
+  const [form, setForm] = useState<AfaVorschlagFormData>(emptyForm);
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
-    setForm(isEdit ? vorschlagToForm(vorschlag) : EMPTY_FORM);
+    setForm(isEdit ? vorschlagToForm(vorschlag) : emptyForm());
     setIsSaving(false);
     setIsDeleting(false);
     setSubmitError(null);

--- a/src/app/hooks/useAfaCompliance.ts
+++ b/src/app/hooks/useAfaCompliance.ts
@@ -161,12 +161,21 @@ export function useAfaCompliance(userId: string | null): UseAfaComplianceReturn 
           docToVorschlag(d.id, d.data() as Record<string, unknown>)
         );
         const latestLocal = loadLocal(userId).map(computeAll);
-        const shouldUseLocal =
-          docs.length === 0 &&
-          latestLocal.length > 0 &&
-          snapshot.metadata.fromCache;
 
-        const nextCases = shouldUseLocal ? latestLocal : docs;
+        let nextCases: AfaVorschlag[];
+        if (snapshot.metadata.fromCache && docs.length === 0 && latestLocal.length > 0) {
+          // Offline cache hit — use local state as primary
+          nextCases = latestLocal;
+        } else {
+          // Live data from Firestore — merge in any locally-created cases
+          // that haven't made it to Firestore yet (created offline, id starts with "afa-")
+          const firestoreIds = new Set(docs.map((d) => d.id));
+          const localOnlyCases = latestLocal.filter(
+            (c) => c.id.startsWith("afa-") && !firestoreIds.has(c.id)
+          );
+          nextCases = [...docs, ...localOnlyCases];
+        }
+
         setCases(nextCases);
         saveLocal(userId, nextCases);
         setError(null);

--- a/src/app/pages/AfaCompliancePage.tsx
+++ b/src/app/pages/AfaCompliancePage.tsx
@@ -54,17 +54,12 @@ export default function AfaCompliancePage() {
   }
 
   return (
-    <div className="min-h-screen bg-neutral-50 dark:bg-black">
+    <div className="min-h-screen bg-background text-foreground app-bg-pattern">
       <AppNavbar
         title="AfA Compliance"
         subtitle="Vermittlungsvorschläge"
         rightActions={
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5"
-            onClick={handleOpenNew}
-          >
+          <Button className="gap-1.5" onClick={handleOpenNew}>
             <Plus className="w-4 h-4" />
             <span className="hidden sm:inline">New Case</span>
           </Button>
@@ -88,10 +83,10 @@ export default function AfaCompliancePage() {
 
             <div>
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase tracking-wide">
+                <h2 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-widest">
                   All Cases
                 </h2>
-                <span className="text-xs text-neutral-400 dark:text-neutral-600">
+                <span className="text-xs text-muted-foreground/60">
                   {cases.length} total
                 </span>
               </div>


### PR DESCRIPTION
1. Stale received_date: EMPTY_FORM was a module-level constant so new Date() was captured at import time. Converted to emptyForm() factory function so today's date is used each time the modal opens. Applied to both useState initialiser and the useEffect reset.

2. Local orphan loss: when a Firestore snapshot arrived while the user had offline-created cases (afa-* IDs), those cases were silently dropped. The snapshot handler now preserves locally-created cases whose IDs are not yet present in Firestore, appending them to the live results so no offline work is lost.

3. AfaCompliancePage styling: page background updated to bg-background
   + app-bg-pattern (brand theme); section heading updated to match tracking-widest/muted-foreground design tokens; 'New Case' button changed from variant='outline' (white on dark navy) to default (electric blue) for consistency with the rest of the app.

Closes #N/A

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

