### PR TITLE
feat(dashboard): AI-powered Command Centre with next-action engine

### DIFF
--- a/src/app/components/dashboard/HotOpportunities.tsx
+++ b/src/app/components/dashboard/HotOpportunities.tsx
@@ -1,0 +1,48 @@
+import { Flame } from "lucide-react";
+import type { HotOpportunity } from "../../services/execution/nextActionEngine";
+import { OpportunityCard } from "./OpportunityCard";
+
+interface HotOpportunitiesProps {
+  opportunities: HotOpportunity[];
+  isLoading?: boolean;
+}
+
+export function HotOpportunities({ opportunities, isLoading }: HotOpportunitiesProps) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Flame className="h-4 w-4 text-orange-500" />
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+          Hot Opportunities
+        </h2>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-2">
+          {[1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-16 animate-pulse rounded-lg bg-neutral-100 dark:bg-neutral-800"
+            />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && opportunities.length === 0 && (
+        <div className="rounded-lg border border-dashed border-neutral-200 dark:border-neutral-800 p-4 text-center">
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
+            No unapplied roles yet. Add roles via Companies.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && opportunities.length > 0 && (
+        <div className="space-y-2">
+          {opportunities.map((opp) => (
+            <OpportunityCard key={opp.roleId} opportunity={opp} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/components/dashboard/NextActionCard.tsx
+++ b/src/app/components/dashboard/NextActionCard.tsx
@@ -1,0 +1,72 @@
+import { ArrowRight } from "lucide-react";
+import { Link } from "react-router";
+import type { NextAction, ActionPriority } from "../../services/execution/nextActionEngine";
+
+const PRIORITY_STYLES: Record<ActionPriority, string> = {
+  urgent: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  high: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400",
+  medium: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  low: "bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400",
+};
+
+const TYPE_COLORS: Record<NextAction["type"], string> = {
+  apply: "border-l-blue-500",
+  follow_up: "border-l-purple-500",
+  optimize_cv: "border-l-green-500",
+  add_role: "border-l-teal-500",
+  research: "border-l-indigo-500",
+  archive: "border-l-neutral-400",
+};
+
+interface NextActionCardProps {
+  action: NextAction;
+  rank: number;
+}
+
+export function NextActionCard({ action, rank }: NextActionCardProps) {
+  return (
+    <div
+      className={`flex items-start gap-3 rounded-lg border border-neutral-200 dark:border-neutral-800 border-l-4 ${TYPE_COLORS[action.type]} bg-white dark:bg-neutral-900 p-3 shadow-sm`}
+    >
+      {/* Rank */}
+      <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-neutral-100 dark:bg-neutral-800 text-xs font-semibold text-neutral-500 dark:text-neutral-400">
+        {rank}
+      </span>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          {action.companyName && (
+            <span className="text-sm font-semibold truncate text-neutral-900 dark:text-neutral-100">
+              {action.companyName}
+            </span>
+          )}
+          {action.roleTitle && (
+            <span className="text-sm text-neutral-500 dark:text-neutral-400 truncate">
+              — {action.roleTitle}
+            </span>
+          )}
+        </div>
+        <p className="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400 line-clamp-2">
+          {action.reason}
+        </p>
+      </div>
+
+      {/* Right side */}
+      <div className="flex shrink-0 flex-col items-end gap-1.5">
+        <span
+          className={`rounded-full px-2 py-0.5 text-xs font-medium ${PRIORITY_STYLES[action.priority]}`}
+        >
+          {action.priority}
+        </span>
+        <Link
+          to={action.href}
+          className="flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+        >
+          {action.actionLabel}
+          <ArrowRight className="h-3 w-3" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/dashboard/OpportunityCard.tsx
+++ b/src/app/components/dashboard/OpportunityCard.tsx
@@ -1,0 +1,64 @@
+import { ArrowRight, Star } from "lucide-react";
+import { Link } from "react-router";
+import type { HotOpportunity } from "../../services/execution/nextActionEngine";
+import type { CompanyPriority } from "../../types/jobOs";
+
+const PRIORITY_BADGE: Record<CompanyPriority, string> = {
+  A: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+  B: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  C: "bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400",
+};
+
+interface OpportunityCardProps {
+  opportunity: HotOpportunity;
+}
+
+export function OpportunityCard({ opportunity }: OpportunityCardProps) {
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 shadow-sm">
+      {/* Fit stars */}
+      <div className="flex shrink-0 flex-col items-center gap-0.5 pt-0.5">
+        <Star
+          className={`h-4 w-4 ${
+            opportunity.fitScore >= 4
+              ? "fill-yellow-400 text-yellow-400"
+              : "text-neutral-300 dark:text-neutral-600"
+          }`}
+        />
+        <span className="text-xs font-semibold text-neutral-500 dark:text-neutral-400">
+          {opportunity.fitScore}/5
+        </span>
+      </div>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-semibold text-neutral-900 dark:text-neutral-100 truncate">
+            {opportunity.companyName}
+          </span>
+          <span
+            className={`rounded-full px-1.5 py-0.5 text-xs font-medium ${PRIORITY_BADGE[opportunity.priority]}`}
+          >
+            {opportunity.priority}
+          </span>
+        </div>
+        <p className="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400 truncate">
+          {opportunity.roleTitle}
+        </p>
+        {opportunity.reason && (
+          <p className="mt-0.5 text-xs text-neutral-400 dark:text-neutral-500 line-clamp-1">
+            {opportunity.reason}
+          </p>
+        )}
+      </div>
+
+      <Link
+        to={opportunity.href}
+        className="shrink-0 flex items-center gap-1 text-xs font-medium text-primary hover:underline mt-0.5"
+      >
+        Apply
+        <ArrowRight className="h-3 w-3" />
+      </Link>
+    </div>
+  );
+}

--- a/src/app/components/dashboard/PipelineStats.tsx
+++ b/src/app/components/dashboard/PipelineStats.tsx
@@ -1,0 +1,72 @@
+import { BarChart2 } from "lucide-react";
+import type { PipelineStats as PipelineStatsData } from "../../services/execution/nextActionEngine";
+
+interface StatTileProps {
+  label: string;
+  value: number | string;
+  highlight?: boolean;
+}
+
+function StatTile({ label, value, highlight }: StatTileProps) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 shadow-sm text-center">
+      <span
+        className={`text-2xl font-bold tabular-nums ${
+          highlight
+            ? "text-primary"
+            : "text-neutral-900 dark:text-neutral-100"
+        }`}
+      >
+        {value}
+      </span>
+      <span className="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+interface PipelineStatsProps {
+  stats: PipelineStatsData;
+  isLoading?: boolean;
+}
+
+export function PipelineStats({ stats, isLoading }: PipelineStatsProps) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <BarChart2 className="h-4 w-4 text-blue-500" />
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+          Pipeline Snapshot
+        </h2>
+      </div>
+
+      {isLoading ? (
+        <div className="grid grid-cols-4 gap-2">
+          {[1, 2, 3, 4].map((i) => (
+            <div
+              key={i}
+              className="h-16 animate-pulse rounded-lg bg-neutral-100 dark:bg-neutral-800"
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+          <StatTile label="To Apply" value={stats.toApply} />
+          <StatTile label="Applied" value={stats.applied} />
+          <StatTile label="Interviewing" value={stats.interviewing} highlight />
+          <StatTile label="Offers" value={stats.offers} highlight={stats.offers > 0} />
+        </div>
+      )}
+
+      {!isLoading && stats.applied > 0 && (
+        <p className="text-xs text-center text-neutral-400 dark:text-neutral-500">
+          Interview conversion rate:{" "}
+          <span className="font-medium text-neutral-600 dark:text-neutral-300">
+            {stats.conversionRate}%
+          </span>
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/app/components/dashboard/QuickActions.tsx
+++ b/src/app/components/dashboard/QuickActions.tsx
@@ -1,0 +1,63 @@
+import { Link } from "react-router";
+import { PlusCircle, FileText, Building2, ClipboardList } from "lucide-react";
+
+interface QuickAction {
+  label: string;
+  description: string;
+  href: string;
+  icon: React.ReactNode;
+}
+
+const QUICK_ACTIONS: QuickAction[] = [
+  {
+    label: "Add Company",
+    description: "Track a new target",
+    href: "/job-os/companies",
+    icon: <Building2 className="h-4 w-4" />,
+  },
+  {
+    label: "Log Application",
+    description: "Record a submission",
+    href: "/job-os/applications",
+    icon: <ClipboardList className="h-4 w-4" />,
+  },
+  {
+    label: "Tailor CV",
+    description: "Optimise for a role",
+    href: "/cv-optimizer",
+    icon: <FileText className="h-4 w-4" />,
+  },
+  {
+    label: "Browse Roles",
+    description: "Review your pipeline",
+    href: "/job-os/roles",
+    icon: <PlusCircle className="h-4 w-4" />,
+  },
+];
+
+export function QuickActions() {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+        Quick Actions
+      </h2>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {QUICK_ACTIONS.map((qa) => (
+          <Link
+            key={qa.href}
+            to={qa.href}
+            className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
+          >
+            <span className="text-neutral-500 dark:text-neutral-400">{qa.icon}</span>
+            <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
+              {qa.label}
+            </span>
+            <span className="text-xs text-neutral-400 dark:text-neutral-500">
+              {qa.description}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/components/dashboard/TodayPanel.tsx
+++ b/src/app/components/dashboard/TodayPanel.tsx
@@ -1,0 +1,53 @@
+import { Zap } from "lucide-react";
+import type { NextAction } from "../../services/execution/nextActionEngine";
+import { NextActionCard } from "./NextActionCard";
+
+interface TodayPanelProps {
+  actions: NextAction[];
+  isLoading?: boolean;
+}
+
+export function TodayPanel({ actions, isLoading }: TodayPanelProps) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Zap className="h-4 w-4 text-yellow-500" />
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+          Today's Actions
+        </h2>
+        {actions.length > 0 && (
+          <span className="ml-auto rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+            {actions.length}
+          </span>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-16 animate-pulse rounded-lg bg-neutral-100 dark:bg-neutral-800"
+            />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && actions.length === 0 && (
+        <div className="rounded-lg border border-dashed border-neutral-200 dark:border-neutral-800 p-6 text-center">
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
+            No urgent actions right now. Keep the pipeline moving!
+          </p>
+        </div>
+      )}
+
+      {!isLoading && actions.length > 0 && (
+        <div className="space-y-2">
+          {actions.map((action, i) => (
+            <NextActionCard key={action.id} action={action} rank={i + 1} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/components/job-os/JobOsLayout.tsx
+++ b/src/app/components/job-os/JobOsLayout.tsx
@@ -4,6 +4,7 @@ import {
   FileSpreadsheet,
   FileText,
   FolderOpen,
+  LayoutDashboard,
   Megaphone,
   WandSparkles,
 } from "lucide-react";
@@ -12,6 +13,7 @@ import { useApp } from "../../context";
 import { useJobOsSyncSnapshot } from "../../services/jobOsSync";
 
 const NAV_ITEMS = [
+  { to: "/job-os/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { to: "/job-os/assets", label: "Assets", icon: FolderOpen },
   { to: "/job-os/companies", label: "Companies", icon: Building2 },
   { to: "/job-os/roles", label: "Roles", icon: FileText },

--- a/src/app/pages/dashboard/DashboardPage.tsx
+++ b/src/app/pages/dashboard/DashboardPage.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+import { useApp } from "../../context";
+import { useJobOs } from "../../hooks/useJobOs";
+import {
+  getNextActions,
+  getHotOpportunities,
+  getPipelineStats,
+} from "../../services/execution/nextActionEngine";
+import { TodayPanel } from "../../components/dashboard/TodayPanel";
+import { HotOpportunities } from "../../components/dashboard/HotOpportunities";
+import { PipelineStats } from "../../components/dashboard/PipelineStats";
+import { QuickActions } from "../../components/dashboard/QuickActions";
+
+export function DashboardPage() {
+  const { session } = useApp();
+  const { companies, roles, applications, loading } = useJobOs(
+    session?.userId ?? null
+  );
+
+  const actions = useMemo(
+    () =>
+      loading
+        ? []
+        : getNextActions({ companies, roles, applications }, 7),
+    [companies, roles, applications, loading]
+  );
+
+  const hotOpportunities = useMemo(
+    () =>
+      loading ? [] : getHotOpportunities(roles, companies, applications),
+    [companies, roles, applications, loading]
+  );
+
+  const stats = useMemo(
+    () =>
+      loading
+        ? { totalCompanies: 0, totalRoles: 0, toApply: 0, applied: 0, inReview: 0, interviewing: 0, offers: 0, conversionRate: 0 }
+        : getPipelineStats(companies, roles, applications),
+    [companies, roles, applications, loading]
+  );
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 p-4 sm:p-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
+          Command Centre
+        </h1>
+        <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+          Your AI-powered job search execution hub.
+        </p>
+      </div>
+
+      {/* Pipeline Snapshot */}
+      <PipelineStats stats={stats} isLoading={loading} />
+
+      {/* Today's Actions */}
+      <TodayPanel actions={actions} isLoading={loading} />
+
+      {/* Hot Opportunities */}
+      {(loading || hotOpportunities.length > 0) && (
+        <HotOpportunities opportunities={hotOpportunities} isLoading={loading} />
+      )}
+
+      {/* Quick Actions */}
+      <QuickActions />
+    </div>
+  );
+}

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 import { createBrowserRouter } from "react-router";
 import Dashboard from "./pages/Dashboard";
+import { DashboardPage } from "./pages/dashboard/DashboardPage";
 import Analytics from "./pages/Analytics";
 import JobOsAssetsPage from "./pages/job-os/JobOsAssetsPage";
 import JobOsCompaniesPage from "./pages/job-os/JobOsCompaniesPage";
@@ -52,7 +53,7 @@ export const router = createBrowserRouter([
       },
       {
         path: "/job-os/dashboard",
-        Component: JobOsApplicationsPage,
+        Component: DashboardPage,
       },
       {
         path: "/job-os/assets",

--- a/src/app/services/execution/nextActionEngine.ts
+++ b/src/app/services/execution/nextActionEngine.ts
@@ -1,0 +1,387 @@
+import type {
+  JobOsCompany,
+  JobOsRole,
+  JobOsApplication,
+  CompanyPriority,
+} from "../../types/jobOs";
+
+// ─── Public Types ─────────────────────────────────────────────────────────────
+
+export type NextActionType =
+  | "apply"
+  | "follow_up"
+  | "add_role"
+  | "research"
+  | "optimize_cv"
+  | "archive";
+
+export type ActionPriority = "urgent" | "high" | "medium" | "low";
+
+export interface NextAction {
+  id: string;
+  type: NextActionType;
+  priority: ActionPriority;
+  /** 0–100 composite score */
+  score: number;
+  companyId?: string;
+  companyName?: string;
+  roleId?: string;
+  roleTitle?: string;
+  applicationId?: string;
+  reason: string;
+  actionLabel: string;
+  /** Deep link into the relevant Job OS page */
+  href: string;
+}
+
+export interface EngineInput {
+  companies: JobOsCompany[];
+  roles: JobOsRole[];
+  applications: JobOsApplication[];
+}
+
+// ─── Scoring Constants ────────────────────────────────────────────────────────
+
+const PRIORITY_WEIGHT: Record<CompanyPriority, number> = { A: 30, B: 15, C: 5 };
+const FIT_WEIGHT = 5; // per fitScore point (1–5)
+const FOLLOW_UP_BASE = 60;
+const APPLY_BASE = 50;
+const OPTIMIZE_CV_BASE = 70;
+const ADD_ROLE_BASE = 40;
+const RESEARCH_BASE = 25;
+const ARCHIVE_BASE = 10;
+
+// Days thresholds
+const FOLLOW_UP_DAYS = 7;
+const STALE_ROLE_DAYS = 30;
+const ARCHIVE_DAYS = 21;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function daysSince(dateStr: string | undefined): number {
+  if (!dateStr) return 0;
+  const ms = Date.now() - new Date(dateStr).getTime();
+  return Math.max(0, Math.floor(ms / 86_400_000));
+}
+
+function toPriority(score: number): ActionPriority {
+  if (score >= 80) return "urgent";
+  if (score >= 55) return "high";
+  if (score >= 35) return "medium";
+  return "low";
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+// ─── Rule Generators ─────────────────────────────────────────────────────────
+
+function generateApplyActions(
+  roles: JobOsRole[],
+  companies: JobOsCompany[],
+  applications: JobOsApplication[]
+): NextAction[] {
+  const companyMap = new Map(companies.map((c) => [c.id, c]));
+  const appliedRoleIds = new Set(applications.map((a) => a.roleId));
+
+  return roles
+    .filter((r) => r.status === "to_apply" && !appliedRoleIds.has(r.id))
+    .map((role) => {
+      const company = companyMap.get(role.companyId);
+      const priorityBonus = company ? PRIORITY_WEIGHT[company.priority] : 0;
+      const fitBonus = role.fitScore * FIT_WEIGHT;
+      const stalePenalty = daysSince(role.createdAt) > STALE_ROLE_DAYS ? 10 : 0;
+      const score = clamp(APPLY_BASE + priorityBonus + fitBonus - stalePenalty, 0, 100);
+
+      return {
+        id: `apply-${role.id}`,
+        type: "apply" as NextActionType,
+        priority: toPriority(score),
+        score,
+        companyId: role.companyId,
+        companyName: company?.name,
+        roleId: role.id,
+        roleTitle: role.title,
+        reason: `Fit score ${role.fitScore}/5${company ? ` · ${company.priority}-priority target` : ""}`,
+        actionLabel: "Apply Now",
+        href: "/job-os/roles",
+      };
+    });
+}
+
+function generateFollowUpActions(
+  applications: JobOsApplication[],
+  companies: JobOsCompany[]
+): NextAction[] {
+  const companyMap = new Map(companies.map((c) => [c.id, c]));
+
+  return applications
+    .filter(
+      (a) =>
+        (a.status === "sent" || a.status === "screen") &&
+        daysSince(a.lastResponseAt ?? a.dateApplied) >= FOLLOW_UP_DAYS
+    )
+    .map((app) => {
+      const company = companyMap.get(app.companyId);
+      const priorityBonus = company ? PRIORITY_WEIGHT[company.priority] : 0;
+      const days = daysSince(app.lastResponseAt ?? app.dateApplied);
+      const urgencyBonus = Math.min(days * 1.5, 20);
+      const score = clamp(FOLLOW_UP_BASE + priorityBonus + urgencyBonus, 0, 100);
+
+      return {
+        id: `follow-up-${app.id}`,
+        type: "follow_up" as NextActionType,
+        priority: toPriority(score),
+        score,
+        companyId: app.companyId,
+        companyName: company?.name,
+        applicationId: app.id,
+        reason: `Applied ${days} day${days !== 1 ? "s" : ""} ago — no response yet`,
+        actionLabel: "Follow Up",
+        href: "/job-os/applications",
+      };
+    });
+}
+
+function generateOptimizeCvActions(
+  applications: JobOsApplication[],
+  companies: JobOsCompany[]
+): NextAction[] {
+  const companyMap = new Map(companies.map((c) => [c.id, c]));
+
+  return applications
+    .filter(
+      (a) =>
+        (a.status === "interview" || a.status === "final" || a.status === "case") &&
+        !a.tailoredCvText
+    )
+    .map((app) => {
+      const company = companyMap.get(app.companyId);
+      const priorityBonus = company ? PRIORITY_WEIGHT[company.priority] : 0;
+      const score = clamp(OPTIMIZE_CV_BASE + priorityBonus, 0, 100);
+
+      return {
+        id: `optimize-cv-${app.id}`,
+        type: "optimize_cv" as NextActionType,
+        priority: toPriority(score),
+        score,
+        companyId: app.companyId,
+        companyName: company?.name,
+        applicationId: app.id,
+        reason: "Interview stage — tailor your CV to maximise impact",
+        actionLabel: "Tailor CV",
+        href: "/cv-optimizer",
+      };
+    });
+}
+
+function generateAddRoleActions(
+  companies: JobOsCompany[],
+  roles: JobOsRole[]
+): NextAction[] {
+  const companiesWithRoles = new Set(roles.map((r) => r.companyId));
+
+  return companies
+    .filter(
+      (c) =>
+        !companiesWithRoles.has(c.id) &&
+        (c.status === "Active" || c.status === "Target")
+    )
+    .map((company) => {
+      const priorityBonus = PRIORITY_WEIGHT[company.priority];
+      const score = clamp(ADD_ROLE_BASE + priorityBonus, 0, 100);
+
+      return {
+        id: `add-role-${company.id}`,
+        type: "add_role" as NextActionType,
+        priority: toPriority(score),
+        score,
+        companyId: company.id,
+        companyName: company.name,
+        reason: `${company.status} company — no roles tracked yet`,
+        actionLabel: "Add Role",
+        href: "/job-os/companies",
+      };
+    });
+}
+
+function generateResearchActions(
+  companies: JobOsCompany[],
+  roles: JobOsRole[]
+): NextAction[] {
+  const companiesWithRoles = new Set(roles.map((r) => r.companyId));
+
+  return companies
+    .filter(
+      (c) =>
+        !companiesWithRoles.has(c.id) &&
+        c.status === "Research" &&
+        c.priority === "A"
+    )
+    .map((company) => ({
+      id: `research-${company.id}`,
+      type: "research" as NextActionType,
+      priority: "medium" as ActionPriority,
+      score: RESEARCH_BASE + PRIORITY_WEIGHT[company.priority],
+      companyId: company.id,
+      companyName: company.name,
+      reason: "A-priority target in research — find open roles",
+      actionLabel: "Research",
+      href: "/job-os/companies",
+    }));
+}
+
+function generateArchiveActions(
+  applications: JobOsApplication[],
+  companies: JobOsCompany[]
+): NextAction[] {
+  const companyMap = new Map(companies.map((c) => [c.id, c]));
+
+  return applications
+    .filter(
+      (a) =>
+        (a.status === "rejected" || a.status === "ghosted") &&
+        daysSince(a.updatedAt) >= ARCHIVE_DAYS
+    )
+    .slice(0, 3) // cap to avoid noise
+    .map((app) => {
+      const company = companyMap.get(app.companyId);
+      return {
+        id: `archive-${app.id}`,
+        type: "archive" as NextActionType,
+        priority: "low" as ActionPriority,
+        score: ARCHIVE_BASE,
+        companyId: app.companyId,
+        companyName: company?.name,
+        applicationId: app.id,
+        reason: "Keep your pipeline clean — close stale applications",
+        actionLabel: "Archive",
+        href: "/job-os/applications",
+      };
+    });
+}
+
+// ─── Hot Opportunities ────────────────────────────────────────────────────────
+
+export interface HotOpportunity {
+  roleId: string;
+  roleTitle: string;
+  companyId: string;
+  companyName: string;
+  priority: CompanyPriority;
+  fitScore: 1 | 2 | 3 | 4 | 5;
+  score: number;
+  reason: string;
+  href: string;
+}
+
+export function getHotOpportunities(
+  roles: JobOsRole[],
+  companies: JobOsCompany[],
+  applications: JobOsApplication[]
+): HotOpportunity[] {
+  const companyMap = new Map(companies.map((c) => [c.id, c]));
+  const appliedRoleIds = new Set(applications.map((a) => a.roleId));
+
+  return roles
+    .filter((r) => r.status === "to_apply" && !appliedRoleIds.has(r.id))
+    .map((role) => {
+      const company = companyMap.get(role.companyId);
+      const priorityBonus = company ? PRIORITY_WEIGHT[company.priority] : 0;
+      const score = clamp(priorityBonus + role.fitScore * FIT_WEIGHT, 0, 100);
+      const reasons: string[] = [];
+      if (company?.priority === "A") reasons.push("A-priority company");
+      if (role.fitScore >= 4) reasons.push(`fit ${role.fitScore}/5`);
+      if (role.sourceType === "link") reasons.push("imported via link");
+
+      return {
+        roleId: role.id,
+        roleTitle: role.title,
+        companyId: role.companyId,
+        companyName: company?.name ?? "Unknown",
+        priority: company?.priority ?? "C",
+        fitScore: role.fitScore,
+        score,
+        reason: reasons.join(" · ") || `Fit score ${role.fitScore}/5`,
+        href: "/job-os/roles",
+      };
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+}
+
+// ─── Pipeline Stats ───────────────────────────────────────────────────────────
+
+export interface PipelineStats {
+  totalCompanies: number;
+  totalRoles: number;
+  toApply: number;
+  applied: number;
+  inReview: number;
+  interviewing: number;
+  offers: number;
+  conversionRate: number; // interviews / applied * 100
+}
+
+export function getPipelineStats(
+  companies: JobOsCompany[],
+  roles: JobOsRole[],
+  applications: JobOsApplication[]
+): PipelineStats {
+  const toApply = roles.filter((r) => r.status === "to_apply").length;
+  const applied = applications.length;
+  const inReview = applications.filter(
+    (a) => a.status === "sent" || a.status === "screen"
+  ).length;
+  const interviewing = applications.filter(
+    (a) => a.status === "interview" || a.status === "final" || a.status === "case"
+  ).length;
+  const offers = applications.filter((a) => a.status === "offer").length;
+  const conversionRate =
+    applied > 0 ? Math.round((interviewing / applied) * 100) : 0;
+
+  return {
+    totalCompanies: companies.length,
+    totalRoles: roles.length,
+    toApply,
+    applied,
+    inReview,
+    interviewing,
+    offers,
+    conversionRate,
+  };
+}
+
+// ─── Main Entry Point ─────────────────────────────────────────────────────────
+
+/**
+ * Generate and rank the top next actions the user should take right now.
+ * Returns the top N actions sorted by score descending.
+ */
+export function getNextActions(
+  data: EngineInput,
+  limit = 5
+): NextAction[] {
+  const { companies, roles, applications } = data;
+
+  const all: NextAction[] = [
+    ...generateOptimizeCvActions(applications, companies),
+    ...generateFollowUpActions(applications, companies),
+    ...generateApplyActions(roles, companies, applications),
+    ...generateAddRoleActions(companies, roles),
+    ...generateResearchActions(companies, roles),
+    ...generateArchiveActions(applications, companies),
+  ];
+
+  // Deduplicate by id, sort by score desc, take top N
+  const seen = new Set<string>();
+  return all
+    .filter((a) => {
+      if (seen.has(a.id)) return false;
+      seen.add(a.id);
+      return true;
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}

--- a/src/app/types/jobOs.ts
+++ b/src/app/types/jobOs.ts
@@ -86,6 +86,8 @@ export interface JobOsCompany {
   sourceUrl?: string;
   sourcePlatform?: string;
   importConfidence?: number;
+  // Execution engine metadata
+  lastInteractionAt?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -107,6 +109,9 @@ export interface JobOsRole {
   sourceType?: "manual" | "csv" | "link" | "generated";
   sourcePlatform?: string;
   importConfidence?: number;
+  // Execution engine metadata
+  lastInteractionAt?: string;
+  hasApplication?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -128,6 +133,8 @@ export interface JobOsApplication {
   tailoredCvSummary?: string;
   tailoredCvText?: string;
   tailoredCvUpdatedAt?: string;
+  // Execution engine metadata
+  lastResponseAt?: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
- Add nextActionEngine.ts with six scoring rules (apply, follow_up, optimize_cv, add_role, research, archive) and composite 0-100 scoring
- Add getHotOpportunities() and getPipelineStats() engine exports
- Extend JobOsCompany, JobOsRole, JobOsApplication types with optional execution-engine metadata fields (lastInteractionAt, lastResponseAt, hasApplication)
- Add six dashboard components: NextActionCard, TodayPanel, OpportunityCard, HotOpportunities, PipelineStats, QuickActions
- Add DashboardPage wiring engine output to UI sections
- Register /job-os/dashboard route pointing to DashboardPage
- Add Dashboard as first tab in JobOsLayout nav (LayoutDashboard icon)

Closes #17

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

