### PR TITLE
fix: harden Job OS role persistence and add seniority/location controls

### DIFF
--- a/src/app/hooks/useJobOs.ts
+++ b/src/app/hooks/useJobOs.ts
@@ -562,8 +562,12 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
       payload: Omit<T, "id" | "createdAt" | "updatedAt">
     ) => {
       const now = new Date().toISOString();
+      const generatedId =
+        firebase && userId && !localOnly
+          ? doc(collection(firebase.db, "users", userId, key)).id
+          : randomId(prefix);
       const localItem = {
-        id: randomId(prefix),
+        id: generatedId,
         ...payload,
         createdAt: now,
         updatedAt: now,
@@ -576,14 +580,7 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
         } as JobOsState),
         firebase && userId && !localOnly
           ? async () => {
-              const docRef = doc(
-                firebase.db,
-                "users",
-                userId,
-                key,
-                localItem.id
-              );
-              await setDoc(docRef, {
+              await setDoc(doc(firebase.db, "users", userId, key, localItem.id), {
                 ...payload,
                 createdAt: serverTimestamp(),
                 updatedAt: serverTimestamp(),


### PR DESCRIPTION
## Summary

This PR fixes the Job OS Roles flow on the deployed app and improves the role form UX.

Closes #67.

## Changes

- harden generated Job OS item IDs by using crypto.randomUUID() when available
- use Firestore-generated document IDs for cloud-backed Job OS writes
- reduce the risk of cloud document ID collisions that can overwrite existing roles
- add a Seniority selector with Senior, Middle, and Junior
- normalize legacy seniority values like Mid to Middle
- change Location to free text with built-in suggestions for Remote and Hybrid
- apply the same seniority/location behavior to inline role editing

## Validation

- 
pm run test
- 
pm run build

## Notes

- left unrelated untracked CSV files untouched
- this targets the deployed/cloud-backed behavior while preserving localhost behavior