### PR TITLE
fix(afa): eliminate new-case duplication caused by onSnapshot + setCa…

### DIFF
--- a/src/app/hooks/useAfaCompliance.ts
+++ b/src/app/hooks/useAfaCompliance.ts
@@ -226,25 +226,28 @@ export function useAfaCompliance(userId: string | null): UseAfaComplianceReturn 
       try {
         const { id: _id, ...payload } = skeleton;
         const colRef = collection(firebase.db, "users", userId, "afa_vorschlaege");
-        const created = await withTimeout(
+        await withTimeout(
           addDoc(colRef, payload),
           FIRESTORE_MUTATION_TIMEOUT_MS,
           "Create case"
         );
-        setCases((prev) => {
-          const nextCases = [...prev, { ...skeleton, id: created.id }];
-          saveLocal(userId, nextCases);
-          return nextCases;
-        });
+        // onSnapshot fires as soon as Firestore writes to local cache (before this
+        // line even runs). Calling setCases here would add a duplicate — let the
+        // snapshot listener be the single source of truth for cases state.
         setError(null);
         setLocalOnlyMode(false);
       } catch (err) {
         if (!isOfflineLikeError(err)) {
           throw err;
         }
-        const local: AfaVorschlag = { ...skeleton, id: generateLocalId() };
+        // Firestore may have already written the doc to its local cache and fired
+        // onSnapshot with a Firestore-generated ID. Replace any such pending entry
+        // (matched by case_id) with an afa- prefixed local ID so the orphan-
+        // preservation logic keeps it when connectivity returns.
         setCases((prev) => {
-          const updated = [...prev, local];
+          const withoutPending = prev.filter((c) => c.case_id !== skeleton.case_id);
+          const local: AfaVorschlag = { ...skeleton, id: generateLocalId() };
+          const updated = [...withoutPending, local];
           saveLocal(userId, updated);
           return updated;
         });


### PR DESCRIPTION
…ses race

Root cause: addDoc writes to Firestore's local cache synchronously, which fires onSnapshot immediately (before the server round-trip completes). The snapshot handler called setCases([...docs]) — already including the new case. When addDoc() then resolved, the explicit setCases([...prev, newCase]) added it a second time, producing a visible duplicate.

Fix (success path): remove the setCases call after addDoc resolves. onSnapshot is the single source of truth for the cases list; no manual state update is needed when Firebase is available.

Fix (offline/timeout catch path): if Firestore had already written the pending doc to its local cache and fired onSnapshot with a Firestore- generated ID, the old code would push a second copy with a generateLocalId() ID. Now we filter out any entry matching skeleton.case_id before inserting the local afa- version, ensuring exactly one copy exists and the orphan- preservation logic can identify it on reconnect.

Closes #N/A

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

