### PR TITLE
fix(job-os): prevent duplicate item on offline add in useJobOs

### DIFF
--- a/src/app/hooks/useJobOs.ts
+++ b/src/app/hooks/useJobOs.ts
@@ -416,13 +416,10 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
         if (!isOfflineLike(error)) {
           throw error;
         }
+        // Optimistic update already ran above — do NOT re-run localMutation here
+        // or it will prepend/apply the change a second time, creating duplicates.
         setLocalOnly(true);
         setSyncNotice("Cloud sync unavailable. Working in local mode.");
-        setState((prev) => {
-          const next = localMutation(prev);
-          writeLocal(userId, next);
-          return next;
-        });
       }
     },
     [localOnly, userId]


### PR DESCRIPTION
The mutate() helper applied localMutation optimistically before the remote call, then re-applied it a second time in the catch block, causing every offline-mode add (role, company, application, outreach) to appear twice. Remove the redundant setState from the catch path — the optimistic update already persisted the item to both React state and localStorage.

Closes #job-os-roles-duplicate

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

