### PR TITLE
feat(dashboard): restore probability engine; feat(roles): add recruit…

### DIFF
--- a/src/app/components/dashboard/ProbabilityPanel.tsx
+++ b/src/app/components/dashboard/ProbabilityPanel.tsx
@@ -1,0 +1,94 @@
+import { TrendingUp } from "lucide-react";
+import { calculateProbabilityScenarios } from "../../utils";
+import { Progress } from "../ui/progress";
+import type { PipelineStats } from "../../services/execution/nextActionEngine";
+
+interface ProbabilityPanelProps {
+  stats: PipelineStats;
+  isLoading?: boolean;
+}
+
+export function ProbabilityPanel({ stats, isLoading }: ProbabilityPanelProps) {
+  const scenarios = calculateProbabilityScenarios(
+    stats.applied,
+    stats.responseRate,
+    stats.interviewRate,
+    stats.offerRate,
+  );
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <TrendingUp className="h-4 w-4 text-green-500" />
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+          Probability Engine
+        </h2>
+      </div>
+
+      <div className="rounded-lg border border-green-200 dark:border-green-900/50 bg-green-50 dark:bg-green-950/30 p-4 space-y-4">
+        {isLoading ? (
+          <div className="h-20 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+        ) : stats.applied === 0 ? (
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
+            Log applications to see offer probability.
+          </p>
+        ) : (
+          <>
+            <div>
+              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
+                Probability of ≥1 Offer
+              </div>
+              <div className="text-3xl font-bold tabular-nums text-neutral-900 dark:text-neutral-100 mb-2">
+                {scenarios.probabilityOfOffer.toFixed(1)}%
+              </div>
+              <Progress value={scenarios.probabilityOfOffer} className="h-2" />
+            </div>
+
+            <div className="border-t border-neutral-200 dark:border-neutral-800 pt-3 space-y-3">
+              <div className="text-xs text-neutral-500 dark:text-neutral-400 uppercase tracking-wide">
+                Scenarios
+              </div>
+              {(
+                [
+                  { label: "Conservative", data: scenarios.conservative, color: "text-orange-500" },
+                  { label: "Realistic", data: scenarios.realistic, color: "text-blue-500" },
+                  { label: "Strong", data: scenarios.strong, color: "text-green-500" },
+                ] as const
+              ).map(({ label, data, color }) => (
+                <div key={label}>
+                  <div className={`text-xs font-medium mb-1 ${color}`}>{label}</div>
+                  <div className="grid grid-cols-3 gap-1 text-xs">
+                    <div>
+                      <div className="text-neutral-500 dark:text-neutral-400">Response</div>
+                      <div className="font-medium text-neutral-900 dark:text-neutral-100">
+                        {data.response.toFixed(1)}%
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-neutral-500 dark:text-neutral-400">Interview</div>
+                      <div className="font-medium text-neutral-900 dark:text-neutral-100">
+                        {data.interview.toFixed(1)}%
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-neutral-500 dark:text-neutral-400">Offer</div>
+                      <div className="font-medium text-neutral-900 dark:text-neutral-100">
+                        {data.offer.toFixed(1)}%
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="border-t border-neutral-200 dark:border-neutral-800 pt-3">
+              <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                Based on: {stats.applied} applications · {stats.responseRate}% response · {stats.interviewRate}% interview · {stats.offerRate}% offer
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/pages/dashboard/DashboardPage.tsx
+++ b/src/app/pages/dashboard/DashboardPage.tsx
@@ -11,6 +11,7 @@ import { AppNavbar } from "../../components/AppNavbar";
 import { TodayPanel } from "../../components/dashboard/TodayPanel";
 import { HotOpportunities } from "../../components/dashboard/HotOpportunities";
 import { PipelineStats } from "../../components/dashboard/PipelineStats";
+import { ProbabilityPanel } from "../../components/dashboard/ProbabilityPanel";
 import { QuickActions } from "../../components/dashboard/QuickActions";
 
 export function DashboardPage() {
@@ -53,7 +54,7 @@ export function DashboardPage() {
   const stats = useMemo(
     () =>
       loading
-        ? { totalCompanies: 0, totalRoles: 0, toApply: 0, applied: 0, inReview: 0, interviewing: 0, offers: 0, conversionRate: 0 }
+        ? { totalCompanies: 0, totalRoles: 0, toApply: 0, applied: 0, inReview: 0, interviewing: 0, offers: 0, conversionRate: 0, responseRate: 0, interviewRate: 0, offerRate: 0 }
         : getPipelineStats(companies, roles, applications),
     [companies, roles, applications, loading]
   );
@@ -82,6 +83,7 @@ export function DashboardPage() {
           {/* Right — context column */}
           <div className="space-y-6">
             <PipelineStats stats={stats} isLoading={loading} />
+            <ProbabilityPanel stats={stats} isLoading={loading} />
             {(loading || hotOpportunities.length > 0) && (
               <HotOpportunities opportunities={hotOpportunities} isLoading={loading} />
             )}

--- a/src/app/pages/job-os/JobOsRolesPage.tsx
+++ b/src/app/pages/job-os/JobOsRolesPage.tsx
@@ -11,6 +11,8 @@ import { useJobOs } from "../../hooks/useJobOs";
 import { JobOsLayout } from "../../components/job-os/JobOsLayout";
 import type { JobOsRole, JobTrack, RoleStatus } from "../../types/jobOs";
 
+type RoleOrigin = "self_sourced" | "recruiter";
+
 const ROLE_STATUSES: RoleStatus[] = ["to_apply", "applied", "interview", "rejected", "offer", "closed"];
 const SENIORITY_OPTIONS = ["Senior", "Middle", "Junior"] as const;
 const LOCATION_SUGGESTIONS = ["Remote", "Hybrid"] as const;
@@ -44,6 +46,7 @@ export default function JobOsRolesPage() {
     track: "TPM",
     fitScore: 3,
     status: "to_apply",
+    origin: "self_sourced",
     jobDescription: "",
     jobDescriptionUpdatedAt: undefined,
   });
@@ -69,6 +72,7 @@ export default function JobOsRolesPage() {
       track: role.track,
       fitScore: role.fitScore,
       status: role.status,
+      origin: role.origin ?? "self_sourced",
       jobDescription: role.jobDescription ?? "",
       jobDescriptionUpdatedAt: role.jobDescriptionUpdatedAt,
     });
@@ -122,6 +126,7 @@ export default function JobOsRolesPage() {
         track: "TPM",
         fitScore: 3,
         status: "to_apply",
+        origin: "self_sourced",
         jobDescription: "",
         jobDescriptionUpdatedAt: undefined,
       });
@@ -143,7 +148,18 @@ export default function JobOsRolesPage() {
             </SelectContent>
           </Select>
           <Input value={draft.title} onChange={(event) => setDraft((current) => ({ ...current, title: event.target.value }))} placeholder="Role title" />
-          <Input value={draft.url} onChange={(event) => setDraft((current) => ({ ...current, url: event.target.value }))} placeholder="Role URL" />
+          <Select value={draft.origin ?? "self_sourced"} onValueChange={(value) => setDraft((current) => ({ ...current, origin: value as RoleOrigin }))}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="self_sourced">Self-sourced</SelectItem>
+              <SelectItem value="recruiter">Recruiter contacted me</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            value={draft.url}
+            onChange={(event) => setDraft((current) => ({ ...current, url: event.target.value }))}
+            placeholder={draft.origin === "recruiter" ? "Posting URL (optional)" : "Role URL"}
+          />
           <Input
             list="role-location-suggestions"
             value={draft.location}
@@ -255,13 +271,32 @@ export default function JobOsRolesPage() {
                   </TableCell>
                   <TableCell className="font-medium">
                     {editingRoleId === role.id && editDraft ? (
-                      <Input
-                        value={editDraft.title}
-                        onChange={(event) => setEditDraft((current) => (current ? { ...current, title: event.target.value } : current))}
-                        className="w-52"
-                      />
+                      <div className="flex flex-col gap-1">
+                        <Input
+                          value={editDraft.title}
+                          onChange={(event) => setEditDraft((current) => (current ? { ...current, title: event.target.value } : current))}
+                          className="w-52"
+                        />
+                        <Select
+                          value={editDraft.origin ?? "self_sourced"}
+                          onValueChange={(value) => setEditDraft((current) => (current ? { ...current, origin: value as RoleOrigin } : current))}
+                        >
+                          <SelectTrigger className="w-52"><SelectValue /></SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="self_sourced">Self-sourced</SelectItem>
+                            <SelectItem value="recruiter">Recruiter contacted me</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
                     ) : (
-                      role.title
+                      <div className="flex items-center gap-1.5">
+                        {role.title}
+                        {role.origin === "recruiter" && (
+                          <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
+                            Recruiter
+                          </span>
+                        )}
+                      </div>
                     )}
                   </TableCell>
                   <TableCell>

--- a/src/app/services/execution/nextActionEngine.ts
+++ b/src/app/services/execution/nextActionEngine.ts
@@ -322,6 +322,9 @@ export interface PipelineStats {
   interviewing: number;
   offers: number;
   conversionRate: number; // interviews / applied * 100
+  responseRate: number;   // got any response / applied * 100
+  interviewRate: number;  // reached interview / responded * 100
+  offerRate: number;      // offers / interviewed * 100
 }
 
 export function getPipelineStats(
@@ -338,8 +341,17 @@ export function getPipelineStats(
     (a) => a.status === "interview" || a.status === "final" || a.status === "case"
   ).length;
   const offers = applications.filter((a) => a.status === "offer").length;
-  const conversionRate =
-    applied > 0 ? Math.round((interviewing / applied) * 100) : 0;
+  const responded = applications.filter((a) =>
+    ["screen", "case", "interview", "final", "offer", "rejected"].includes(a.status)
+  ).length;
+  const interviewed = applications.filter((a) =>
+    ["interview", "final", "offer"].includes(a.status)
+  ).length;
+
+  const conversionRate = applied > 0 ? Math.round((interviewing / applied) * 100) : 0;
+  const responseRate = applied > 0 ? Math.round((responded / applied) * 100) : 0;
+  const interviewRate = responded > 0 ? Math.round((interviewed / responded) * 100) : 0;
+  const offerRate = interviewed > 0 ? Math.round((offers / interviewed) * 100) : 0;
 
   return {
     totalCompanies: companies.length,
@@ -350,6 +362,9 @@ export function getPipelineStats(
     interviewing,
     offers,
     conversionRate,
+    responseRate,
+    interviewRate,
+    offerRate,
   };
 }
 

--- a/src/app/types/jobOs.ts
+++ b/src/app/types/jobOs.ts
@@ -103,6 +103,7 @@ export interface JobOsRole {
   track: JobTrack;
   fitScore: 1 | 2 | 3 | 4 | 5;
   status: RoleStatus;
+  origin?: "self_sourced" | "recruiter"; // how the candidate discovered the role
   jobDescription?: string;
   jobDescriptionUpdatedAt?: string;
   // Ingestion / import metadata (optional — backwards compatible)


### PR DESCRIPTION
…er origin

Probability Engine:
- Extend PipelineStats with responseRate, interviewRate, offerRate computed from Job OS application data (responded/interviewed counts)
- Add ProbabilityPanel component (props-driven, no legacy context dependency)
- Render ProbabilityPanel in Command Centre right column below pipeline snapshot

Recruiter-contacted roles:
- Add origin?: "self_sourced" | "recruiter" to JobOsRole type (backwards-compatible)
- Add origin picker to Add Role form; URL field placeholder adapts to recruiter mode
- Inline edit row shows origin select below title input
- Roles table shows violet "Recruiter" badge next to title for recruiter-sourced roles

Closes #18

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

