### PR TITLE
Refine Job OS UX and add AI job import pipeline

### DIFF
--- a/docs/AI_IMPORT_API.md
+++ b/docs/AI_IMPORT_API.md
@@ -1,0 +1,188 @@
+# AI Import API
+
+JobSprint can enrich imported job links through a backend endpoint that keeps the OpenAI API key server-side and returns strict structured output.
+
+## Endpoint
+
+`POST /job-import-enrich`
+
+This endpoint is implemented in the existing server at [cv-tailor-server.mjs](/d:/WORK/IT_Projects/JobSprint/server/cv-tailor-server.mjs).
+
+## Why a backend is required
+
+The frontend is a browser-based Vite SPA. The OpenAI API key must stay on the server, so the frontend should call this endpoint and the server should call OpenAI.
+
+## Request shape
+
+The request must be JSON and include `rawExtracted`.
+
+```json
+{
+  "sourceUrl": "https://boards.greenhouse.io/acme/jobs/12345",
+  "sourcePlatform": "greenhouse",
+  "sourceType": "job",
+  "importConfidence": 0.78,
+  "rawExtracted": {
+    "companyName": "Acme",
+    "website": "https://acme.com",
+    "careersUrl": "https://acme.com/careers",
+    "industryHint": "Developer tools",
+    "sizeHint": "201-500 employees",
+    "locationHint": "Berlin, Germany",
+    "remotePolicyHint": "Hybrid",
+    "roleTitle": "Senior Technical Product Manager",
+    "roleUrl": "https://boards.greenhouse.io/acme/jobs/12345",
+    "roleLocation": "Berlin, Germany",
+    "seniorityHint": "Senior",
+    "jobDescription": "Full job description text...",
+    "notes": "Imported from ATS page"
+  },
+  "normalized": {
+    "company": {
+      "name": "Acme",
+      "industry": "Developer tools",
+      "size": "201-500 employees",
+      "remotePolicy": "Hybrid",
+      "location": "Berlin, Germany",
+      "englishFirst": "Unknown"
+    },
+    "role": {
+      "title": "Senior Technical Product Manager",
+      "url": "https://boards.greenhouse.io/acme/jobs/12345",
+      "location": "Berlin, Germany",
+      "seniority": "Senior",
+      "track": "TPM",
+      "fitScore": 3,
+      "status": "to_apply",
+      "nextAction": "Apply"
+    }
+  }
+}
+```
+
+Validation rules:
+- request body must be a JSON object
+- `rawExtracted` must be present
+- at least one of `rawExtracted.companyName`, `rawExtracted.roleTitle`, or `rawExtracted.jobDescription` must be present
+- `importConfidence`, if provided, must be between `0` and `1`
+
+## Response shape
+
+```json
+{
+  "schemaVersion": "ai_import_v1",
+  "canonicalTitle": "Senior Technical Product Manager",
+  "roleTrack": "TPM",
+  "seniority": "Senior",
+  "industry": "Developer Tools",
+  "companyStage": "Unknown",
+  "companySizeBand": "201-500",
+  "workplaceMode": "Hybrid",
+  "fitScore": 4,
+  "priorityBand": "B",
+  "nextBestAction": "Tailor CV",
+  "confidence": {
+    "overall": {
+      "score": 0.78,
+      "level": "medium",
+      "evidence": ["Senior Technical Product Manager", "Hybrid", "201-500 employees"],
+      "source": "model"
+    },
+    "fields": {
+      "canonicalTitle": {
+        "score": 0.93,
+        "level": "high",
+        "evidence": ["Senior Technical Product Manager"],
+        "source": "model"
+      },
+      "roleTrack": {
+        "score": 0.88,
+        "level": "high",
+        "evidence": ["Technical Product Manager"],
+        "source": "model"
+      },
+      "seniority": {
+        "score": 0.95,
+        "level": "high",
+        "evidence": ["Senior"],
+        "source": "model"
+      },
+      "industry": {
+        "score": 0.61,
+        "level": "medium",
+        "evidence": ["Developer tools"],
+        "source": "model"
+      },
+      "companyStage": {
+        "score": 0.15,
+        "level": "low",
+        "evidence": [],
+        "source": "model"
+      },
+      "companySizeBand": {
+        "score": 0.86,
+        "level": "high",
+        "evidence": ["201-500 employees"],
+        "source": "model"
+      },
+      "workplaceMode": {
+        "score": 0.91,
+        "level": "high",
+        "evidence": ["Hybrid"],
+        "source": "model"
+      },
+      "fitScore": {
+        "score": 0.67,
+        "level": "medium",
+        "evidence": ["complete JD present", "structured title present"],
+        "source": "model"
+      },
+      "priorityBand": {
+        "score": 0.32,
+        "level": "low",
+        "evidence": [],
+        "source": "model"
+      },
+      "nextBestAction": {
+        "score": 0.76,
+        "level": "medium",
+        "evidence": ["full job description present"],
+        "source": "model"
+      }
+    }
+  },
+  "reviewFlags": [
+    {
+      "code": "unclear_company_stage",
+      "severity": "review",
+      "message": "The source does not provide reliable company stage evidence.",
+      "fieldPath": "companyStage"
+    }
+  ],
+  "model": "gpt-4.1-mini"
+}
+```
+
+## Enforced enums
+
+The endpoint only allows the following structured classifications:
+
+- `roleTrack`: `TPM | Product Engineer | Systems PM | Unknown`
+- `seniority`: `Junior | Middle | Senior | Lead | Staff | Principal | Director | VP | Executive | Unknown`
+- `industry`: `AI / Data | Cybersecurity | Developer Tools | E-Commerce / Marketplace | EdTech | Fintech / Finance | Healthcare | HR / Talent | Logistics | Media / Content | PropTech | SaaS / Software | Unknown`
+- `companyStage`: `Pre-seed | Seed | Series A | Series B | Series C+ | Private Growth | Bootstrapped | Public | Enterprise | Unknown`
+- `companySizeBand`: `1-10 | 11-50 | 51-200 | 201-500 | 501-1000 | 1001-5000 | 5000+ | Unknown`
+- `workplaceMode`: `Remote | Hybrid | On-site | Unknown`
+- `priorityBand`: `A | B | C | Unknown`
+- `nextBestAction`: `Research | Tailor CV | Apply | Follow up | Network | Archive`
+
+## Hallucination safeguards
+
+The server prompt explicitly tells the model to:
+- classify only from the supplied import payload
+- never invent unsupported facts
+- return `Unknown` when evidence is weak or absent
+- keep normalized fields as secondary context, not as permission to infer new facts
+- add review flags for anything a human should verify
+
+The server also enforces strict JSON schema output with `strict: true`, so the model can only return the allowed fields and enums.

--- a/docs/AI_IMPORT_SCHEMA_V1.md
+++ b/docs/AI_IMPORT_SCHEMA_V1.md
@@ -1,0 +1,226 @@
+# AI Import Schema V1
+
+## Purpose
+AI Import Enrichment v1 adds an optional enrichment layer on top of the existing Paste Link ingestion flow.
+
+The deterministic pipeline stays responsible for:
+- source detection
+- HTML/text parsing
+- rule-based normalization
+- duplicate matching
+- review and save
+
+The AI layer is additive. It can suggest structured fields, confidence, and review flags without blocking the current import path.
+
+## Design Principles
+- Backward-compatible: existing company and role drafts still work unchanged.
+- Optional: all AI fields live under `aiEnrichment`.
+- Review-first: AI output is advisory until accepted by the user or downstream logic.
+- Source-aware: keep raw extracted values separate from normalized and enriched values.
+
+## Top-Level Shape
+`aiEnrichment` uses schema version `ai_import_v1` and may appear on:
+- `ParsedImportResult`
+- `NormalizedImportResult`
+- `NormalizedCompanyDraft`
+- `NormalizedRoleDraft`
+- persisted `JobOsCompany`
+- persisted `JobOsRole`
+- persisted `JobOsApplication`
+
+## Data Layers
+
+### 1. Raw Extracted Fields
+These are directly parsed from HTML, meta tags, JSON blobs, pasted JD text, or source adapters.
+
+Company-oriented fields:
+- `companyName`
+- `website`
+- `careersUrl`
+- `industryHint`
+- `sizeHint`
+- `locationHint`
+- `remotePolicyHint`
+- `englishFirstHint`
+
+Role-oriented fields:
+- `roleTitle`
+- `roleUrl`
+- `roleLocation`
+- `seniorityHint`
+- `jobDescription`
+- `notes`
+
+These fields are lossy and source-shaped. They should not be treated as final canonical data.
+
+### 2. Normalized Fields
+These represent the deterministic JobSprint-ready draft after rule-based cleanup.
+
+Normalized company fields:
+- `name`
+- `industry`
+- `size`
+- `remotePolicy`
+- `location`
+- `englishFirst`
+
+Normalized role fields:
+- `title`
+- `url`
+- `location`
+- `seniority`
+- `track`
+- `fitScore`
+- `status`
+- `nextAction`
+
+These fields remain the primary save payload for v1.
+
+### 3. AI-Enriched Fields
+These are optional structured suggestions intended to improve downstream workflows.
+
+Company enrichment:
+- `industry`
+- `sizeBand`
+- `companyStage`
+- `hiringSignal`
+- `operatingRegion`
+
+Role enrichment:
+- `track`
+- `seniority`
+- `nextBestAction`
+- `applicationReadiness`
+- `keyRequirements`
+
+## Enums
+
+### Role Track
+- `TPM`
+- `Product Engineer`
+- `Systems PM`
+- `Unknown`
+
+### Seniority
+- `Junior`
+- `Middle`
+- `Senior`
+- `Lead`
+- `Staff`
+- `Principal`
+- `Director`
+- `VP`
+- `Executive`
+- `Unknown`
+
+### Industry
+- `AI / Data`
+- `Cybersecurity`
+- `Developer Tools`
+- `E-Commerce / Marketplace`
+- `EdTech`
+- `Fintech / Finance`
+- `Healthcare`
+- `HR / Talent`
+- `Logistics`
+- `Media / Content`
+- `PropTech`
+- `SaaS / Software`
+- `Unknown`
+
+### Company Size Band
+- `1-10`
+- `11-50`
+- `51-200`
+- `201-500`
+- `501-1000`
+- `1001-5000`
+- `5000+`
+- `Unknown`
+
+### Company Stage
+- `Pre-seed`
+- `Seed`
+- `Series A`
+- `Series B`
+- `Series C+`
+- `Private Growth`
+- `Bootstrapped`
+- `Public`
+- `Enterprise`
+- `Unknown`
+
+### Next Best Action
+- `Research`
+- `Tailor CV`
+- `Apply`
+- `Follow up`
+- `Network`
+- `Archive`
+
+## Confidence Model
+Confidence is modeled separately from the values themselves.
+
+`overall`
+- one confidence object for the full enrichment package
+
+`fields`
+- keyed map of per-field confidence objects
+- examples:
+  - `company.industry`
+  - `company.sizeBand`
+  - `role.track`
+  - `role.nextBestAction`
+
+Each confidence object contains:
+- `score`: numeric `0..1`
+- `level`: `low | medium | high`
+- `evidence?`: optional supporting phrases or extracted snippets
+- `source?`: `rules | model | human`
+
+## Review Flags
+Review flags are explicit reasons to pause, verify, or route to user review.
+
+Current flag codes:
+- `missing_company_name`
+- `missing_role_title`
+- `missing_job_description`
+- `unclear_location`
+- `unclear_seniority`
+- `unclear_track`
+- `unclear_industry`
+- `unclear_company_size`
+- `unclear_company_stage`
+- `duplicate_company_match`
+- `low_confidence_parse`
+- `manual_review_recommended`
+
+Each flag includes:
+- `code`
+- `severity`: `info | review | warning`
+- `message`
+- `fieldPath?`
+
+## Backward Compatibility Strategy
+- Existing top-level company and role fields remain unchanged.
+- `aiEnrichment` is optional and ignored by old callers.
+- The review UI can continue reading `result.company` and `result.role`.
+- The save path can persist `aiEnrichment` without requiring UI changes.
+- Future backend/model work can populate `ParsedImportResult.aiEnrichment` without rewriting the current adapters first.
+
+## Initial Persistence Plan
+In v1, `aiEnrichment` is allowed on:
+- company records
+- role records
+- application records
+
+This keeps the schema flexible enough for:
+- import-time suggestions
+- post-import enrichment
+- later review workflows
+
+## Out Of Scope For V1
+- live AI backend calls
+- UI changes for editing AI fields
+- automated overwrite of normalized deterministic values
+- mandatory migration of existing data

--- a/server/cv-tailor-server.mjs
+++ b/server/cv-tailor-server.mjs
@@ -1,10 +1,51 @@
-﻿import { createServer } from "node:http";
+import { createServer } from "node:http";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const DEFAULT_PORT = 8787;
 const DEFAULT_MODEL = process.env.OPENAI_MODEL || "gpt-4.1-mini";
 const MAX_BODY_BYTES = 2 * 1024 * 1024;
+const JOB_IMPORT_SCHEMA_VERSION = "ai_import_v1";
+const JOB_IMPORT_ENUMS = {
+  roleTrack: ["TPM", "Product Engineer", "Systems PM", "Unknown"],
+  seniority: ["Junior", "Middle", "Senior", "Lead", "Staff", "Principal", "Director", "VP", "Executive", "Unknown"],
+  industry: [
+    "AI / Data",
+    "Cybersecurity",
+    "Developer Tools",
+    "E-Commerce / Marketplace",
+    "EdTech",
+    "Fintech / Finance",
+    "Healthcare",
+    "HR / Talent",
+    "Logistics",
+    "Media / Content",
+    "PropTech",
+    "SaaS / Software",
+    "Unknown"
+  ],
+  companyStage: ["Pre-seed", "Seed", "Series A", "Series B", "Series C+", "Private Growth", "Bootstrapped", "Public", "Enterprise", "Unknown"],
+  companySizeBand: ["1-10", "11-50", "51-200", "201-500", "501-1000", "1001-5000", "5000+", "Unknown"],
+  workplaceMode: ["Remote", "Hybrid", "On-site", "Unknown"],
+  priorityBand: ["A", "B", "C", "Unknown"],
+  nextBestAction: ["Research", "Tailor CV", "Apply", "Follow up", "Network", "Archive"],
+  confidenceLevel: ["low", "medium", "high"],
+  reviewFlagCode: [
+    "missing_company_name",
+    "missing_role_title",
+    "missing_job_description",
+    "unclear_location",
+    "unclear_seniority",
+    "unclear_track",
+    "unclear_industry",
+    "unclear_company_size",
+    "unclear_company_stage",
+    "duplicate_company_match",
+    "low_confidence_parse",
+    "manual_review_recommended"
+  ],
+  reviewSeverity: ["info", "review", "warning"]
+};
 
 loadEnvFiles();
 
@@ -44,6 +85,21 @@ const server = createServer(async (request, response) => {
       const body = await readJsonBody(request);
       validateTailoringRequest(body);
       const result = await tailorCvWithOpenAi(body, { apiKey: openAiApiKey, model });
+      writeJson(response, 200, result);
+      return;
+    }
+
+    if (request.method === "POST" && request.url === "/job-import-enrich") {
+      if (!openAiApiKey) {
+        writeJson(response, 500, {
+          error: "OPENAI_API_KEY is missing on the server. Configure it in .env.server or your runtime environment.",
+        });
+        return;
+      }
+
+      const body = await readJsonBody(request);
+      validateJobImportEnrichmentRequest(body);
+      const result = await enrichJobImportWithOpenAi(body, { apiKey: openAiApiKey, model });
       writeJson(response, 200, result);
       return;
     }
@@ -116,6 +172,37 @@ function validateTailoringRequest(body) {
   }
 }
 
+function validateJobImportEnrichmentRequest(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("Job import enrichment request must be a JSON object.");
+  }
+
+  if (!body.rawExtracted || typeof body.rawExtracted !== "object" || Array.isArray(body.rawExtracted)) {
+    throw new Error("Job import enrichment request is missing rawExtracted.");
+  }
+
+  const hasCompanySignal = typeof body.rawExtracted.companyName === "string" && body.rawExtracted.companyName.trim();
+  const hasRoleSignal = typeof body.rawExtracted.roleTitle === "string" && body.rawExtracted.roleTitle.trim();
+  const hasJobDescription = typeof body.rawExtracted.jobDescription === "string" && body.rawExtracted.jobDescription.trim();
+
+  if (!hasCompanySignal && !hasRoleSignal && !hasJobDescription) {
+    throw new Error(
+      "Job import enrichment requires at least one of rawExtracted.companyName, rawExtracted.roleTitle, or rawExtracted.jobDescription."
+    );
+  }
+
+  if (
+    body.importConfidence != null &&
+    (typeof body.importConfidence !== "number" || Number.isNaN(body.importConfidence) || body.importConfidence < 0 || body.importConfidence > 1)
+  ) {
+    throw new Error("Job import enrichment importConfidence must be a number between 0 and 1.");
+  }
+
+  if (body.normalized != null && (typeof body.normalized !== "object" || Array.isArray(body.normalized))) {
+    throw new Error("Job import enrichment normalized must be an object when provided.");
+  }
+}
+
 async function tailorCvWithOpenAi(payload, config) {
   const schema = {
     type: "object",
@@ -170,6 +257,82 @@ async function tailorCvWithOpenAi(payload, config) {
     2
   );
 
+  const parsed = await callOpenAiWithJsonSchema(
+    {
+      apiKey: config.apiKey,
+      model: config.model,
+      schemaName: "cv_tailoring_response",
+      schema,
+      systemPrompt,
+      userPrompt,
+    }
+  );
+  const changedLineIndices = getChangedLineIndices(payload.cvSourceText, parsed.fullCvText);
+  const changedWordSpans = getChangedWordSpans(payload.cvSourceText, parsed.fullCvText, changedLineIndices);
+
+  return {
+    headline: parsed.headline,
+    summary: parsed.summary,
+    rewrittenBullets: Array.isArray(parsed.rewrittenBullets) ? parsed.rewrittenBullets : [],
+    portfolioRecommendations: Array.isArray(parsed.portfolioRecommendations) ? parsed.portfolioRecommendations : [],
+    fullCvText: parsed.fullCvText,
+    changedLineIndices,
+    changedWordSpans,
+    model: config.model,
+  };
+}
+
+async function enrichJobImportWithOpenAi(payload, config) {
+  const schema = createJobImportEnrichmentSchema();
+  const systemPrompt = [
+    "You are a job import enrichment assistant for JobSprint.",
+    "Your job is to classify and normalize only from the supplied import payload.",
+    "Never invent unsupported facts about the company, role, funding stage, size, work mode, or hiring process.",
+    "If the evidence is weak, ambiguous, or absent, return the enum value Unknown instead of guessing.",
+    "Use the supplied rawExtracted fields as the primary evidence.",
+    "Use normalized fields only as secondary context, not as license to hallucinate.",
+    "canonicalTitle must be concise and grounded in the supplied role title or job description. If no reliable title exists, return Unknown.",
+    "fitScore must be 1 through 5 and should represent import usefulness and workflow readiness, not candidate-job match quality.",
+    "priorityBand must be conservative. Use Unknown when the signal is weak.",
+    "nextBestAction must recommend the safest immediate workflow step based on the supplied evidence.",
+    "reviewFlags should explain what a human should verify before trusting the enrichment.",
+    "confidence must reflect the certainty of each field, and low-confidence fields should usually pair with Unknown values or review flags.",
+    "When a review flag is not tied to a single field, use an empty string for fieldPath.",
+    "Return valid JSON only matching the provided schema.",
+  ].join(" ");
+
+  const userPrompt = JSON.stringify(
+    {
+      task: "job_import_enrichment_v1",
+      schemaVersion: JOB_IMPORT_SCHEMA_VERSION,
+      payload,
+      outputRules: {
+        unknownWhenUnclear: true,
+        doNotInventUnsupportedFacts: true,
+        allowOnlyEnumeratedValues: true,
+        keepReviewFlagsActionable: true,
+      },
+    },
+    null,
+    2
+  );
+
+  const parsed = await callOpenAiWithJsonSchema({
+    apiKey: config.apiKey,
+    model: config.model,
+    schemaName: "job_import_enrichment_response",
+    schema,
+    systemPrompt,
+    userPrompt,
+  });
+
+  return {
+    ...parsed,
+    model: config.model,
+  };
+}
+
+async function callOpenAiWithJsonSchema(config) {
   const apiResponse = await fetch("https://api.openai.com/v1/responses", {
     method: "POST",
     headers: {
@@ -181,18 +344,18 @@ async function tailorCvWithOpenAi(payload, config) {
       input: [
         {
           role: "system",
-          content: [{ type: "input_text", text: systemPrompt }],
+          content: [{ type: "input_text", text: config.systemPrompt }],
         },
         {
           role: "user",
-          content: [{ type: "input_text", text: userPrompt }],
+          content: [{ type: "input_text", text: config.userPrompt }],
         },
       ],
       text: {
         format: {
           type: "json_schema",
-          name: "cv_tailoring_response",
-          schema,
+          name: config.schemaName,
+          schema: config.schema,
           strict: true,
         },
       },
@@ -206,19 +369,106 @@ async function tailorCvWithOpenAi(payload, config) {
 
   const responseJson = await apiResponse.json();
   const outputText = extractOutputText(responseJson);
-  const parsed = parseModelJson(outputText);
-  const changedLineIndices = getChangedLineIndices(payload.cvSourceText, parsed.fullCvText);
-  const changedWordSpans = getChangedWordSpans(payload.cvSourceText, parsed.fullCvText, changedLineIndices);
+  return parseModelJson(outputText);
+}
+
+function createJobImportEnrichmentSchema() {
+  const confidenceField = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      score: { type: "number", minimum: 0, maximum: 1 },
+      level: { type: "string", enum: JOB_IMPORT_ENUMS.confidenceLevel },
+      evidence: {
+        type: "array",
+        items: { type: "string" },
+      },
+      source: { type: "string", enum: ["model"] },
+    },
+    required: ["score", "level", "evidence", "source"],
+  };
 
   return {
-    headline: parsed.headline,
-    summary: parsed.summary,
-    rewrittenBullets: Array.isArray(parsed.rewrittenBullets) ? parsed.rewrittenBullets : [],
-    portfolioRecommendations: Array.isArray(parsed.portfolioRecommendations) ? parsed.portfolioRecommendations : [],
-    fullCvText: parsed.fullCvText,
-    changedLineIndices,
-    changedWordSpans,
-    model: config.model,
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      schemaVersion: { type: "string", const: JOB_IMPORT_SCHEMA_VERSION },
+      canonicalTitle: { type: "string" },
+      roleTrack: { type: "string", enum: JOB_IMPORT_ENUMS.roleTrack },
+      seniority: { type: "string", enum: JOB_IMPORT_ENUMS.seniority },
+      industry: { type: "string", enum: JOB_IMPORT_ENUMS.industry },
+      companyStage: { type: "string", enum: JOB_IMPORT_ENUMS.companyStage },
+      companySizeBand: { type: "string", enum: JOB_IMPORT_ENUMS.companySizeBand },
+      workplaceMode: { type: "string", enum: JOB_IMPORT_ENUMS.workplaceMode },
+      fitScore: { type: "integer", enum: [1, 2, 3, 4, 5] },
+      priorityBand: { type: "string", enum: JOB_IMPORT_ENUMS.priorityBand },
+      nextBestAction: { type: "string", enum: JOB_IMPORT_ENUMS.nextBestAction },
+      confidence: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          overall: confidenceField,
+          fields: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              canonicalTitle: confidenceField,
+              roleTrack: confidenceField,
+              seniority: confidenceField,
+              industry: confidenceField,
+              companyStage: confidenceField,
+              companySizeBand: confidenceField,
+              workplaceMode: confidenceField,
+              fitScore: confidenceField,
+              priorityBand: confidenceField,
+              nextBestAction: confidenceField,
+            },
+            required: [
+              "canonicalTitle",
+              "roleTrack",
+              "seniority",
+              "industry",
+              "companyStage",
+              "companySizeBand",
+              "workplaceMode",
+              "fitScore",
+              "priorityBand",
+              "nextBestAction",
+            ],
+          },
+        },
+        required: ["overall", "fields"],
+      },
+      reviewFlags: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            code: { type: "string", enum: JOB_IMPORT_ENUMS.reviewFlagCode },
+            severity: { type: "string", enum: JOB_IMPORT_ENUMS.reviewSeverity },
+            message: { type: "string" },
+            fieldPath: { type: "string" },
+          },
+          required: ["code", "severity", "message", "fieldPath"],
+        },
+      },
+    },
+    required: [
+      "schemaVersion",
+      "canonicalTitle",
+      "roleTrack",
+      "seniority",
+      "industry",
+      "companyStage",
+      "companySizeBand",
+      "workplaceMode",
+      "fitScore",
+      "priorityBand",
+      "nextBestAction",
+      "confidence",
+      "reviewFlags",
+    ],
   };
 }
 

--- a/src/app/components/AppNavbar.tsx
+++ b/src/app/components/AppNavbar.tsx
@@ -37,8 +37,6 @@ const NAV_ITEMS = [
     icon: BriefcaseBusiness,
     matches: (pathname: string) =>
       pathname === "/job-os" ||
-      pathname === "/job-os/companies" ||
-      pathname === "/job-os/roles" ||
       pathname === "/job-os/applications" ||
       pathname === "/job-os/outreach",
   },
@@ -48,6 +46,8 @@ const NAV_ITEMS = [
     icon: FolderOpen,
     matches: (pathname: string) =>
       pathname === "/job-os/assets" ||
+      pathname === "/job-os/companies" ||
+      pathname === "/job-os/roles" ||
       pathname === "/job-os/settings" ||
       pathname === "/cv-optimizer" ||
       pathname === "/compliance/afa",

--- a/src/app/components/dashboard/FirstRunScreen.tsx
+++ b/src/app/components/dashboard/FirstRunScreen.tsx
@@ -6,6 +6,10 @@ import { Input } from "../ui/input";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
 import { PasteLinkReviewStep } from "../job-os/PasteLinkReviewStep";
 import {
+  PasteLinkNextActionStep,
+  type InitialImportStage,
+} from "../job-os/PasteLinkNextActionStep";
+import {
   normalizeImportResult,
   parseFromInput,
 } from "../../services/ingestion/companyIngestionService";
@@ -15,9 +19,20 @@ import type {
   NormalizedImportResult,
   NormalizedRoleDraft,
 } from "../../services/ingestion/types";
-import type { JobOsCompany, JobOsRole } from "../../types/jobOs";
+import type {
+  JobOsApplication,
+  JobOsCompany,
+  JobOsRole,
+} from "../../types/jobOs";
 
-type Step = "input" | "analyzing" | "reviewing" | "saving";
+type Step = "input" | "analyzing" | "reviewing" | "next_action" | "saving";
+
+interface PendingImportState {
+  companyDraft: NormalizedCompanyDraft;
+  roleDraft: NormalizedRoleDraft | undefined;
+  mode: ImportMode;
+  updateExistingId?: string;
+}
 
 interface FirstRunScreenProps {
   existingCompanies: JobOsCompany[];
@@ -28,6 +43,9 @@ interface FirstRunScreenProps {
   addRole: (
     payload: Omit<JobOsRole, "id" | "createdAt" | "updatedAt">
   ) => Promise<string | null>;
+  addApplication: (
+    payload: Omit<JobOsApplication, "id" | "createdAt" | "updatedAt">
+  ) => Promise<string | null>;
   onDismiss: () => void;
   onComplete: () => void;
 }
@@ -37,6 +55,7 @@ export function FirstRunScreen({
   addCompany,
   updateCompany,
   addRole,
+  addApplication,
   onDismiss,
   onComplete,
 }: FirstRunScreenProps) {
@@ -45,12 +64,17 @@ export function FirstRunScreen({
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<NormalizedImportResult | null>(null);
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const [pendingImport, setPendingImport] = useState<PendingImportState | null>(null);
+  const [initialStage, setInitialStage] = useState<InitialImportStage>("to_apply");
+  const [nextAction, setNextAction] = useState("Apply");
 
   async function handleAnalyze() {
     const trimmed = url.trim();
     if (!trimmed) return;
+
     setError(null);
     setStep("analyzing");
+
     try {
       const parsed = await parseFromInput({ url: trimmed });
       const normalized = normalizeImportResult(parsed, trimmed, existingCompanies);
@@ -64,47 +88,107 @@ export function FirstRunScreen({
     }
   }
 
-  async function handleSave(
+  function handleReviewContinue(
     companyDraft: NormalizedCompanyDraft,
     roleDraft: NormalizedRoleDraft | undefined,
     mode: ImportMode,
     updateExistingId?: string
   ) {
+    setPendingImport({
+      companyDraft,
+      roleDraft,
+      mode,
+      updateExistingId,
+    });
+
+    if (mode === "company_and_role" && roleDraft) {
+      setInitialStage(roleDraft.status === "applied" ? "applied" : "to_apply");
+      setNextAction(roleDraft.nextAction?.trim() || "Apply");
+      setStep("next_action");
+      return;
+    }
+
+    setInitialStage("saved");
+    setNextAction("Research");
+    void handleSave(
+      {
+        companyDraft,
+        roleDraft,
+        mode,
+        updateExistingId,
+      },
+      "saved",
+      "Research"
+    );
+  }
+
+  async function handleSave(
+    pending: PendingImportState,
+    stage: InitialImportStage,
+    action: string
+  ) {
     setStep("saving");
+
     try {
       const {
         englishFirst,
-        sourceType: cSourceType,
+        sourceType: companySourceType,
         ...coreCompany
-      } = companyDraft;
+      } = pending.companyDraft;
 
       const companyPayload: Omit<JobOsCompany, "id" | "createdAt" | "updatedAt"> = {
         ...coreCompany,
         englishFirst: (englishFirst as JobOsCompany["englishFirst"]) ?? undefined,
-        sourceType: (cSourceType as JobOsCompany["sourceType"]) ?? undefined,
+        sourceType: (companySourceType as JobOsCompany["sourceType"]) ?? undefined,
       };
 
       let companyId: string | null;
-      if (updateExistingId) {
-        await updateCompany(updateExistingId, companyPayload);
-        companyId = updateExistingId;
+      if (pending.updateExistingId) {
+        await updateCompany(pending.updateExistingId, companyPayload);
+        companyId = pending.updateExistingId;
       } else {
         companyId = await addCompany(companyPayload);
       }
 
-      if (mode === "company_and_role" && roleDraft && companyId) {
-        const { sourceType: rSourceType, ...coreRole } = roleDraft;
-        await addRole({
+      if (pending.mode === "company_and_role" && pending.roleDraft && companyId) {
+        const {
+          sourceType: roleSourceType,
+          ...coreRole
+        } = pending.roleDraft;
+
+        const roleId = await addRole({
           ...coreRole,
           companyId,
-          sourceType: (rSourceType as JobOsRole["sourceType"]) ?? undefined,
+          status: stage === "applied" ? "applied" : "to_apply",
+          nextAction: action,
+          sourceType: (roleSourceType as JobOsRole["sourceType"]) ?? undefined,
         });
+
+        if (stage === "applied" && roleId) {
+          await addApplication({
+            companyId,
+            roleId,
+            dateApplied: new Date().toISOString().slice(0, 10),
+            channel: "Imported link",
+            cvAssetId: undefined,
+            cvVersion: "",
+            status: "sent",
+            nextAction: action,
+            notes: "",
+            latestJobDescriptionId: undefined,
+            latestCvTailoringRunId: undefined,
+            tailoredCvHeadline: "",
+            tailoredCvSummary: "",
+            tailoredCvText: "",
+            tailoredCvUpdatedAt: undefined,
+          });
+        }
       }
 
       onComplete();
     } catch {
       setError("Failed to save. Please try again.");
-      setStep("reviewing");
+      setStep(pending.mode === "company_and_role" && pending.roleDraft ? "next_action" : "reviewing");
     }
   }
 
@@ -129,9 +213,9 @@ export function FirstRunScreen({
               <Input
                 placeholder="https://boards.greenhouse.io/... or https://jobs.ashbyhq.com/..."
                 value={url}
-                onChange={(e) => setUrl(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleAnalyze();
+                onChange={(event) => setUrl(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") handleAnalyze();
                 }}
                 disabled={isAnalyzing}
                 className="h-12 rounded-xl px-4 text-base"
@@ -164,7 +248,11 @@ export function FirstRunScreen({
             ) : null}
 
             <div className="mt-5 flex items-center justify-center">
-              <Button variant="ghost" asChild className="text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200">
+              <Button
+                variant="ghost"
+                asChild
+                className="text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+              >
                 <Link to="/job-os/companies" onClick={onDismiss}>
                   Enter manually
                 </Link>
@@ -176,12 +264,16 @@ export function FirstRunScreen({
                 <CollapsibleTrigger className="flex w-full items-center gap-2 px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-200">
                   <span>How it works</span>
                   <span className="ml-auto text-neutral-400">
-                    {detailsOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                    {detailsOpen ? (
+                      <ChevronUp className="h-4 w-4" />
+                    ) : (
+                      <ChevronDown className="h-4 w-4" />
+                    )}
                   </span>
                 </CollapsibleTrigger>
                 <CollapsibleContent>
                   <div className="border-t border-slate-200 px-4 py-3 text-sm leading-6 text-slate-600 dark:border-slate-800 dark:text-slate-300">
-                    We extract the company, role, and job description from the link, then send you to a quick review step before anything is saved.
+                    We extract the company, role, and job description from the link, then guide you through review and the first pipeline action before anything is saved.
                   </div>
                 </CollapsibleContent>
               </div>
@@ -192,23 +284,39 @@ export function FirstRunScreen({
         <div className="mx-auto w-full max-w-2xl rounded-xl border border-neutral-200 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-950">
           <div className="mb-5 space-y-1">
             <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
-              Review extracted details
+              {step === "reviewing" ? "Review extracted details" : "Set the first workflow move"}
             </h2>
             <p className="text-sm text-neutral-500">
-              Confirm what we found, then save your first company and role.
+              {step === "reviewing"
+                ? "Confirm what we found, then choose how the role should enter your pipeline."
+                : "Finish the import with a clear starting stage and next action."}
             </p>
           </div>
-          {result ? (
+
+          {step === "reviewing" && result ? (
             <PasteLinkReviewStep
               result={result}
               defaultMode="company_and_role"
-              isSaving={step === "saving"}
-              onSave={handleSave}
+              onContinue={handleReviewContinue}
               onBack={() => {
                 setStep("input");
                 setResult(null);
               }}
               onCancel={onDismiss}
+            />
+          ) : null}
+
+          {(step === "next_action" || step === "saving") && pendingImport ? (
+            <PasteLinkNextActionStep
+              roleTitle={pendingImport.roleDraft?.title}
+              stage={initialStage}
+              nextAction={nextAction}
+              isSaving={step === "saving"}
+              onStageChange={setInitialStage}
+              onNextActionChange={setNextAction}
+              onBack={() => setStep("reviewing")}
+              onCancel={onDismiss}
+              onSave={() => void handleSave(pendingImport, initialStage, nextAction.trim())}
             />
           ) : null}
         </div>

--- a/src/app/components/dashboard/HotOpportunities.tsx
+++ b/src/app/components/dashboard/HotOpportunities.tsx
@@ -31,7 +31,7 @@ export function HotOpportunities({ opportunities, isLoading }: HotOpportunitiesP
       {!isLoading && opportunities.length === 0 && (
         <div className="rounded-lg border border-dashed border-neutral-200 dark:border-neutral-800 p-4 text-center">
           <p className="text-sm text-neutral-500 dark:text-neutral-400">
-            No unapplied roles yet. Add roles via Companies.
+            No hot opportunities yet. Import a job link or add a role in System to start surfacing stronger bets here.
           </p>
         </div>
       )}

--- a/src/app/components/dashboard/TodayPanel.tsx
+++ b/src/app/components/dashboard/TodayPanel.tsx
@@ -41,7 +41,7 @@ export function TodayPanel({ actions, isLoading }: TodayPanelProps) {
       {!isLoading && queuedActions.length === 0 && (
         <div className="rounded-lg border border-dashed border-neutral-200 dark:border-neutral-800 p-4 text-center">
           <p className="text-sm text-neutral-500 dark:text-neutral-400">
-            No additional actions are queued after the current top priority.
+            The hero action is your only priority right now. Finish it, or add more pipeline data if you want the queue to refill.
           </p>
         </div>
       )}

--- a/src/app/components/job-os/JobOsLayout.tsx
+++ b/src/app/components/job-os/JobOsLayout.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "react-router";
+import { NavLink, useLocation } from "react-router";
 import {
   Building2,
   FileSpreadsheet,
@@ -12,13 +12,15 @@ import { AppNavbar } from "../AppNavbar";
 import { useApp } from "../../context";
 import { useJobOsSyncSnapshot } from "../../services/jobOsSync";
 
-const NAV_ITEMS = [
+const PIPELINE_NAV_ITEMS = [
+  { to: "/job-os/applications", label: "Applications", icon: FileSpreadsheet },
+  { to: "/job-os/outreach", label: "Outreach", icon: Megaphone },
+];
+
+const SYSTEM_NAV_ITEMS = [
   { to: "/job-os/assets", label: "Assets", icon: FolderOpen },
   { to: "/job-os/companies", label: "Companies", icon: Building2 },
   { to: "/job-os/roles", label: "Roles", icon: FileText },
-  { to: "/job-os/applications", label: "Applications", icon: FileSpreadsheet },
-  { to: "/job-os/outreach", label: "Outreach", icon: Megaphone },
-  { to: "/cv-optimizer", label: "CV Optimizer", icon: WandSparkles },
   { to: "/job-os/settings", label: "Settings", icon: Settings },
 ];
 
@@ -39,9 +41,15 @@ export function JobOsLayout({
 }) {
   const { session } = useApp();
   const jobOsSync = useJobOsSyncSnapshot();
+  const location = useLocation();
   const lastSyncedLabel = jobOsSync.lastSyncedAt
     ? new Date(jobOsSync.lastSyncedAt).toLocaleString()
     : "not yet synced";
+  const inPipelineContext =
+    location.pathname === "/job-os" ||
+    location.pathname.startsWith("/job-os/applications") ||
+    location.pathname.startsWith("/job-os/outreach");
+  const navItems = inPipelineContext ? PIPELINE_NAV_ITEMS : SYSTEM_NAV_ITEMS;
 
   const settingsContent = session ? (
     <div className="rounded-md bg-white p-4 text-sm dark:bg-neutral-950">
@@ -70,9 +78,9 @@ export function JobOsLayout({
         settingsContent={settingsContent}
       />
       <div className="border-b border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
-        <div className="max-w-[1800px] mx-auto px-6 py-3">
+        <div className="max-w-[1800px] mx-auto flex flex-wrap items-center justify-between gap-3 px-6 py-3">
           <nav className="flex flex-wrap gap-2">
-            {NAV_ITEMS.map((item) => {
+            {navItems.map((item) => {
               const Icon = item.icon;
               return (
                 <NavLink
@@ -92,6 +100,15 @@ export function JobOsLayout({
               );
             })}
           </nav>
+          {!inPipelineContext ? (
+            <NavLink
+              to="/cv-optimizer"
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-neutral-500 transition-colors hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
+            >
+              <WandSparkles className="h-3.5 w-3.5" />
+              CV Optimizer
+            </NavLink>
+          ) : null}
         </div>
       </div>
       <main className="max-w-[1800px] mx-auto px-6 py-6 space-y-4">

--- a/src/app/components/job-os/JobOsPipelineBoard.tsx
+++ b/src/app/components/job-os/JobOsPipelineBoard.tsx
@@ -1,0 +1,148 @@
+import { CalendarDays, FileText, MoveRight } from "lucide-react";
+import { Badge } from "../ui/badge";
+import type { ApplicationStatus, JobOsApplication, JobOsCompany, JobOsRole } from "../../types/jobOs";
+
+export const APPLICATION_STATUS_LABELS: Record<ApplicationStatus, string> = {
+  sent: "Submitted",
+  screen: "Screening",
+  case: "Case Study",
+  interview: "Interview",
+  final: "Final Round",
+  offer: "Offer",
+  rejected: "Rejected",
+  ghosted: "Ghosted",
+};
+
+export const APPLICATION_STAGE_GROUPS = {
+  active: {
+    label: "Active",
+    description: "Fresh submissions and live early-stage progress.",
+    statuses: ["sent", "screen", "case"] as ApplicationStatus[],
+  },
+  interviewing: {
+    label: "Interviewing",
+    description: "Processes that need tighter follow-through.",
+    statuses: ["interview", "final", "offer"] as ApplicationStatus[],
+  },
+  closed: {
+    label: "Closed",
+    description: "Finished outcomes kept for reference and cleanup.",
+    statuses: ["rejected", "ghosted"] as ApplicationStatus[],
+  },
+} as const;
+
+type ApplicationStageGroup = keyof typeof APPLICATION_STAGE_GROUPS;
+
+interface JobOsPipelineBoardProps {
+  applications: JobOsApplication[];
+  companiesById: Map<string, JobOsCompany>;
+  rolesById: Map<string, JobOsRole>;
+  group: ApplicationStageGroup;
+  onSelectApplication: (application: JobOsApplication) => void;
+}
+
+function JobOsPipelineCard({
+  application,
+  companyName,
+  roleTitle,
+  onClick,
+}: {
+  application: JobOsApplication;
+  companyName: string;
+  roleTitle: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full rounded-xl border border-border bg-card p-3 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-md"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-semibold text-foreground">
+            {companyName}
+          </div>
+          <div className="truncate text-xs text-muted-foreground">
+            {roleTitle}
+          </div>
+        </div>
+        <MoveRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+        <span className="inline-flex items-center gap-1">
+          <CalendarDays className="h-3.5 w-3.5" />
+          {new Date(application.dateApplied).toLocaleDateString()}
+        </span>
+        {application.tailoredCvUpdatedAt ? (
+          <Badge variant="outline" className="rounded-full text-[10px]">
+            CV tailored
+          </Badge>
+        ) : null}
+        {application.nextAction ? (
+          <Badge variant="outline" className="rounded-full text-[10px]">
+            {application.nextAction}
+          </Badge>
+        ) : null}
+        {application.notes ? <FileText className="h-3.5 w-3.5" /> : null}
+      </div>
+    </button>
+  );
+}
+
+export function JobOsPipelineBoard({
+  applications,
+  companiesById,
+  rolesById,
+  group,
+  onSelectApplication,
+}: JobOsPipelineBoardProps) {
+  const visibleStatuses = APPLICATION_STAGE_GROUPS[group].statuses;
+
+  return (
+    <div className="grid grid-cols-1 gap-3 xl:grid-cols-3">
+      {visibleStatuses.map((status) => {
+        const stageApplications = applications.filter((application) => application.status === status);
+        return (
+          <section
+            key={status}
+            className="flex min-w-0 flex-col rounded-2xl border border-border/70 bg-background/70 p-3 dark:bg-background/30"
+          >
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <div>
+                <h3 className="text-sm font-semibold text-foreground">
+                  {APPLICATION_STATUS_LABELS[status]}
+                </h3>
+                <p className="text-xs text-muted-foreground">
+                  {stageApplications.length} application{stageApplications.length === 1 ? "" : "s"}
+                </p>
+              </div>
+              <Badge variant="outline" className="rounded-full px-2.5 py-1 text-[11px]">
+                {stageApplications.length}
+              </Badge>
+            </div>
+
+            <div className="space-y-2 rounded-xl border border-dashed border-border/60 bg-background/60 p-2 lg:max-h-[calc(100vh-24rem)] lg:overflow-y-auto">
+              {stageApplications.length > 0 ? (
+                stageApplications.map((application) => (
+                  <JobOsPipelineCard
+                    key={application.id}
+                    application={application}
+                    companyName={companiesById.get(application.companyId)?.name ?? "Unknown company"}
+                    roleTitle={rolesById.get(application.roleId)?.title ?? "Unknown role"}
+                    onClick={() => onSelectApplication(application)}
+                  />
+                ))
+              ) : (
+                <div className="rounded-xl border border-dashed border-border/60 px-4 py-6 text-center text-sm text-muted-foreground">
+                  No applications in this stage.
+                </div>
+              )}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/components/job-os/PasteLinkImportDialog.tsx
+++ b/src/app/components/job-os/PasteLinkImportDialog.tsx
@@ -9,6 +9,10 @@ import { Button } from "../ui/button";
 import { PasteLinkInputStep } from "./PasteLinkInputStep";
 import { PasteLinkReviewStep } from "./PasteLinkReviewStep";
 import {
+  PasteLinkNextActionStep,
+  type InitialImportStage,
+} from "./PasteLinkNextActionStep";
+import {
   parseFromInput,
   normalizeImportResult,
 } from "../../services/ingestion/companyIngestionService";
@@ -18,9 +22,22 @@ import type {
   NormalizedCompanyDraft,
   NormalizedRoleDraft,
 } from "../../services/ingestion/types";
-import type { JobOsCompany, JobOsRole } from "../../types/jobOs";
+import type { JobOsApplication, JobOsCompany, JobOsRole } from "../../types/jobOs";
 
-type DialogStep = "input" | "analyzing" | "reviewing" | "saving" | "success";
+type DialogStep =
+  | "input"
+  | "analyzing"
+  | "reviewing"
+  | "next_action"
+  | "saving"
+  | "success";
+
+interface PendingImportState {
+  companyDraft: NormalizedCompanyDraft;
+  roleDraft: NormalizedRoleDraft | undefined;
+  mode: ImportMode;
+  updateExistingId?: string;
+}
 
 interface PasteLinkImportDialogProps {
   open: boolean;
@@ -36,6 +53,9 @@ interface PasteLinkImportDialogProps {
   addRole: (
     payload: Omit<JobOsRole, "id" | "createdAt" | "updatedAt">
   ) => Promise<string | null>;
+  addApplication: (
+    payload: Omit<JobOsApplication, "id" | "createdAt" | "updatedAt">
+  ) => Promise<string | null>;
 }
 
 export function PasteLinkImportDialog({
@@ -45,18 +65,25 @@ export function PasteLinkImportDialog({
   addCompany,
   updateCompany,
   addRole,
+  addApplication,
 }: PasteLinkImportDialogProps) {
   const [step, setStep] = useState<DialogStep>("input");
   const [importMode, setImportMode] = useState<ImportMode>("company_and_role");
   const [parseError, setParseError] = useState<string | null>(null);
   const [result, setResult] = useState<NormalizedImportResult | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [pendingImport, setPendingImport] = useState<PendingImportState | null>(null);
+  const [initialStage, setInitialStage] = useState<InitialImportStage>("to_apply");
+  const [nextAction, setNextAction] = useState("Apply");
 
   function resetAndClose() {
     setStep("input");
     setResult(null);
     setParseError(null);
     setSuccessMessage(null);
+    setPendingImport(null);
+    setInitialStage("to_apply");
+    setNextAction("Apply");
     onClose();
   }
 
@@ -68,6 +95,7 @@ export function PasteLinkImportDialog({
     setImportMode(mode);
     setParseError(null);
     setStep("analyzing");
+
     try {
       const parsed = await parseFromInput({
         url,
@@ -84,73 +112,129 @@ export function PasteLinkImportDialog({
     }
   }
 
-  async function handleSave(
+  function handleReviewContinue(
     companyDraft: NormalizedCompanyDraft,
     roleDraft: NormalizedRoleDraft | undefined,
     mode: ImportMode,
     updateExistingId?: string
   ) {
+    setPendingImport({
+      companyDraft,
+      roleDraft,
+      mode,
+      updateExistingId,
+    });
+
+    if (mode === "company_and_role" && roleDraft) {
+      setInitialStage(roleDraft.status === "applied" ? "applied" : "to_apply");
+      setNextAction(roleDraft.nextAction?.trim() || "Apply");
+      setStep("next_action");
+      return;
+    }
+
+    setInitialStage("saved");
+    setNextAction("Research");
+    void handleSave({
+      companyDraft,
+      roleDraft,
+      mode,
+      updateExistingId,
+    }, "saved", "Research");
+  }
+
+  async function handleSave(
+    pending: PendingImportState,
+    stage: InitialImportStage,
+    action: string
+  ) {
     setStep("saving");
+
     try {
-      // Strip fields not in Omit<JobOsCompany, "id"|"createdAt"|"updatedAt">
       const {
         englishFirst,
-        sourceType: cSourceType,
+        sourceType: companySourceType,
         ...coreCompany
-      } = companyDraft;
+      } = pending.companyDraft;
 
       const companyPayload: Omit<JobOsCompany, "id" | "createdAt" | "updatedAt"> = {
         ...coreCompany,
         englishFirst: (englishFirst as JobOsCompany["englishFirst"]) ?? undefined,
-        sourceType: (cSourceType as JobOsCompany["sourceType"]) ?? undefined,
+        sourceType: (companySourceType as JobOsCompany["sourceType"]) ?? undefined,
       };
 
       let companyId: string | null;
-      if (updateExistingId) {
-        await updateCompany(updateExistingId, companyPayload);
-        companyId = updateExistingId;
+      if (pending.updateExistingId) {
+        await updateCompany(pending.updateExistingId, companyPayload);
+        companyId = pending.updateExistingId;
       } else {
         companyId = await addCompany(companyPayload);
       }
 
       const parts: string[] = [
-        updateExistingId
-          ? `Updated "${companyDraft.name}".`
-          : `Company "${companyDraft.name}" created.`,
+        pending.updateExistingId
+          ? `Updated "${pending.companyDraft.name}".`
+          : `Company "${pending.companyDraft.name}" created.`,
       ];
 
-      if (mode === "company_and_role" && roleDraft && companyId) {
+      if (pending.mode === "company_and_role" && pending.roleDraft && companyId) {
         const {
-          sourceType: rSourceType,
+          sourceType: roleSourceType,
           ...coreRole
-        } = roleDraft;
+        } = pending.roleDraft;
+
         const rolePayload: Omit<JobOsRole, "id" | "createdAt" | "updatedAt"> = {
           ...coreRole,
           companyId,
-          sourceType: (rSourceType as JobOsRole["sourceType"]) ?? undefined,
+          status: stage === "applied" ? "applied" : "to_apply",
+          nextAction: action,
+          sourceType: (roleSourceType as JobOsRole["sourceType"]) ?? undefined,
         };
-        await addRole(rolePayload);
-        parts.push(`Role "${roleDraft.title}" added.`);
+
+        const roleId = await addRole(rolePayload);
+        parts.push(`Role "${pending.roleDraft.title}" added.`);
+
+        if (stage === "applied" && roleId) {
+          await addApplication({
+            companyId,
+            roleId,
+            dateApplied: new Date().toISOString().slice(0, 10),
+            channel: "Imported link",
+            cvAssetId: undefined,
+            cvVersion: "",
+            status: "sent",
+            nextAction: action,
+            notes: "",
+            latestJobDescriptionId: undefined,
+            latestCvTailoringRunId: undefined,
+            tailoredCvHeadline: "",
+            tailoredCvSummary: "",
+            tailoredCvText: "",
+            tailoredCvUpdatedAt: undefined,
+          });
+          parts.push("Application created.");
+        } else {
+          parts.push(`Next action set to "${action}".`);
+        }
       }
 
       setSuccessMessage(parts.join(" "));
       setStep("success");
     } catch {
       setParseError("Failed to save. Please try again.");
-      setStep("reviewing");
+      setStep(pending.mode === "company_and_role" && pending.roleDraft ? "next_action" : "reviewing");
     }
   }
 
   return (
     <Dialog
       open={open}
-      onOpenChange={(v) => {
-        if (!v) resetAndClose();
+      onOpenChange={(value) => {
+        if (!value) resetAndClose();
       }}
     >
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Paste Link — Target Ingestion</DialogTitle>
+          <DialogTitle>Paste Link - Target Ingestion</DialogTitle>
         </DialogHeader>
 
         {(step === "input" || step === "analyzing") && (
@@ -162,14 +246,27 @@ export function PasteLinkImportDialog({
           />
         )}
 
-        {(step === "reviewing" || step === "saving") && result && (
+        {step === "reviewing" && result && (
           <PasteLinkReviewStep
             result={result}
             defaultMode={importMode}
-            isSaving={step === "saving"}
-            onSave={handleSave}
+            onContinue={handleReviewContinue}
             onBack={() => setStep("input")}
             onCancel={resetAndClose}
+          />
+        )}
+
+        {(step === "next_action" || step === "saving") && pendingImport && (
+          <PasteLinkNextActionStep
+            roleTitle={pendingImport.roleDraft?.title}
+            stage={initialStage}
+            nextAction={nextAction}
+            isSaving={step === "saving"}
+            onStageChange={setInitialStage}
+            onNextActionChange={setNextAction}
+            onBack={() => setStep("reviewing")}
+            onCancel={resetAndClose}
+            onSave={() => void handleSave(pendingImport, initialStage, nextAction.trim())}
           />
         )}
 
@@ -185,6 +282,9 @@ export function PasteLinkImportDialog({
                   setResult(null);
                   setSuccessMessage(null);
                   setParseError(null);
+                  setPendingImport(null);
+                  setInitialStage("to_apply");
+                  setNextAction("Apply");
                 }}
               >
                 Import Another

--- a/src/app/components/job-os/PasteLinkImportDialog.tsx
+++ b/src/app/components/job-os/PasteLinkImportDialog.tsx
@@ -14,8 +14,10 @@ import {
 } from "./PasteLinkNextActionStep";
 import {
   parseFromInput,
+  mergeImportEnrichment,
   normalizeImportResult,
 } from "../../services/ingestion/companyIngestionService";
+import { requestRemoteJobImportEnrichment } from "../../services/ingestion/jobImportEnrichmentGateway";
 import type {
   ImportMode,
   NormalizedImportResult,
@@ -27,6 +29,7 @@ import type { JobOsApplication, JobOsCompany, JobOsRole } from "../../types/jobO
 type DialogStep =
   | "input"
   | "analyzing"
+  | "enriching"
   | "reviewing"
   | "next_action"
   | "saving"
@@ -102,7 +105,17 @@ export function PasteLinkImportDialog({
         pastedText: pastedText || undefined,
       });
       const normalized = normalizeImportResult(parsed, url, existingCompanies);
-      setResult(normalized);
+      setStep("enriching");
+
+      const enrichment = await requestRemoteJobImportEnrichment({
+        parsed,
+        normalized,
+        sourceUrl: url,
+      });
+
+      setResult(
+        enrichment ? mergeImportEnrichment(normalized, enrichment) : normalized
+      );
       setStep("reviewing");
     } catch {
       setParseError(
@@ -182,11 +195,32 @@ export function PasteLinkImportDialog({
           ...coreRole
         } = pending.roleDraft;
 
+        const roleAiEnrichment = coreRole.aiEnrichment
+          ? {
+              ...coreRole.aiEnrichment,
+              normalized: {
+                ...coreRole.aiEnrichment.normalized,
+                role: {
+                  ...coreRole.aiEnrichment.normalized?.role,
+                  nextAction: action,
+                },
+              },
+              enriched: {
+                ...coreRole.aiEnrichment.enriched,
+                role: {
+                  ...coreRole.aiEnrichment.enriched?.role,
+                  nextBestAction: action as typeof coreRole.aiEnrichment.enriched.role.nextBestAction,
+                },
+              },
+            }
+          : undefined;
+
         const rolePayload: Omit<JobOsRole, "id" | "createdAt" | "updatedAt"> = {
           ...coreRole,
           companyId,
           status: stage === "applied" ? "applied" : "to_apply",
           nextAction: action,
+          aiEnrichment: roleAiEnrichment,
           sourceType: (roleSourceType as JobOsRole["sourceType"]) ?? undefined,
         };
 
@@ -210,6 +244,7 @@ export function PasteLinkImportDialog({
             tailoredCvSummary: "",
             tailoredCvText: "",
             tailoredCvUpdatedAt: undefined,
+            aiEnrichment: roleAiEnrichment,
           });
           parts.push("Application created.");
         } else {
@@ -244,6 +279,19 @@ export function PasteLinkImportDialog({
             onAnalyze={handleAnalyze}
             onCancel={resetAndClose}
           />
+        )}
+
+        {step === "enriching" && (
+          <div className="py-12 text-center space-y-3">
+            <div className="text-sm font-medium text-foreground">
+              Enriching import with AI
+            </div>
+            <p className="text-sm text-muted-foreground max-w-md mx-auto">
+              Deterministic parsing is complete. JobSprint is adding structured
+              hints for title, track, seniority, and next best action before
+              review.
+            </p>
+          </div>
         )}
 
         {step === "reviewing" && result && (

--- a/src/app/components/job-os/PasteLinkNextActionStep.tsx
+++ b/src/app/components/job-os/PasteLinkNextActionStep.tsx
@@ -1,6 +1,8 @@
+import { CircleHelp } from "lucide-react";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { cn } from "../ui/utils";
 
 export type InitialImportStage = "saved" | "to_apply" | "applied";
@@ -57,6 +59,13 @@ export function PasteLinkNextActionStep({
   onCancel,
   onSave,
 }: PasteLinkNextActionStepProps) {
+  function handleNextActionKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter" && !isSaving && nextAction.trim()) {
+      event.preventDefault();
+      onSave();
+    }
+  }
+
   return (
     <div className="space-y-5">
       <div className="space-y-1">
@@ -70,10 +79,23 @@ export function PasteLinkNextActionStep({
 
       <section className="space-y-3">
         <div className="space-y-1">
-          <Label>Initial Stage</Label>
-          <p className="text-xs text-muted-foreground">
-            Keep this lightweight: one starting point, one immediate action.
-          </p>
+          <div className="flex items-center gap-2">
+            <Label>Initial Stage</Label>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className="inline-flex text-muted-foreground transition-colors hover:text-foreground"
+                  aria-label="How initial stage works"
+                >
+                  <CircleHelp className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                Pick the starting lane. You can change it later if the workflow changes.
+              </TooltipContent>
+            </Tooltip>
+          </div>
         </div>
         <div className="grid gap-3 md:grid-cols-3">
           {STAGE_OPTIONS.map((option) => {
@@ -104,10 +126,23 @@ export function PasteLinkNextActionStep({
 
       <section className="space-y-3">
         <div className="space-y-1">
-          <Label htmlFor="paste-link-next-action">Next Action</Label>
-          <p className="text-xs text-muted-foreground">
-            This becomes the visible operating cue after the import is saved.
-          </p>
+          <div className="flex items-center gap-2">
+            <Label htmlFor="paste-link-next-action">Next Action</Label>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className="inline-flex text-muted-foreground transition-colors hover:text-foreground"
+                  aria-label="How next action works"
+                >
+                  <CircleHelp className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                This becomes the first visible cue in your workflow after the import is saved.
+              </TooltipContent>
+            </Tooltip>
+          </div>
         </div>
 
         <div className="flex flex-wrap gap-2">
@@ -132,9 +167,13 @@ export function PasteLinkNextActionStep({
           id="paste-link-next-action"
           value={nextAction}
           onChange={(event) => onNextActionChange(event.target.value)}
-          placeholder="What should happen next?"
+          onKeyDown={handleNextActionKeyDown}
+          placeholder="e.g. Tailor CV for this role"
           disabled={isSaving}
         />
+        <p className="text-xs text-muted-foreground">
+          Press Enter to save once the action looks right.
+        </p>
       </section>
 
       <div className="flex gap-2 justify-end pt-2 border-t">

--- a/src/app/components/job-os/PasteLinkNextActionStep.tsx
+++ b/src/app/components/job-os/PasteLinkNextActionStep.tsx
@@ -1,0 +1,153 @@
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { cn } from "../ui/utils";
+
+export type InitialImportStage = "saved" | "to_apply" | "applied";
+
+const STAGE_OPTIONS: Array<{
+  value: InitialImportStage;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "saved",
+    label: "Saved",
+    description: "Capture the role now and decide what to do next from the pipeline.",
+  },
+  {
+    value: "to_apply",
+    label: "To Apply",
+    description: "Mark it as ready for execution without creating an application yet.",
+  },
+  {
+    value: "applied",
+    label: "Applied",
+    description: "Create the first application record immediately and carry the next step with it.",
+  },
+];
+
+const NEXT_ACTION_OPTIONS = [
+  "Tailor CV",
+  "Apply",
+  "Research",
+  "Follow up",
+] as const;
+
+interface PasteLinkNextActionStepProps {
+  roleTitle?: string;
+  stage: InitialImportStage;
+  nextAction: string;
+  isSaving: boolean;
+  onStageChange: (stage: InitialImportStage) => void;
+  onNextActionChange: (nextAction: string) => void;
+  onBack: () => void;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+export function PasteLinkNextActionStep({
+  roleTitle,
+  stage,
+  nextAction,
+  isSaving,
+  onStageChange,
+  onNextActionChange,
+  onBack,
+  onCancel,
+  onSave,
+}: PasteLinkNextActionStepProps) {
+  return (
+    <div className="space-y-5">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold">Set the first workflow move</h3>
+        <p className="text-sm text-muted-foreground">
+          {roleTitle
+            ? `Choose how ${roleTitle} should enter the pipeline and what happens next.`
+            : "Choose how this import should enter the pipeline and what happens next."}
+        </p>
+      </div>
+
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <Label>Initial Stage</Label>
+          <p className="text-xs text-muted-foreground">
+            Keep this lightweight: one starting point, one immediate action.
+          </p>
+        </div>
+        <div className="grid gap-3 md:grid-cols-3">
+          {STAGE_OPTIONS.map((option) => {
+            const active = stage === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => onStageChange(option.value)}
+                disabled={isSaving}
+                className={cn(
+                  "rounded-lg border px-4 py-3 text-left transition-colors",
+                  "hover:border-primary/60 hover:bg-primary/5",
+                  active
+                    ? "border-primary bg-primary/10 shadow-sm"
+                    : "border-border bg-background"
+                )}
+              >
+                <div className="text-sm font-medium">{option.label}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {option.description}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <Label htmlFor="paste-link-next-action">Next Action</Label>
+          <p className="text-xs text-muted-foreground">
+            This becomes the visible operating cue after the import is saved.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {NEXT_ACTION_OPTIONS.map((option) => {
+            const active = nextAction === option;
+            return (
+              <Button
+                key={option}
+                type="button"
+                variant={active ? "default" : "outline"}
+                size="sm"
+                disabled={isSaving}
+                onClick={() => onNextActionChange(option)}
+              >
+                {option}
+              </Button>
+            );
+          })}
+        </div>
+
+        <Input
+          id="paste-link-next-action"
+          value={nextAction}
+          onChange={(event) => onNextActionChange(event.target.value)}
+          placeholder="What should happen next?"
+          disabled={isSaving}
+        />
+      </section>
+
+      <div className="flex gap-2 justify-end pt-2 border-t">
+        <Button variant="outline" onClick={onBack} disabled={isSaving}>
+          Back
+        </Button>
+        <Button variant="outline" onClick={onCancel} disabled={isSaving}>
+          Cancel
+        </Button>
+        <Button onClick={onSave} disabled={!nextAction.trim() || isSaving}>
+          {isSaving ? "Saving..." : "Save Import"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/job-os/PasteLinkReviewStep.tsx
+++ b/src/app/components/job-os/PasteLinkReviewStep.tsx
@@ -17,6 +17,12 @@ import type {
   ImportMode,
 } from "../../services/ingestion/types";
 import type {
+  AiImportCompanySizeBand,
+  AiImportCompanyStage,
+  AiImportFieldConfidence,
+  AiImportNextBestAction,
+  AiImportReviewFlag,
+  AiImportSeniority,
   CompanyPriority,
   CompanyStatus,
   JobTrack,
@@ -44,6 +50,49 @@ const ROLE_STATUSES: RoleStatus[] = [
 ];
 
 const TRACKS: JobTrack[] = ["TPM", "Product Engineer", "Systems PM"];
+const SENIORITY_OPTIONS: AiImportSeniority[] = [
+  "Junior",
+  "Middle",
+  "Senior",
+  "Lead",
+  "Staff",
+  "Principal",
+  "Director",
+  "VP",
+  "Executive",
+  "Unknown",
+];
+const COMPANY_SIZE_BANDS: AiImportCompanySizeBand[] = [
+  "1-10",
+  "11-50",
+  "51-200",
+  "201-500",
+  "501-1000",
+  "1001-5000",
+  "5000+",
+  "Unknown",
+];
+const COMPANY_STAGES: AiImportCompanyStage[] = [
+  "Pre-seed",
+  "Seed",
+  "Series A",
+  "Series B",
+  "Series C+",
+  "Private Growth",
+  "Bootstrapped",
+  "Public",
+  "Enterprise",
+  "Unknown",
+];
+const NEXT_BEST_ACTIONS: AiImportNextBestAction[] = [
+  "Research",
+  "Tailor CV",
+  "Apply",
+  "Follow up",
+  "Network",
+  "Archive",
+];
+const FIT_SCORES: Array<1 | 2 | 3 | 4 | 5> = [1, 2, 3, 4, 5];
 
 interface PasteLinkReviewStepProps {
   result: NormalizedImportResult;
@@ -86,6 +135,50 @@ export function PasteLinkReviewStep({
     setRole((prev) => (prev ? { ...prev, [key]: value } : prev));
   }
 
+  function setCompanyAiField(
+    field: "industry" | "sizeBand" | "companyStage",
+    value: string
+  ) {
+    setCompany((prev) => ({
+      ...prev,
+      aiEnrichment: {
+        ...prev.aiEnrichment,
+        schemaVersion: prev.aiEnrichment?.schemaVersion ?? "ai_import_v1",
+        enriched: {
+          ...prev.aiEnrichment?.enriched,
+          company: {
+            ...prev.aiEnrichment?.enriched?.company,
+            [field]: value,
+          },
+        },
+      },
+    }));
+  }
+
+  function setRoleAiField(
+    field: "track" | "seniority" | "nextBestAction",
+    value: string
+  ) {
+    setRole((prev) =>
+      prev
+        ? {
+            ...prev,
+            aiEnrichment: {
+              ...prev.aiEnrichment,
+              schemaVersion: prev.aiEnrichment?.schemaVersion ?? "ai_import_v1",
+              enriched: {
+                ...prev.aiEnrichment?.enriched,
+                role: {
+                  ...prev.aiEnrichment?.enriched?.role,
+                  [field]: value,
+                },
+              },
+            },
+          }
+        : prev
+    );
+  }
+
   function handleContinue(includeRole: boolean) {
     const updateId =
       result.duplicateMatch && duplicateAction === "update"
@@ -102,6 +195,22 @@ export function PasteLinkReviewStep({
 
   const hasRole = !!role;
   const showRoleFields = mode === "company_and_role" && hasRole;
+  const activeAi = role?.aiEnrichment ?? company.aiEnrichment ?? result.aiEnrichment;
+  const aiReviewFlags = activeAi?.reviewFlags ?? [];
+  const aiModel = activeAi?.model;
+  const roleConfidence = activeAi?.confidence?.fields ?? {};
+  const companyStage =
+    company.aiEnrichment?.enriched?.company?.companyStage ?? "Unknown";
+  const companySizeBand =
+    company.aiEnrichment?.enriched?.company?.sizeBand ?? "Unknown";
+  const aiIndustry =
+    company.aiEnrichment?.enriched?.company?.industry ?? "Unknown";
+  const aiRoleTrack =
+    role?.aiEnrichment?.enriched?.role?.track ?? "Unknown";
+  const aiSeniority =
+    role?.aiEnrichment?.enriched?.role?.seniority ?? "Unknown";
+  const aiNextBestAction =
+    role?.aiEnrichment?.enriched?.role?.nextBestAction ?? "Research";
 
   return (
     <div className="space-y-5">
@@ -109,6 +218,21 @@ export function PasteLinkReviewStep({
         confidence={result.confidence}
         platform={result.sourcePlatform}
       />
+
+      {result.aiEnrichment && (
+        <div className="rounded border border-blue-200 dark:border-blue-900/50 bg-blue-50/80 dark:bg-blue-950/20 px-3 py-2 space-y-1">
+          <div className="text-sm font-medium text-blue-800 dark:text-blue-200">
+            AI enrichment applied
+          </div>
+          <div className="text-xs text-blue-700/90 dark:text-blue-300/80">
+            Review is prefilled with structured suggestions for role classification and next-step planning.
+            {aiModel ? ` Model: ${aiModel}.` : ""}
+            {aiReviewFlags.length > 0
+              ? ` ${aiReviewFlags.length} item${aiReviewFlags.length === 1 ? "" : "s"} flagged for review.`
+              : ""}
+          </div>
+        </div>
+      )}
 
       {result.duplicateMatch && (
         <DuplicateMatchAlert
@@ -119,8 +243,13 @@ export function PasteLinkReviewStep({
         />
       )}
 
-      <section className="space-y-3">
-        <h3 className="text-sm font-semibold border-b pb-1">Company</h3>
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold border-b pb-1">Extracted from source</h3>
+          <p className="text-xs text-muted-foreground">
+            Confirm the facts pulled from the job page or pasted description.
+          </p>
+        </div>
         <div className="grid md:grid-cols-2 gap-3">
           <div className="space-y-1.5">
             <Label htmlFor="rv-name">Company Name *</Label>
@@ -148,25 +277,6 @@ export function PasteLinkReviewStep({
               value={company.careersUrl ?? ""}
               onChange={(event) => setC("careersUrl", event.target.value || undefined)}
               placeholder="https://example.com/careers"
-            />
-          </div>
-
-          <div className="space-y-1.5">
-            <Label htmlFor="rv-industry">Industry</Label>
-            <Input
-              id="rv-industry"
-              value={company.industry}
-              onChange={(event) => setC("industry", event.target.value)}
-            />
-          </div>
-
-          <div className="space-y-1.5">
-            <Label htmlFor="rv-size">Size</Label>
-            <Input
-              id="rv-size"
-              value={company.size}
-              onChange={(event) => setC("size", event.target.value)}
-              placeholder="e.g. 51-200"
             />
           </div>
 
@@ -257,7 +367,7 @@ export function PasteLinkReviewStep({
       {hasRole && (
         <section className="space-y-3">
           <div className="flex items-center justify-between border-b pb-1">
-            <h3 className="text-sm font-semibold">Role</h3>
+            <h3 className="text-sm font-semibold">Extracted role facts</h3>
             <div className="flex gap-4 text-sm">
               <label className="flex items-center gap-1.5 cursor-pointer">
                 <input
@@ -322,44 +432,6 @@ export function PasteLinkReviewStep({
                 />
               </div>
 
-              <div className="space-y-1.5">
-                <Label>Track</Label>
-                <Select
-                  value={role.track}
-                  onValueChange={(value) => setR("track", value as JobTrack)}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {TRACKS.map((track) => (
-                      <SelectItem key={track} value={track}>
-                        {track}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="space-y-1.5">
-                <Label>Role Status</Label>
-                <Select
-                  value={role.status}
-                  onValueChange={(value) => setR("status", value as RoleStatus)}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {ROLE_STATUSES.map((status) => (
-                      <SelectItem key={status} value={status}>
-                        {status}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
               {role.jobDescription && (
                 <div className="md:col-span-2 space-y-1.5">
                   <Label>Job Description Preview</Label>
@@ -373,6 +445,245 @@ export function PasteLinkReviewStep({
           )}
         </section>
       )}
+
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold border-b pb-1">AI inferred / recommended</h3>
+          <p className="text-xs text-muted-foreground">
+            These suggestions are editable and can help route the import into the right workflow faster.
+          </p>
+        </div>
+
+        {activeAi ? (
+          <>
+            <div className="grid md:grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <FieldLabel
+                  label="Industry"
+                  confidence={roleConfidence.industry}
+                />
+                <Input
+                  value={company.industry}
+                  onChange={(event) => {
+                    setC("industry", event.target.value);
+                    setCompanyAiField("industry", event.target.value);
+                  }}
+                  placeholder={aiIndustry !== "Unknown" ? aiIndustry : "Industry"}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <FieldLabel
+                  label="Company size band"
+                  confidence={roleConfidence.companySizeBand}
+                />
+                <Select
+                  value={companySizeBand}
+                  onValueChange={(value) => {
+                    setC("size", value === "Unknown" ? "" : value);
+                    setCompanyAiField("sizeBand", value);
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {COMPANY_SIZE_BANDS.map((band) => (
+                      <SelectItem key={band} value={band}>
+                        {band}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <FieldLabel
+                  label="Company stage"
+                  confidence={roleConfidence.companyStage}
+                />
+                <Select
+                  value={companyStage}
+                  onValueChange={(value) => setCompanyAiField("companyStage", value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {COMPANY_STAGES.map((stage) => (
+                      <SelectItem key={stage} value={stage}>
+                        {stage}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <FieldLabel
+                  label="Priority band"
+                  confidence={roleConfidence.priorityBand}
+                />
+                <Select
+                  value={company.priority}
+                  onValueChange={(value) => setC("priority", value as CompanyPriority)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="A">A</SelectItem>
+                    <SelectItem value="B">B</SelectItem>
+                    <SelectItem value="C">C</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {showRoleFields && role && (
+                <>
+                  <div className="space-y-1.5">
+                    <FieldLabel
+                      label="Role track"
+                      confidence={roleConfidence.roleTrack}
+                    />
+                    <Select
+                      value={role.track}
+                      onValueChange={(value) => {
+                        setR("track", value as JobTrack);
+                        setRoleAiField("track", value);
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {TRACKS.map((track) => (
+                          <SelectItem key={track} value={track}>
+                            {track}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {aiRoleTrack !== "Unknown" && (
+                      <p className="text-[11px] text-muted-foreground">
+                        AI suggested: {aiRoleTrack}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <FieldLabel
+                      label="Seniority"
+                      confidence={roleConfidence.seniority}
+                    />
+                    <Select
+                      value={aiSeniority}
+                      onValueChange={(value) => {
+                        setR("seniority", value === "Middle" ? "Mid" : value);
+                        setRoleAiField("seniority", value);
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {SENIORITY_OPTIONS.map((seniority) => (
+                          <SelectItem key={seniority} value={seniority}>
+                            {seniority}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <FieldLabel
+                      label="Fit score"
+                      confidence={roleConfidence.fitScore}
+                    />
+                    <Select
+                      value={String(role.fitScore)}
+                      onValueChange={(value) => setR("fitScore", Number(value) as 1 | 2 | 3 | 4 | 5)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {FIT_SCORES.map((score) => (
+                          <SelectItem key={score} value={String(score)}>
+                            {score}/5
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <Label>Role Status</Label>
+                    <Select
+                      value={role.status}
+                      onValueChange={(value) => setR("status", value as RoleStatus)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {ROLE_STATUSES.map((status) => (
+                          <SelectItem key={status} value={status}>
+                            {status}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="md:col-span-2 space-y-1.5">
+                    <FieldLabel
+                      label="Next best action"
+                      confidence={roleConfidence.nextBestAction}
+                    />
+                    <Select
+                      value={role.nextAction?.trim() || aiNextBestAction}
+                      onValueChange={(value) => {
+                        setR("nextAction", value);
+                        setRoleAiField("nextBestAction", value);
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {NEXT_BEST_ACTIONS.map((action) => (
+                          <SelectItem key={action} value={action}>
+                            {action}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </>
+              )}
+            </div>
+
+            {aiReviewFlags.length > 0 && (
+              <div className="rounded border border-amber-200 dark:border-amber-900/50 bg-amber-50/70 dark:bg-amber-950/20 px-3 py-3 space-y-2">
+                <div className="text-sm font-medium text-amber-900 dark:text-amber-200">
+                  Review flags
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {aiReviewFlags.map((flag) => (
+                    <ReviewFlagChip key={`${flag.code}-${flag.fieldPath ?? ""}`} flag={flag} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="rounded border border-dashed px-3 py-3 text-sm text-muted-foreground">
+            AI enrichment was not available for this import, so review is showing source-derived data only.
+          </div>
+        )}
+      </section>
 
       <div className="flex gap-2 justify-end pt-2 border-t">
         <Button variant="outline" onClick={onBack}>
@@ -391,6 +702,52 @@ export function PasteLinkReviewStep({
           </Button>
         )}
       </div>
+    </div>
+  );
+}
+
+function FieldLabel({
+  label,
+  confidence,
+}: {
+  label: string;
+  confidence?: AiImportFieldConfidence;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <Label>{label}</Label>
+      {confidence && <ConfidencePill confidence={confidence} />}
+    </div>
+  );
+}
+
+function ConfidencePill({ confidence }: { confidence: AiImportFieldConfidence }) {
+  const pct = Math.round(confidence.score * 100);
+  const tone =
+    confidence.level === "high"
+      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+      : confidence.level === "medium"
+        ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
+        : "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300";
+
+  return (
+    <span className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${tone}`}>
+      {pct}% {confidence.level}
+    </span>
+  );
+}
+
+function ReviewFlagChip({ flag }: { flag: AiImportReviewFlag }) {
+  const tone =
+    flag.severity === "warning"
+      ? "border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-300"
+      : flag.severity === "review"
+        ? "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-300"
+        : "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300";
+
+  return (
+    <div className={`rounded-md border px-2.5 py-1.5 text-xs ${tone}`}>
+      {flag.message}
     </div>
   );
 }

--- a/src/app/components/job-os/PasteLinkReviewStep.tsx
+++ b/src/app/components/job-os/PasteLinkReviewStep.tsx
@@ -16,7 +16,12 @@ import type {
   NormalizedRoleDraft,
   ImportMode,
 } from "../../services/ingestion/types";
-import type { CompanyPriority, CompanyStatus, JobTrack, RoleStatus } from "../../types/jobOs";
+import type {
+  CompanyPriority,
+  CompanyStatus,
+  JobTrack,
+  RoleStatus,
+} from "../../types/jobOs";
 import { ImportConfidenceBadge } from "./ImportConfidenceBadge";
 import { DuplicateMatchAlert } from "./DuplicateMatchAlert";
 
@@ -28,6 +33,7 @@ const COMPANY_STATUSES: CompanyStatus[] = [
   "Interviewing",
   "Closed",
 ];
+
 const ROLE_STATUSES: RoleStatus[] = [
   "to_apply",
   "applied",
@@ -36,13 +42,13 @@ const ROLE_STATUSES: RoleStatus[] = [
   "offer",
   "closed",
 ];
+
 const TRACKS: JobTrack[] = ["TPM", "Product Engineer", "Systems PM"];
 
 interface PasteLinkReviewStepProps {
   result: NormalizedImportResult;
   defaultMode: ImportMode;
-  isSaving: boolean;
-  onSave: (
+  onContinue: (
     companyDraft: NormalizedCompanyDraft,
     roleDraft: NormalizedRoleDraft | undefined,
     mode: ImportMode,
@@ -55,8 +61,7 @@ interface PasteLinkReviewStepProps {
 export function PasteLinkReviewStep({
   result,
   defaultMode,
-  isSaving,
-  onSave,
+  onContinue,
   onBack,
   onCancel,
 }: PasteLinkReviewStepProps) {
@@ -81,12 +86,13 @@ export function PasteLinkReviewStep({
     setRole((prev) => (prev ? { ...prev, [key]: value } : prev));
   }
 
-  function handleSave(includeRole: boolean) {
+  function handleContinue(includeRole: boolean) {
     const updateId =
       result.duplicateMatch && duplicateAction === "update"
         ? result.duplicateMatch.companyId
         : undefined;
-    onSave(
+
+    onContinue(
       company,
       includeRole ? role : undefined,
       includeRole ? "company_and_role" : "company_only",
@@ -99,13 +105,11 @@ export function PasteLinkReviewStep({
 
   return (
     <div className="space-y-5">
-      {/* Confidence + source badge */}
       <ImportConfidenceBadge
         confidence={result.confidence}
         platform={result.sourcePlatform}
       />
 
-      {/* Duplicate warning */}
       {result.duplicateMatch && (
         <DuplicateMatchAlert
           existingCompanyName={result.duplicateMatch.companyName}
@@ -115,7 +119,6 @@ export function PasteLinkReviewStep({
         />
       )}
 
-      {/* ── Company Fields ── */}
       <section className="space-y-3">
         <h3 className="text-sm font-semibold border-b pb-1">Company</h3>
         <div className="grid md:grid-cols-2 gap-3">
@@ -124,8 +127,7 @@ export function PasteLinkReviewStep({
             <Input
               id="rv-name"
               value={company.name}
-              onChange={(e) => setC("name", e.target.value)}
-              disabled={isSaving}
+              onChange={(event) => setC("name", event.target.value)}
             />
           </div>
 
@@ -134,11 +136,8 @@ export function PasteLinkReviewStep({
             <Input
               id="rv-website"
               value={company.website ?? ""}
-              onChange={(e) =>
-                setC("website", e.target.value || undefined)
-              }
+              onChange={(event) => setC("website", event.target.value || undefined)}
               placeholder="https://example.com"
-              disabled={isSaving}
             />
           </div>
 
@@ -147,11 +146,8 @@ export function PasteLinkReviewStep({
             <Input
               id="rv-careers"
               value={company.careersUrl ?? ""}
-              onChange={(e) =>
-                setC("careersUrl", e.target.value || undefined)
-              }
+              onChange={(event) => setC("careersUrl", event.target.value || undefined)}
               placeholder="https://example.com/careers"
-              disabled={isSaving}
             />
           </div>
 
@@ -160,8 +156,7 @@ export function PasteLinkReviewStep({
             <Input
               id="rv-industry"
               value={company.industry}
-              onChange={(e) => setC("industry", e.target.value)}
-              disabled={isSaving}
+              onChange={(event) => setC("industry", event.target.value)}
             />
           </div>
 
@@ -170,9 +165,8 @@ export function PasteLinkReviewStep({
             <Input
               id="rv-size"
               value={company.size}
-              onChange={(e) => setC("size", e.target.value)}
-              placeholder="e.g. 51–200"
-              disabled={isSaving}
+              onChange={(event) => setC("size", event.target.value)}
+              placeholder="e.g. 51-200"
             />
           </div>
 
@@ -181,10 +175,7 @@ export function PasteLinkReviewStep({
             <Input
               id="rv-location"
               value={company.location ?? ""}
-              onChange={(e) =>
-                setC("location", e.target.value || undefined)
-              }
-              disabled={isSaving}
+              onChange={(event) => setC("location", event.target.value || undefined)}
             />
           </div>
 
@@ -193,9 +184,8 @@ export function PasteLinkReviewStep({
             <Input
               id="rv-remote"
               value={company.remotePolicy}
-              onChange={(e) => setC("remotePolicy", e.target.value)}
+              onChange={(event) => setC("remotePolicy", event.target.value)}
               placeholder="Remote / Hybrid / On-site"
-              disabled={isSaving}
             />
           </div>
 
@@ -203,8 +193,7 @@ export function PasteLinkReviewStep({
             <Label>English-First</Label>
             <Select
               value={company.englishFirst ?? "Unknown"}
-              onValueChange={(v) => setC("englishFirst", v)}
-              disabled={isSaving}
+              onValueChange={(value) => setC("englishFirst", value)}
             >
               <SelectTrigger>
                 <SelectValue />
@@ -221,8 +210,7 @@ export function PasteLinkReviewStep({
             <Label>Priority</Label>
             <Select
               value={company.priority}
-              onValueChange={(v) => setC("priority", v as CompanyPriority)}
-              disabled={isSaving}
+              onValueChange={(value) => setC("priority", value as CompanyPriority)}
             >
               <SelectTrigger>
                 <SelectValue />
@@ -239,16 +227,15 @@ export function PasteLinkReviewStep({
             <Label>Status</Label>
             <Select
               value={company.status}
-              onValueChange={(v) => setC("status", v as CompanyStatus)}
-              disabled={isSaving}
+              onValueChange={(value) => setC("status", value as CompanyStatus)}
             >
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {COMPANY_STATUSES.map((s) => (
-                  <SelectItem key={s} value={s}>
-                    {s}
+                {COMPANY_STATUSES.map((status) => (
+                  <SelectItem key={status} value={status}>
+                    {status}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -261,14 +248,12 @@ export function PasteLinkReviewStep({
           <Textarea
             id="rv-notes"
             value={company.notes}
-            onChange={(e) => setC("notes", e.target.value)}
+            onChange={(event) => setC("notes", event.target.value)}
             rows={3}
-            disabled={isSaving}
           />
         </div>
       </section>
 
-      {/* ── Role Fields ── */}
       {hasRole && (
         <section className="space-y-3">
           <div className="flex items-center justify-between border-b pb-1">
@@ -282,7 +267,6 @@ export function PasteLinkReviewStep({
                   checked={mode === "company_only"}
                   onChange={() => setMode("company_only")}
                   className="accent-primary"
-                  disabled={isSaving}
                 />
                 Company only
               </label>
@@ -294,7 +278,6 @@ export function PasteLinkReviewStep({
                   checked={mode === "company_and_role"}
                   onChange={() => setMode("company_and_role")}
                   className="accent-primary"
-                  disabled={isSaving}
                 />
                 Include role
               </label>
@@ -308,8 +291,7 @@ export function PasteLinkReviewStep({
                 <Input
                   id="rv-role-title"
                   value={role.title}
-                  onChange={(e) => setR("title", e.target.value)}
-                  disabled={isSaving}
+                  onChange={(event) => setR("title", event.target.value)}
                 />
               </div>
 
@@ -318,8 +300,7 @@ export function PasteLinkReviewStep({
                 <Input
                   id="rv-role-url"
                   value={role.url}
-                  onChange={(e) => setR("url", e.target.value)}
-                  disabled={isSaving}
+                  onChange={(event) => setR("url", event.target.value)}
                 />
               </div>
 
@@ -328,8 +309,7 @@ export function PasteLinkReviewStep({
                 <Input
                   id="rv-role-location"
                   value={role.location}
-                  onChange={(e) => setR("location", e.target.value)}
-                  disabled={isSaving}
+                  onChange={(event) => setR("location", event.target.value)}
                 />
               </div>
 
@@ -338,8 +318,7 @@ export function PasteLinkReviewStep({
                 <Input
                   id="rv-seniority"
                   value={role.seniority}
-                  onChange={(e) => setR("seniority", e.target.value)}
-                  disabled={isSaving}
+                  onChange={(event) => setR("seniority", event.target.value)}
                 />
               </div>
 
@@ -347,16 +326,15 @@ export function PasteLinkReviewStep({
                 <Label>Track</Label>
                 <Select
                   value={role.track}
-                  onValueChange={(v) => setR("track", v as JobTrack)}
-                  disabled={isSaving}
+                  onValueChange={(value) => setR("track", value as JobTrack)}
                 >
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {TRACKS.map((t) => (
-                      <SelectItem key={t} value={t}>
-                        {t}
+                    {TRACKS.map((track) => (
+                      <SelectItem key={track} value={track}>
+                        {track}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -367,16 +345,15 @@ export function PasteLinkReviewStep({
                 <Label>Role Status</Label>
                 <Select
                   value={role.status}
-                  onValueChange={(v) => setR("status", v as RoleStatus)}
-                  disabled={isSaving}
+                  onValueChange={(value) => setR("status", value as RoleStatus)}
                 >
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {ROLE_STATUSES.map((s) => (
-                      <SelectItem key={s} value={s}>
-                        {s}
+                    {ROLE_STATUSES.map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {status}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -388,7 +365,7 @@ export function PasteLinkReviewStep({
                   <Label>Job Description Preview</Label>
                   <div className="text-xs text-neutral-600 dark:text-neutral-400 rounded border p-2 max-h-32 overflow-y-auto whitespace-pre-wrap bg-neutral-50 dark:bg-neutral-900">
                     {role.jobDescription.slice(0, 600)}
-                    {role.jobDescription.length > 600 && "…"}
+                    {role.jobDescription.length > 600 && "..."}
                   </div>
                 </div>
               )}
@@ -397,27 +374,20 @@ export function PasteLinkReviewStep({
         </section>
       )}
 
-      {/* Actions */}
       <div className="flex gap-2 justify-end pt-2 border-t">
-        <Button variant="outline" onClick={onBack} disabled={isSaving}>
+        <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button variant="outline" onClick={onCancel} disabled={isSaving}>
+        <Button variant="outline" onClick={onCancel}>
           Cancel
         </Button>
         {mode === "company_and_role" && hasRole ? (
-          <Button
-            onClick={() => handleSave(true)}
-            disabled={!company.name.trim() || isSaving}
-          >
-            {isSaving ? "Saving…" : "Save Company + Role"}
+          <Button onClick={() => handleContinue(true)} disabled={!company.name.trim()}>
+            Continue
           </Button>
         ) : (
-          <Button
-            onClick={() => handleSave(false)}
-            disabled={!company.name.trim() || isSaving}
-          >
-            {isSaving ? "Saving…" : "Save Company"}
+          <Button onClick={() => handleContinue(false)} disabled={!company.name.trim()}>
+            Continue
           </Button>
         )}
       </div>

--- a/src/app/components/layout/AppPageShell.tsx
+++ b/src/app/components/layout/AppPageShell.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react";
+import { cn } from "../ui/utils";
+
+interface AppPageShellProps {
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  actions?: ReactNode;
+  toolbar?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  headerClassName?: string;
+  contentClassName?: string;
+  scrollContent?: boolean;
+}
+
+export function AppPageShell({
+  title,
+  subtitle,
+  actions,
+  toolbar,
+  children,
+  className,
+  headerClassName,
+  contentClassName,
+  scrollContent = false,
+}: AppPageShellProps) {
+  const showHeader = title || subtitle || actions;
+
+  return (
+    <section className={cn("min-w-0 space-y-5", className)}>
+      {showHeader ? (
+        <header
+          className={cn(
+            "flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between",
+            headerClassName
+          )}
+        >
+          <div className="min-w-0 space-y-1">
+            {title ? (
+              <h1 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
+                {title}
+              </h1>
+            ) : null}
+            {subtitle ? (
+              <p className="max-w-3xl text-sm text-muted-foreground">{subtitle}</p>
+            ) : null}
+          </div>
+          {actions ? <div className="flex flex-wrap items-center gap-2">{actions}</div> : null}
+        </header>
+      ) : null}
+
+      {toolbar ? <div className="flex min-w-0 flex-col gap-3">{toolbar}</div> : null}
+
+      <div
+        className={cn(
+          "min-w-0",
+          scrollContent && "min-h-0 overflow-auto",
+          contentClassName
+        )}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/app/components/ui/select.tsx
+++ b/src/app/components/ui/select.tsx
@@ -13,7 +13,7 @@ import { cn } from "./utils";
 function Select({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />;
+  return <SelectPrimitive.Root data-slot="select" modal={false} {...props} />;
 }
 
 function SelectGroup({

--- a/src/app/hooks/useJobOs.ts
+++ b/src/app/hooks/useJobOs.ts
@@ -165,9 +165,29 @@ function mergePendingLocalItems<T extends { id: string; clientRequestId?: string
 }
 
 function stripUndefinedFields<T extends Record<string, unknown>>(value: T): T {
-  return Object.fromEntries(
-    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined)
-  ) as T;
+  return stripUndefinedValue(value) as T;
+}
+
+function stripUndefinedValue(value: unknown): unknown {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => stripUndefinedValue(item))
+      .filter((item) => item !== undefined);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .map(([key, entryValue]) => [key, stripUndefinedValue(entryValue)] as const)
+        .filter(([, entryValue]) => entryValue !== undefined)
+    );
+  }
+
+  return value;
 }
 
 function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {

--- a/src/app/pages/dashboard/DashboardPage.tsx
+++ b/src/app/pages/dashboard/DashboardPage.tsx
@@ -36,6 +36,7 @@ export function DashboardPage() {
     addCompany,
     updateCompany,
     addRole,
+    addApplication,
   } = useJobOs(session?.userId ?? null);
 
   const lastSyncedLabel = jobOsSync.lastSyncedAt
@@ -124,6 +125,7 @@ export function DashboardPage() {
             addCompany={addCompany}
             updateCompany={updateCompany}
             addRole={addRole}
+            addApplication={addApplication}
             onDismiss={() => {
               updateOnboardingStatus("dismissed");
               void navigate("/job-os/companies");

--- a/src/app/pages/dashboard/DashboardPage.tsx
+++ b/src/app/pages/dashboard/DashboardPage.tsx
@@ -21,6 +21,7 @@ import { PipelineStats } from "../../components/dashboard/PipelineStats";
 import { ProbabilityPanel } from "../../components/dashboard/ProbabilityPanel";
 import { QuickActions } from "../../components/dashboard/QuickActions";
 import { FirstRunScreen } from "../../components/dashboard/FirstRunScreen";
+import { AppPageShell } from "../../components/layout/AppPageShell";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../../components/ui/collapsible";
 
 export function DashboardPage() {
@@ -134,55 +135,61 @@ export function DashboardPage() {
           />
         ) : null}
 
-        <div className={`grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1.7fr)_360px] xl:grid-cols-[minmax(0,1.8fr)_380px]${showFirstRun || holdDashboard ? " hidden" : ""}`}>
-          <div className="min-w-0 space-y-4">
-            <FocusedNextAction
-              action={primaryAction}
-              isLoading={loading}
-              queueSize={Math.max(actions.length - 1, 0)}
-            />
-            <TodayPanel actions={actions} isLoading={loading} />
-          </div>
+        <AppPageShell
+          title="Command Center"
+          subtitle="Act on the strongest next move first, then use the side rail for supporting context."
+          className={showFirstRun || holdDashboard ? "hidden" : ""}
+        >
+          <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1.7fr)_360px] xl:grid-cols-[minmax(0,1.8fr)_380px]">
+            <div className="min-w-0 space-y-4">
+              <FocusedNextAction
+                action={primaryAction}
+                isLoading={loading}
+                queueSize={Math.max(actions.length - 1, 0)}
+              />
+              <TodayPanel actions={actions} isLoading={loading} />
+            </div>
 
-          <div className="min-w-0 lg:self-start">
-            <div className="space-y-4 lg:sticky lg:top-24">
-              <QuickActions />
-              <PipelineStats stats={stats} isLoading={loading} />
-              <ProbabilityPanel stats={stats} isLoading={loading} />
-              <Collapsible open={supportOpen} onOpenChange={setSupportOpen}>
-                <section className="rounded-2xl border border-neutral-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-950">
-                  <CollapsibleTrigger className="w-full text-left">
-                    <div className="flex items-center gap-2 px-4 py-3">
-                      <Layers3 className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
-                      <div>
-                        <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
-                          Supporting Signals
-                        </h2>
-                        <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                          Use these when you want more context, not before.
-                        </p>
+            <div className="min-w-0 lg:self-start">
+              <div className="space-y-4 lg:sticky lg:top-24">
+                <QuickActions />
+                <PipelineStats stats={stats} isLoading={loading} />
+                <ProbabilityPanel stats={stats} isLoading={loading} />
+                <Collapsible open={supportOpen} onOpenChange={setSupportOpen}>
+                  <section className="rounded-2xl border border-neutral-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-950">
+                    <CollapsibleTrigger className="w-full text-left">
+                      <div className="flex items-center gap-2 px-4 py-3">
+                        <Layers3 className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
+                        <div>
+                          <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+                            Supporting Signals
+                          </h2>
+                          <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                            Use these when you want more context, not before.
+                          </p>
+                        </div>
+                        <span className="ml-auto text-neutral-400">
+                          {supportOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                        </span>
                       </div>
-                      <span className="ml-auto text-neutral-400">
-                        {supportOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-                      </span>
-                    </div>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <div className="border-t border-neutral-200 px-4 py-4 dark:border-neutral-800">
-                      {(loading || hotOpportunities.length > 0) ? (
-                        <HotOpportunities opportunities={hotOpportunities} isLoading={loading} />
-                      ) : (
-                        <p className="text-sm text-neutral-500 dark:text-neutral-400">
-                          No additional hot opportunities to surface right now.
-                        </p>
-                      )}
-                    </div>
-                  </CollapsibleContent>
-                </section>
-              </Collapsible>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent>
+                      <div className="border-t border-neutral-200 px-4 py-4 dark:border-neutral-800">
+                        {(loading || hotOpportunities.length > 0) ? (
+                          <HotOpportunities opportunities={hotOpportunities} isLoading={loading} />
+                        ) : (
+                          <p className="text-sm text-neutral-500 dark:text-neutral-400">
+                            No additional hot opportunities to surface right now.
+                          </p>
+                        )}
+                      </div>
+                    </CollapsibleContent>
+                  </section>
+                </Collapsible>
+              </div>
             </div>
           </div>
-        </div>
+        </AppPageShell>
       </main>
     </div>
   );

--- a/src/app/pages/job-os/JobOsApplicationsPage.tsx
+++ b/src/app/pages/job-os/JobOsApplicationsPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router";
 import { useEffect, useMemo, useState } from "react";
-import { KanbanSquare, List, Plus, Search } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, KanbanSquare, List, Plus, Search } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog";
@@ -35,6 +35,8 @@ const STATUS_VALUES: ApplicationStatus[] = [
 
 type PipelineViewMode = "board" | "list";
 type ApplicationStageGroup = keyof typeof APPLICATION_STAGE_GROUPS;
+type SortField = "company" | "role" | "status" | "date" | "nextAction";
+type SortDirection = "asc" | "desc";
 
 const EMPTY_APPLICATION_DRAFT = {
   dateApplied: new Date().toISOString().slice(0, 10),
@@ -78,13 +80,15 @@ export default function JobOsApplicationsPage() {
   } = useJobOs(session?.userId ?? null);
 
   const defaultCv = getDefaultCvAsset(assets.cvs);
-  const [viewMode, setViewMode] = useState<PipelineViewMode>("board");
+  const [viewMode, setViewMode] = useState<PipelineViewMode>("list");
   const [stageGroup, setStageGroup] = useState<ApplicationStageGroup>("active");
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [createOpen, setCreateOpen] = useState(false);
   const [detailId, setDetailId] = useState<string | null>(null);
   const [detailDraft, setDetailDraft] = useState<Pick<JobOsApplication, "status" | "nextAction" | "notes"> | null>(null);
+  const [sortField, setSortField] = useState<SortField>("date");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const [draft, setDraft] = useState<Omit<JobOsApplication, "id" | "createdAt" | "updatedAt">>(createDraft(defaultCv ? { id: defaultCv.id, name: defaultCv.name } : undefined));
 
   useEffect(() => {
@@ -119,7 +123,7 @@ export default function JobOsApplicationsPage() {
   const filteredApplications = useMemo(() => {
     const query = searchTerm.trim().toLowerCase();
 
-    return applications.filter((application) => {
+    const visibleApplications = applications.filter((application) => {
       if (!groupStatuses.includes(application.status)) return false;
       if (!query) return true;
 
@@ -137,7 +141,32 @@ export default function JobOsApplicationsPage() {
 
       return haystack.includes(query);
     });
-  }, [applications, companiesById, groupStatuses, rolesById, searchTerm]);
+
+    return [...visibleApplications].sort((left, right) => {
+      const leftCompany = companiesById.get(left.companyId)?.name ?? "";
+      const rightCompany = companiesById.get(right.companyId)?.name ?? "";
+      const leftRole = rolesById.get(left.roleId)?.title ?? "";
+      const rightRole = rolesById.get(right.roleId)?.title ?? "";
+
+      const comparison = (() => {
+        switch (sortField) {
+          case "company":
+            return leftCompany.localeCompare(rightCompany);
+          case "role":
+            return leftRole.localeCompare(rightRole);
+          case "status":
+            return APPLICATION_STATUS_LABELS[left.status].localeCompare(APPLICATION_STATUS_LABELS[right.status]);
+          case "nextAction":
+            return (left.nextAction || "").localeCompare(right.nextAction || "");
+          case "date":
+          default:
+            return left.dateApplied.localeCompare(right.dateApplied);
+        }
+      })();
+
+      return sortDirection === "asc" ? comparison : -comparison;
+    });
+  }, [applications, companiesById, groupStatuses, rolesById, searchTerm, sortDirection, sortField]);
 
   function resetDraft(): void {
     setDraft(createDraft(defaultCv ? { id: defaultCv.id, name: defaultCv.name } : undefined));
@@ -145,6 +174,32 @@ export default function JobOsApplicationsPage() {
 
   function toggleSelection(id: string): void {
     setSelectedIds((prev) => (prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]));
+  }
+
+  function toggleSort(field: SortField): void {
+    if (sortField === field) {
+      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
+      return;
+    }
+
+    setSortField(field);
+    setSortDirection(field === "date" ? "desc" : "asc");
+  }
+
+  function SortHeader({ label, field }: { label: string; field: SortField }) {
+    const active = sortField === field;
+    return (
+      <button
+        type="button"
+        onClick={() => toggleSort(field)}
+        className="inline-flex items-center gap-1 font-medium text-foreground transition-colors hover:text-primary"
+      >
+        <span>{label}</span>
+        {!active && <ArrowUpDown className="h-3.5 w-3.5 opacity-60" />}
+        {active && sortDirection === "asc" && <ArrowUp className="h-3.5 w-3.5 text-primary" />}
+        {active && sortDirection === "desc" && <ArrowDown className="h-3.5 w-3.5 text-primary" />}
+      </button>
+    );
   }
 
   async function applyBulkStatus(status: ApplicationStatus): Promise<void> {
@@ -185,7 +240,7 @@ export default function JobOsApplicationsPage() {
             <div className="space-y-1">
               <CardTitle className="text-base">Pipeline</CardTitle>
               <CardDescription>
-                The active applications route now prioritizes a grouped workflow view instead of a permanent spreadsheet.
+                Start with the readable execution list, then switch to board view when you need stage-level triage.
               </CardDescription>
             </div>
             <div className="flex flex-wrap items-center gap-2">
@@ -288,22 +343,26 @@ export default function JobOsApplicationsPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead />
-                  <TableHead>Company</TableHead>
-                  <TableHead>Role</TableHead>
-                  <TableHead>Applied</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>CV</TableHead>
-                  <TableHead>Next Action</TableHead>
+                  <TableHead><SortHeader label="Company" field="company" /></TableHead>
+                  <TableHead><SortHeader label="Role" field="role" /></TableHead>
+                  <TableHead><SortHeader label="Status" field="status" /></TableHead>
+                  <TableHead><SortHeader label="Date" field="date" /></TableHead>
+                  <TableHead><SortHeader label="Next Action" field="nextAction" /></TableHead>
                   <TableHead />
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {filteredApplications.map((application) => (
-                  <TableRow key={application.id}>
+                  <TableRow
+                    key={application.id}
+                    className="cursor-pointer"
+                    onClick={() => setDetailId(application.id)}
+                  >
                     <TableCell>
                       <input
                         type="checkbox"
                         checked={selectedSet.has(application.id)}
+                        onClick={(event) => event.stopPropagation()}
                         onChange={() => toggleSelection(application.id)}
                       />
                     </TableCell>
@@ -311,9 +370,11 @@ export default function JobOsApplicationsPage() {
                       {companiesById.get(application.companyId)?.name ?? "-"}
                     </TableCell>
                     <TableCell>{rolesById.get(application.roleId)?.title ?? "-"}</TableCell>
-                    <TableCell>{application.dateApplied}</TableCell>
                     <TableCell>
-                      <Select value={application.status} onValueChange={(value) => void updateApplication(application.id, { status: value as ApplicationStatus })}>
+                      <Select
+                        value={application.status}
+                        onValueChange={(value) => void updateApplication(application.id, { status: value as ApplicationStatus })}
+                      >
                         <SelectTrigger className="w-36">
                           <SelectValue />
                         </SelectTrigger>
@@ -326,31 +387,25 @@ export default function JobOsApplicationsPage() {
                         </SelectContent>
                       </Select>
                     </TableCell>
-                    <TableCell>{getApplicationCvLabel(application, assets.cvs)}</TableCell>
+                    <TableCell>{application.dateApplied}</TableCell>
                     <TableCell className="max-w-[220px] truncate">{application.nextAction || "-"}</TableCell>
                     <TableCell>
-                      <div className="flex gap-2">
-                        <Button size="sm" variant="outline" onClick={() => setDetailId(application.id)}>
-                          View
-                        </Button>
-                        <Button asChild size="sm" variant="outline">
-                          <Link to={`/cv-optimizer?applicationId=${application.id}`}>Tailor CV</Link>
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="text-red-500"
-                          onClick={() => void removeApplication(application.id)}
-                        >
-                          Delete
-                        </Button>
-                      </div>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          setDetailId(application.id);
+                        }}
+                      >
+                        Open
+                      </Button>
                     </TableCell>
                   </TableRow>
                 ))}
                 {filteredApplications.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={8} className="py-10 text-center text-sm text-muted-foreground">
+                    <TableCell colSpan={7} className="py-10 text-center text-sm text-muted-foreground">
                       No applications match this stage group and search.
                     </TableCell>
                   </TableRow>
@@ -494,6 +549,14 @@ export default function JobOsApplicationsPage() {
                     Channel
                   </div>
                   <div className="text-sm text-foreground">{detailApplication.channel}</div>
+                </div>
+                <div className="space-y-1">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    CV
+                  </div>
+                  <div className="text-sm text-foreground">
+                    {getApplicationCvLabel(detailApplication, assets.cvs)}
+                  </div>
                 </div>
                 <div className="md:col-span-2">
                   <Select value={detailDraft.status} onValueChange={(value) => setDetailDraft((current) => current ? { ...current, status: value as ApplicationStatus } : current)}>

--- a/src/app/pages/job-os/JobOsApplicationsPage.tsx
+++ b/src/app/pages/job-os/JobOsApplicationsPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router";
 import { useEffect, useMemo, useState } from "react";
-import { ArrowDown, ArrowUp, ArrowUpDown, KanbanSquare, List, Plus, Search } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, CircleHelp, KanbanSquare, List, Plus, Search } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog";
@@ -10,10 +10,12 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from ".
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs";
 import { Textarea } from "../../components/ui/textarea";
 import { Badge } from "../../components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../components/ui/tooltip";
 import { useApp } from "../../context";
 import { useJobOs } from "../../hooks/useJobOs";
 import { JobOsTransferControls } from "../../components/job-os/JobOsTransferControls";
 import { JobOsLayout } from "../../components/job-os/JobOsLayout";
+import { AppPageShell } from "../../components/layout/AppPageShell";
 import {
   APPLICATION_STAGE_GROUPS,
   APPLICATION_STATUS_LABELS,
@@ -225,6 +227,101 @@ export default function JobOsApplicationsPage() {
     setDetailId(null);
   }
 
+  function handleCreateDialogKeyDown(
+    event: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>
+  ): void {
+    const isModifierEnter =
+      event.key === "Enter" &&
+      ((event.metaKey || event.ctrlKey) || event.currentTarget instanceof HTMLInputElement);
+
+    if (isModifierEnter && draft.companyId && draft.roleId) {
+      event.preventDefault();
+      void handleCreateApplication();
+    }
+  }
+
+  function handleDetailDialogKeyDown(
+    event: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>
+  ): void {
+    const isModifierEnter =
+      event.key === "Enter" &&
+      ((event.metaKey || event.ctrlKey) || event.currentTarget instanceof HTMLInputElement);
+
+    if (isModifierEnter && detailApplication && detailDraft) {
+      event.preventDefault();
+      void handleSaveDetails();
+    }
+  }
+
+  const shellActions = (
+    <>
+      <div className="flex items-center gap-1 rounded-xl border border-border/70 bg-background/70 p-1">
+        <Button
+          type="button"
+          size="sm"
+          variant={viewMode === "board" ? "default" : "ghost"}
+          className="rounded-lg"
+          onClick={() => setViewMode("board")}
+        >
+          <KanbanSquare className="h-4 w-4" />
+          Board
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant={viewMode === "list" ? "default" : "ghost"}
+          className="rounded-lg"
+          onClick={() => setViewMode("list")}
+        >
+          <List className="h-4 w-4" />
+          List
+        </Button>
+      </div>
+      <Button onClick={() => setCreateOpen(true)} className="gap-2">
+        <Plus className="h-4 w-4" />
+        Add Application
+      </Button>
+    </>
+  );
+
+  const shellToolbar = (
+    <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+      <Tabs
+        value={stageGroup}
+        onValueChange={(value) => setStageGroup(value as ApplicationStageGroup)}
+        className="gap-3"
+      >
+        <TabsList className="h-auto w-full flex-wrap justify-start rounded-2xl bg-muted/70 p-1 sm:w-fit">
+          {(Object.keys(APPLICATION_STAGE_GROUPS) as ApplicationStageGroup[]).map((group) => (
+            <TabsTrigger key={group} value={group} className="rounded-xl px-3 py-2 text-sm">
+              {APPLICATION_STAGE_GROUPS[group].label}
+              <Badge
+                variant="outline"
+                className="ml-1 rounded-full bg-background/70 px-1.5 py-0 text-[10px]"
+              >
+                {
+                  applications.filter((application) =>
+                    APPLICATION_STAGE_GROUPS[group].statuses.includes(application.status)
+                  ).length
+                }
+              </Badge>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      <div className="relative w-full xl:max-w-sm">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+          placeholder="Search company, role, next action, notes"
+          className="pl-9"
+        />
+      </div>
+    </div>
+  );
+
   return (
     <JobOsLayout
       title="Applications"
@@ -234,187 +331,154 @@ export default function JobOsApplicationsPage() {
         <JobOsTransferControls getExportState={exportState} onImportState={replaceState} />
       }
     >
-      <Card>
-        <CardHeader className="gap-4">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-            <div className="space-y-1">
-              <CardTitle className="text-base">Pipeline</CardTitle>
-              <CardDescription>
-                Start with the readable execution list, then switch to board view when you need stage-level triage.
-              </CardDescription>
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
-              <div className="flex items-center gap-1 rounded-xl border border-border/70 bg-background/70 p-1">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant={viewMode === "board" ? "default" : "ghost"}
-                  className="rounded-lg"
-                  onClick={() => setViewMode("board")}
-                >
-                  <KanbanSquare className="h-4 w-4" />
-                  Board
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant={viewMode === "list" ? "default" : "ghost"}
-                  className="rounded-lg"
-                  onClick={() => setViewMode("list")}
-                >
-                  <List className="h-4 w-4" />
-                  List
-                </Button>
-              </div>
-              <Button onClick={() => setCreateOpen(true)} className="gap-2">
-                <Plus className="h-4 w-4" />
-                Add Application
-              </Button>
-            </div>
-          </div>
+      <AppPageShell
+        title="Pipeline"
+        subtitle="Start with the readable execution list, then switch to board view when you need stage-level triage."
+        actions={shellActions}
+        toolbar={shellToolbar}
+      >
+        <div className="space-y-4">
+          {selectedIds.length > 0 ? (
+            <Card>
+              <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="text-sm text-muted-foreground">
+                  {selectedIds.length} application{selectedIds.length === 1 ? "" : "s"} selected.
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button size="sm" variant="outline" onClick={() => void bulkFollowUp()}>
+                    Set Follow-up
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => void applyBulkStatus("screen")}>
+                    Move to Screen
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => void applyBulkStatus("rejected")}>
+                    Mark Rejected
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={() => setSelectedIds([])}>
+                    Clear
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ) : null}
 
-          <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-            <Tabs value={stageGroup} onValueChange={(value) => setStageGroup(value as ApplicationStageGroup)} className="gap-3">
-              <TabsList className="h-auto w-full flex-wrap justify-start rounded-2xl bg-muted/70 p-1 sm:w-fit">
-                {(Object.keys(APPLICATION_STAGE_GROUPS) as ApplicationStageGroup[]).map((group) => (
-                  <TabsTrigger key={group} value={group} className="rounded-xl px-3 py-2 text-sm">
-                    {APPLICATION_STAGE_GROUPS[group].label}
-                    <Badge variant="outline" className="ml-1 rounded-full bg-background/70 px-1.5 py-0 text-[10px]">
-                      {applications.filter((application) => APPLICATION_STAGE_GROUPS[group].statuses.includes(application.status)).length}
-                    </Badge>
-                  </TabsTrigger>
-                ))}
-              </TabsList>
-            </Tabs>
-
-            <div className="relative w-full xl:max-w-sm">
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                value={searchTerm}
-                onChange={(event) => setSearchTerm(event.target.value)}
-                placeholder="Search company, role, next action, notes"
-                className="pl-9"
-              />
-            </div>
-          </div>
-        </CardHeader>
-      </Card>
-
-      {selectedIds.length > 0 ? (
-        <Card>
-          <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
-            <div className="text-sm text-muted-foreground">
-              {selectedIds.length} application{selectedIds.length === 1 ? "" : "s"} selected.
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Button size="sm" variant="outline" onClick={() => void bulkFollowUp()}>
-                Set Follow-up
-              </Button>
-              <Button size="sm" variant="outline" onClick={() => void applyBulkStatus("screen")}>
-                Move to Screen
-              </Button>
-              <Button size="sm" variant="outline" onClick={() => void applyBulkStatus("rejected")}>
-                Mark Rejected
-              </Button>
-              <Button size="sm" variant="ghost" onClick={() => setSelectedIds([])}>
-                Clear
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      ) : null}
-
-      {viewMode === "board" ? (
-        <Card>
-          <CardContent className="pt-6">
-            <JobOsPipelineBoard
-              applications={filteredApplications}
-              companiesById={companiesById as Map<string, JobOsCompany>}
-              rolesById={rolesById as Map<string, JobOsRole>}
-              group={stageGroup}
-              onSelectApplication={(application) => setDetailId(application.id)}
-            />
-          </CardContent>
-        </Card>
-      ) : (
-        <Card>
-          <CardContent className="pt-6">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead />
-                  <TableHead><SortHeader label="Company" field="company" /></TableHead>
-                  <TableHead><SortHeader label="Role" field="role" /></TableHead>
-                  <TableHead><SortHeader label="Status" field="status" /></TableHead>
-                  <TableHead><SortHeader label="Date" field="date" /></TableHead>
-                  <TableHead><SortHeader label="Next Action" field="nextAction" /></TableHead>
-                  <TableHead />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filteredApplications.map((application) => (
-                  <TableRow
-                    key={application.id}
-                    className="cursor-pointer"
-                    onClick={() => setDetailId(application.id)}
-                  >
-                    <TableCell>
-                      <input
-                        type="checkbox"
-                        checked={selectedSet.has(application.id)}
-                        onClick={(event) => event.stopPropagation()}
-                        onChange={() => toggleSelection(application.id)}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      {companiesById.get(application.companyId)?.name ?? "-"}
-                    </TableCell>
-                    <TableCell>{rolesById.get(application.roleId)?.title ?? "-"}</TableCell>
-                    <TableCell>
-                      <Select
-                        value={application.status}
-                        onValueChange={(value) => void updateApplication(application.id, { status: value as ApplicationStatus })}
+          {viewMode === "board" ? (
+            <Card>
+              <CardContent className="pt-6">
+                <JobOsPipelineBoard
+                  applications={filteredApplications}
+                  companiesById={companiesById as Map<string, JobOsCompany>}
+                  rolesById={rolesById as Map<string, JobOsRole>}
+                  group={stageGroup}
+                  onSelectApplication={(application) => setDetailId(application.id)}
+                />
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="pt-6">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead />
+                      <TableHead><SortHeader label="Company" field="company" /></TableHead>
+                      <TableHead><SortHeader label="Role" field="role" /></TableHead>
+                      <TableHead><SortHeader label="Status" field="status" /></TableHead>
+                      <TableHead><SortHeader label="Date" field="date" /></TableHead>
+                      <TableHead><SortHeader label="Next Action" field="nextAction" /></TableHead>
+                      <TableHead />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {filteredApplications.map((application) => (
+                      <TableRow
+                        key={application.id}
+                        className="cursor-pointer"
+                        onClick={() => setDetailId(application.id)}
                       >
-                        <SelectTrigger className="w-36">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {STATUS_VALUES.map((status) => (
-                            <SelectItem key={status} value={status}>
-                              {APPLICATION_STATUS_LABELS[status]}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </TableCell>
-                    <TableCell>{application.dateApplied}</TableCell>
-                    <TableCell className="max-w-[220px] truncate">{application.nextAction || "-"}</TableCell>
-                    <TableCell>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          setDetailId(application.id);
-                        }}
-                      >
-                        Open
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                ))}
-                {filteredApplications.length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={7} className="py-10 text-center text-sm text-muted-foreground">
-                      No applications match this stage group and search.
-                    </TableCell>
-                  </TableRow>
-                ) : null}
-              </TableBody>
-            </Table>
-          </CardContent>
-        </Card>
-      )}
+                        <TableCell>
+                          <input
+                            type="checkbox"
+                            checked={selectedSet.has(application.id)}
+                            onClick={(event) => event.stopPropagation()}
+                            onChange={() => toggleSelection(application.id)}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          {companiesById.get(application.companyId)?.name ?? "-"}
+                        </TableCell>
+                        <TableCell>{rolesById.get(application.roleId)?.title ?? "-"}</TableCell>
+                        <TableCell>
+                          <Select
+                            value={application.status}
+                            onValueChange={(value) =>
+                              void updateApplication(application.id, {
+                                status: value as ApplicationStatus,
+                              })
+                            }
+                          >
+                            <SelectTrigger className="w-36">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {STATUS_VALUES.map((status) => (
+                                <SelectItem key={status} value={status}>
+                                  {APPLICATION_STATUS_LABELS[status]}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </TableCell>
+                        <TableCell>{application.dateApplied}</TableCell>
+                        <TableCell className="max-w-[220px] truncate">
+                          {application.nextAction || "-"}
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              setDetailId(application.id);
+                            }}
+                          >
+                            Open
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                    {filteredApplications.length === 0 ? (
+                      <TableRow>
+                        <TableCell
+                          colSpan={7}
+                          className="py-10 text-center text-sm text-muted-foreground"
+                        >
+                          <div className="mx-auto flex max-w-md flex-col items-center gap-3">
+                            <p>No applications match this stage group and search.</p>
+                            <div className="flex flex-wrap justify-center gap-2">
+                              {searchTerm ? (
+                                <Button size="sm" variant="outline" onClick={() => setSearchTerm("")}>
+                                  Clear search
+                                </Button>
+                              ) : null}
+                              <Button size="sm" variant="outline" onClick={() => setStageGroup("active")}>
+                                Switch to Active
+                              </Button>
+                              <Button size="sm" onClick={() => setCreateOpen(true)}>
+                                Add application
+                              </Button>
+                            </div>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ) : null}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </AppPageShell>
 
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
@@ -426,16 +490,18 @@ export default function JobOsApplicationsPage() {
           </DialogHeader>
 
           <div className="grid gap-3 md:grid-cols-2">
-            <Input
-              type="date"
-              value={draft.dateApplied}
-              onChange={(event) => setDraft((current) => ({ ...current, dateApplied: event.target.value }))}
-            />
-            <Input
-              value={draft.channel}
-              onChange={(event) => setDraft((current) => ({ ...current, channel: event.target.value }))}
-              placeholder="Channel"
-            />
+              <Input
+                type="date"
+                value={draft.dateApplied}
+                onChange={(event) => setDraft((current) => ({ ...current, dateApplied: event.target.value }))}
+                onKeyDown={handleCreateDialogKeyDown}
+              />
+              <Input
+                value={draft.channel}
+                onChange={(event) => setDraft((current) => ({ ...current, channel: event.target.value }))}
+                onKeyDown={handleCreateDialogKeyDown}
+                placeholder="Application source"
+              />
             <Select value={draft.companyId} onValueChange={(value) => setDraft((current) => ({ ...current, companyId: value, roleId: "" }))}>
               <SelectTrigger>
                 <SelectValue placeholder="Company" />
@@ -500,20 +566,35 @@ export default function JobOsApplicationsPage() {
               <Input
                 value={draft.nextAction}
                 onChange={(event) => setDraft((current) => ({ ...current, nextAction: event.target.value }))}
-                placeholder="Next action"
+                onKeyDown={handleCreateDialogKeyDown}
+                placeholder="e.g. Follow up next Tuesday"
               />
             </div>
             <div className="md:col-span-2">
               <Textarea
                 value={draft.notes}
                 onChange={(event) => setDraft((current) => ({ ...current, notes: event.target.value }))}
+                onKeyDown={handleCreateDialogKeyDown}
                 rows={4}
-                placeholder="Notes"
+                placeholder="Context, recruiter notes, or submission details"
               />
             </div>
           </div>
 
-          <div className="flex justify-end gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex">
+                    <CircleHelp className="h-3.5 w-3.5" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  Press Enter in a field, or Cmd/Ctrl + Enter in notes, to save quickly.
+                </TooltipContent>
+              </Tooltip>
+              Keyboard shortcut available
+            </div>
             <Button variant="ghost" onClick={() => setCreateOpen(false)}>
               Cancel
             </Button>
@@ -576,15 +657,17 @@ export default function JobOsApplicationsPage() {
                   <Input
                     value={detailDraft.nextAction}
                     onChange={(event) => setDetailDraft((current) => current ? { ...current, nextAction: event.target.value } : current)}
-                    placeholder="Next action"
+                    onKeyDown={handleDetailDialogKeyDown}
+                    placeholder="What should happen next?"
                   />
                 </div>
                 <div className="md:col-span-2">
                   <Textarea
                     value={detailDraft.notes}
                     onChange={(event) => setDetailDraft((current) => current ? { ...current, notes: event.target.value } : current)}
+                    onKeyDown={handleDetailDialogKeyDown}
                     rows={5}
-                    placeholder="Notes"
+                    placeholder="Add context, response notes, or follow-up details"
                   />
                 </div>
               </div>
@@ -605,9 +688,12 @@ export default function JobOsApplicationsPage() {
                     Delete
                   </Button>
                 </div>
-                <Button onClick={() => void handleSaveDetails()}>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground">Cmd/Ctrl + Enter saves</span>
+                  <Button onClick={() => void handleSaveDetails()}>
                   Save Changes
-                </Button>
+                  </Button>
+                </div>
               </div>
             </>
           ) : null}

--- a/src/app/pages/job-os/JobOsApplicationsPage.tsx
+++ b/src/app/pages/job-os/JobOsApplicationsPage.tsx
@@ -1,17 +1,26 @@
 import { Link } from "react-router";
 import { useEffect, useMemo, useState } from "react";
+import { KanbanSquare, List, Plus, Search } from "lucide-react";
 import { Button } from "../../components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog";
 import { Input } from "../../components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs";
 import { Textarea } from "../../components/ui/textarea";
+import { Badge } from "../../components/ui/badge";
 import { useApp } from "../../context";
 import { useJobOs } from "../../hooks/useJobOs";
 import { JobOsTransferControls } from "../../components/job-os/JobOsTransferControls";
 import { JobOsLayout } from "../../components/job-os/JobOsLayout";
+import {
+  APPLICATION_STAGE_GROUPS,
+  APPLICATION_STATUS_LABELS,
+  JobOsPipelineBoard,
+} from "../../components/job-os/JobOsPipelineBoard";
 import { getApplicationCvLabel, getDefaultCvAsset } from "../../services/cvAssets";
-import type { ApplicationStatus, JobOsApplication } from "../../types/jobOs";
+import type { ApplicationStatus, JobOsApplication, JobOsCompany, JobOsRole } from "../../types/jobOs";
 
 const STATUS_VALUES: ApplicationStatus[] = [
   "sent",
@@ -24,43 +33,117 @@ const STATUS_VALUES: ApplicationStatus[] = [
   "ghosted",
 ];
 
-export default function JobOsApplicationsPage() {
-  const { session } = useApp();
-  const { applications, companies, roles, assets, addApplication, updateApplication, removeApplication, syncNotice, exportState, replaceState } = useJobOs(
-    session?.userId ?? null
-  );
-  const defaultCv = getDefaultCvAsset(assets.cvs);
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [draft, setDraft] = useState<Omit<JobOsApplication, "id" | "createdAt" | "updatedAt">>({
-    dateApplied: new Date().toISOString().slice(0, 10),
-    companyId: "",
-    roleId: "",
-    channel: "LinkedIn",
+type PipelineViewMode = "board" | "list";
+type ApplicationStageGroup = keyof typeof APPLICATION_STAGE_GROUPS;
+
+const EMPTY_APPLICATION_DRAFT = {
+  dateApplied: new Date().toISOString().slice(0, 10),
+  companyId: "",
+  roleId: "",
+  channel: "LinkedIn",
+  cvAssetId: undefined,
+  cvVersion: "",
+  status: "sent" as ApplicationStatus,
+  nextAction: "",
+  notes: "",
+  latestJobDescriptionId: undefined,
+  latestCvTailoringRunId: undefined,
+  tailoredCvHeadline: "",
+  tailoredCvSummary: "",
+  tailoredCvText: "",
+  tailoredCvUpdatedAt: undefined,
+};
+
+function createDraft(defaultCv?: { id: string; name: string }): Omit<JobOsApplication, "id" | "createdAt" | "updatedAt"> {
+  return {
+    ...EMPTY_APPLICATION_DRAFT,
     cvAssetId: defaultCv?.id,
     cvVersion: defaultCv?.name ?? "",
-    status: "sent",
-    nextAction: "",
-    notes: "",
-    latestJobDescriptionId: undefined,
-    latestCvTailoringRunId: undefined,
-    tailoredCvHeadline: "",
-    tailoredCvSummary: "",
-    tailoredCvText: "",
-    tailoredCvUpdatedAt: undefined,
-  });
+  };
+}
+
+export default function JobOsApplicationsPage() {
+  const { session } = useApp();
+  const {
+    applications,
+    companies,
+    roles,
+    assets,
+    addApplication,
+    updateApplication,
+    removeApplication,
+    syncNotice,
+    exportState,
+    replaceState,
+  } = useJobOs(session?.userId ?? null);
+
+  const defaultCv = getDefaultCvAsset(assets.cvs);
+  const [viewMode, setViewMode] = useState<PipelineViewMode>("board");
+  const [stageGroup, setStageGroup] = useState<ApplicationStageGroup>("active");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [detailId, setDetailId] = useState<string | null>(null);
+  const [detailDraft, setDetailDraft] = useState<Pick<JobOsApplication, "status" | "nextAction" | "notes"> | null>(null);
+  const [draft, setDraft] = useState<Omit<JobOsApplication, "id" | "createdAt" | "updatedAt">>(createDraft(defaultCv ? { id: defaultCv.id, name: defaultCv.name } : undefined));
 
   useEffect(() => {
     if (!draft.cvVersion && defaultCv?.name) {
-      const { id, name } = defaultCv;
-      void Promise.resolve().then(() =>
-        setDraft((current) => ({ ...current, cvAssetId: id, cvVersion: name }))
-      );
+      setDraft((current) => ({
+        ...current,
+        cvAssetId: defaultCv.id,
+        cvVersion: defaultCv.name,
+      }));
     }
   }, [defaultCv, draft.cvVersion]);
 
-  const byId = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const companiesById = useMemo(() => new Map(companies.map((company) => [company.id, company])), [companies]);
+  const rolesById = useMemo(() => new Map(roles.map((role) => [role.id, role])), [roles]);
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const detailApplication = detailId ? applications.find((application) => application.id === detailId) ?? null : null;
 
-  function toggle(id: string): void {
+  useEffect(() => {
+    if (!detailApplication) {
+      setDetailDraft(null);
+      return;
+    }
+
+    setDetailDraft({
+      status: detailApplication.status,
+      nextAction: detailApplication.nextAction,
+      notes: detailApplication.notes,
+    });
+  }, [detailApplication]);
+
+  const groupStatuses = APPLICATION_STAGE_GROUPS[stageGroup].statuses;
+  const filteredApplications = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+
+    return applications.filter((application) => {
+      if (!groupStatuses.includes(application.status)) return false;
+      if (!query) return true;
+
+      const companyName = companiesById.get(application.companyId)?.name ?? "";
+      const roleTitle = rolesById.get(application.roleId)?.title ?? "";
+      const haystack = [
+        companyName,
+        roleTitle,
+        application.channel,
+        application.nextAction,
+        application.notes,
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      return haystack.includes(query);
+    });
+  }, [applications, companiesById, groupStatuses, rolesById, searchTerm]);
+
+  function resetDraft(): void {
+    setDraft(createDraft(defaultCv ? { id: defaultCv.id, name: defaultCv.name } : undefined));
+  }
+
+  function toggleSelection(id: string): void {
     setSelectedIds((prev) => (prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]));
   }
 
@@ -70,146 +153,403 @@ export default function JobOsApplicationsPage() {
   }
 
   async function bulkFollowUp(): Promise<void> {
-    await Promise.all(
-      selectedIds.map((id) =>
-        updateApplication(id, {
-          nextAction: "Follow up",
-        })
-      )
-    );
+    await Promise.all(selectedIds.map((id) => updateApplication(id, { nextAction: "Follow up" })));
     setSelectedIds([]);
+  }
+
+  async function handleCreateApplication(): Promise<void> {
+    if (!draft.companyId || !draft.roleId) return;
+    await addApplication(draft);
+    resetDraft();
+    setCreateOpen(false);
+  }
+
+  async function handleSaveDetails(): Promise<void> {
+    if (!detailApplication || !detailDraft) return;
+    await updateApplication(detailApplication.id, detailDraft);
+    setDetailId(null);
   }
 
   return (
     <JobOsLayout
       title="Applications"
-      subtitle="Master tracking sheet for all submitted applications"
+      subtitle="Pipeline control surface for submitted applications"
       notice={syncNotice}
       settingsFooter={
         <JobOsTransferControls getExportState={exportState} onImportState={replaceState} />
       }
     >
       <Card>
-        <CardHeader><CardTitle className="text-sm">Log Application</CardTitle></CardHeader>
-        <CardContent className="grid md:grid-cols-4 gap-3">
-          <Input type="date" value={draft.dateApplied} onChange={(event) => setDraft((current) => ({ ...current, dateApplied: event.target.value }))} />
-          <Select value={draft.companyId} onValueChange={(value) => setDraft((current) => ({ ...current, companyId: value }))}>
-            <SelectTrigger><SelectValue placeholder="Company" /></SelectTrigger>
-            <SelectContent>{companies.map((company) => <SelectItem key={company.id} value={company.id}>{company.name}</SelectItem>)}</SelectContent>
-          </Select>
-          <Select value={draft.roleId} onValueChange={(value) => setDraft((current) => ({ ...current, roleId: value }))}>
-            <SelectTrigger><SelectValue placeholder="Role" /></SelectTrigger>
-            <SelectContent>{roles.filter((role) => !draft.companyId || role.companyId === draft.companyId).map((role) => <SelectItem key={role.id} value={role.id}>{role.title}</SelectItem>)}</SelectContent>
-          </Select>
-          <Input value={draft.channel} onChange={(event) => setDraft((current) => ({ ...current, channel: event.target.value }))} placeholder="Channel" />
-          <Select
-            value={draft.cvAssetId ?? ""}
-            onValueChange={(value) => {
-              const selectedCv = assets.cvs.find((cv) => cv.id === value);
-              setDraft((current) => ({
-                ...current,
-                cvAssetId: selectedCv?.id,
-                cvVersion: selectedCv?.name ?? "",
-              }));
-            }}
-          >
-            <SelectTrigger><SelectValue /></SelectTrigger>
-            <SelectContent>{assets.cvs.map((cv) => <SelectItem key={cv.id} value={cv.id}>{cv.name}</SelectItem>)}</SelectContent>
-          </Select>
-          <Select value={draft.status} onValueChange={(value) => setDraft((current) => ({ ...current, status: value as ApplicationStatus }))}>
-            <SelectTrigger><SelectValue /></SelectTrigger>
-            <SelectContent>{STATUS_VALUES.map((status) => <SelectItem key={status} value={status}>{status}</SelectItem>)}</SelectContent>
-          </Select>
-          <Input value={draft.nextAction} onChange={(event) => setDraft((current) => ({ ...current, nextAction: event.target.value }))} placeholder="Next action" />
-          <Button
-            onClick={() => {
-              if (!draft.companyId) return;
-              void addApplication(draft);
-              setDraft((current) => ({ ...current, nextAction: "", notes: "" }));
-            }}
-          >
-            Save
-          </Button>
-          <div className="md:col-span-4">
-            <Textarea value={draft.notes} onChange={(event) => setDraft((current) => ({ ...current, notes: event.target.value }))} rows={2} placeholder="Notes" />
+        <CardHeader className="gap-4">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-1">
+              <CardTitle className="text-base">Pipeline</CardTitle>
+              <CardDescription>
+                The active applications route now prioritizes a grouped workflow view instead of a permanent spreadsheet.
+              </CardDescription>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex items-center gap-1 rounded-xl border border-border/70 bg-background/70 p-1">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={viewMode === "board" ? "default" : "ghost"}
+                  className="rounded-lg"
+                  onClick={() => setViewMode("board")}
+                >
+                  <KanbanSquare className="h-4 w-4" />
+                  Board
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={viewMode === "list" ? "default" : "ghost"}
+                  className="rounded-lg"
+                  onClick={() => setViewMode("list")}
+                >
+                  <List className="h-4 w-4" />
+                  List
+                </Button>
+              </div>
+              <Button onClick={() => setCreateOpen(true)} className="gap-2">
+                <Plus className="h-4 w-4" />
+                Add Application
+              </Button>
+            </div>
           </div>
-        </CardContent>
-      </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-sm">Bulk Actions</CardTitle>
-          <div className="flex flex-wrap gap-2">
-            <Button size="sm" variant="outline" disabled={selectedIds.length === 0} onClick={() => void bulkFollowUp()}>
-              Set Follow-up
-            </Button>
-            <Button size="sm" variant="outline" disabled={selectedIds.length === 0} onClick={() => void applyBulkStatus("rejected")}>
-              Mark Rejected
-            </Button>
-            <Button size="sm" variant="outline" disabled={selectedIds.length === 0} onClick={() => void applyBulkStatus("screen")}>
-              Update Status
-            </Button>
+          <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+            <Tabs value={stageGroup} onValueChange={(value) => setStageGroup(value as ApplicationStageGroup)} className="gap-3">
+              <TabsList className="h-auto w-full flex-wrap justify-start rounded-2xl bg-muted/70 p-1 sm:w-fit">
+                {(Object.keys(APPLICATION_STAGE_GROUPS) as ApplicationStageGroup[]).map((group) => (
+                  <TabsTrigger key={group} value={group} className="rounded-xl px-3 py-2 text-sm">
+                    {APPLICATION_STAGE_GROUPS[group].label}
+                    <Badge variant="outline" className="ml-1 rounded-full bg-background/70 px-1.5 py-0 text-[10px]">
+                      {applications.filter((application) => APPLICATION_STAGE_GROUPS[group].statuses.includes(application.status)).length}
+                    </Badge>
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+
+            <div className="relative w-full xl:max-w-sm">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Search company, role, next action, notes"
+                className="pl-9"
+              />
+            </div>
           </div>
         </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead />
-                <TableHead>Date Applied</TableHead>
-                <TableHead>Company</TableHead>
-                <TableHead>Role</TableHead>
-                <TableHead>Channel</TableHead>
-                <TableHead>CV Version</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Tailored CV</TableHead>
-                <TableHead>Next Action</TableHead>
-                <TableHead>Notes</TableHead>
-                <TableHead />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {applications.map((application) => (
-                <TableRow key={application.id}>
-                  <TableCell>
-                    <input
-                      type="checkbox"
-                      checked={byId.has(application.id)}
-                      onChange={() => toggle(application.id)}
-                    />
-                  </TableCell>
-                  <TableCell>{application.dateApplied}</TableCell>
-                  <TableCell>{companies.find((company) => company.id === application.companyId)?.name ?? "-"}</TableCell>
-                  <TableCell>{roles.find((role) => role.id === application.roleId)?.title ?? "-"}</TableCell>
-                  <TableCell>{application.channel}</TableCell>
-                  <TableCell>{getApplicationCvLabel(application, assets.cvs)}</TableCell>
-                  <TableCell>
-                    <Select value={application.status} onValueChange={(value) => void updateApplication(application.id, { status: value as ApplicationStatus })}>
-                      <SelectTrigger className="w-36"><SelectValue /></SelectTrigger>
-                      <SelectContent>{STATUS_VALUES.map((status) => <SelectItem key={status} value={status}>{status}</SelectItem>)}</SelectContent>
-                    </Select>
-                  </TableCell>
-                  <TableCell>
-                    {application.tailoredCvUpdatedAt ? new Date(application.tailoredCvUpdatedAt).toLocaleDateString() : "Not saved"}
-                  </TableCell>
-                  <TableCell>{application.nextAction || "-"}</TableCell>
-                  <TableCell className="max-w-[260px] truncate">{application.notes || "-"}</TableCell>
-                  <TableCell>
-                    <div className="flex gap-2">
-                      <Button asChild size="sm" variant="outline">
-                        <Link to={`/cv-optimizer?applicationId=${application.id}`}>Tailor CV</Link>
-                      </Button>
-                      <Button size="sm" variant="ghost" className="text-red-500" onClick={() => void removeApplication(application.id)}>
-                        Delete
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </CardContent>
       </Card>
+
+      {selectedIds.length > 0 ? (
+        <Card>
+          <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-sm text-muted-foreground">
+              {selectedIds.length} application{selectedIds.length === 1 ? "" : "s"} selected.
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button size="sm" variant="outline" onClick={() => void bulkFollowUp()}>
+                Set Follow-up
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => void applyBulkStatus("screen")}>
+                Move to Screen
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => void applyBulkStatus("rejected")}>
+                Mark Rejected
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setSelectedIds([])}>
+                Clear
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {viewMode === "board" ? (
+        <Card>
+          <CardContent className="pt-6">
+            <JobOsPipelineBoard
+              applications={filteredApplications}
+              companiesById={companiesById as Map<string, JobOsCompany>}
+              rolesById={rolesById as Map<string, JobOsRole>}
+              group={stageGroup}
+              onSelectApplication={(application) => setDetailId(application.id)}
+            />
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="pt-6">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead />
+                  <TableHead>Company</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Applied</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>CV</TableHead>
+                  <TableHead>Next Action</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredApplications.map((application) => (
+                  <TableRow key={application.id}>
+                    <TableCell>
+                      <input
+                        type="checkbox"
+                        checked={selectedSet.has(application.id)}
+                        onChange={() => toggleSelection(application.id)}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      {companiesById.get(application.companyId)?.name ?? "-"}
+                    </TableCell>
+                    <TableCell>{rolesById.get(application.roleId)?.title ?? "-"}</TableCell>
+                    <TableCell>{application.dateApplied}</TableCell>
+                    <TableCell>
+                      <Select value={application.status} onValueChange={(value) => void updateApplication(application.id, { status: value as ApplicationStatus })}>
+                        <SelectTrigger className="w-36">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {STATUS_VALUES.map((status) => (
+                            <SelectItem key={status} value={status}>
+                              {APPLICATION_STATUS_LABELS[status]}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                    <TableCell>{getApplicationCvLabel(application, assets.cvs)}</TableCell>
+                    <TableCell className="max-w-[220px] truncate">{application.nextAction || "-"}</TableCell>
+                    <TableCell>
+                      <div className="flex gap-2">
+                        <Button size="sm" variant="outline" onClick={() => setDetailId(application.id)}>
+                          View
+                        </Button>
+                        <Button asChild size="sm" variant="outline">
+                          <Link to={`/cv-optimizer?applicationId=${application.id}`}>Tailor CV</Link>
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="text-red-500"
+                          onClick={() => void removeApplication(application.id)}
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {filteredApplications.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={8} className="py-10 text-center text-sm text-muted-foreground">
+                      No applications match this stage group and search.
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Add Application</DialogTitle>
+            <DialogDescription>
+              Capture a new application without leaving the pipeline surface.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            <Input
+              type="date"
+              value={draft.dateApplied}
+              onChange={(event) => setDraft((current) => ({ ...current, dateApplied: event.target.value }))}
+            />
+            <Input
+              value={draft.channel}
+              onChange={(event) => setDraft((current) => ({ ...current, channel: event.target.value }))}
+              placeholder="Channel"
+            />
+            <Select value={draft.companyId} onValueChange={(value) => setDraft((current) => ({ ...current, companyId: value, roleId: "" }))}>
+              <SelectTrigger>
+                <SelectValue placeholder="Company" />
+              </SelectTrigger>
+              <SelectContent>
+                {companies.map((company) => (
+                  <SelectItem key={company.id} value={company.id}>
+                    {company.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={draft.roleId} onValueChange={(value) => setDraft((current) => ({ ...current, roleId: value }))}>
+              <SelectTrigger>
+                <SelectValue placeholder="Role" />
+              </SelectTrigger>
+              <SelectContent>
+                {roles
+                  .filter((role) => !draft.companyId || role.companyId === draft.companyId)
+                  .map((role) => (
+                    <SelectItem key={role.id} value={role.id}>
+                      {role.title}
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={draft.cvAssetId ?? ""}
+              onValueChange={(value) => {
+                const selectedCv = assets.cvs.find((cv) => cv.id === value);
+                setDraft((current) => ({
+                  ...current,
+                  cvAssetId: selectedCv?.id,
+                  cvVersion: selectedCv?.name ?? "",
+                }));
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="CV asset" />
+              </SelectTrigger>
+              <SelectContent>
+                {assets.cvs.map((cv) => (
+                  <SelectItem key={cv.id} value={cv.id}>
+                    {cv.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={draft.status} onValueChange={(value) => setDraft((current) => ({ ...current, status: value as ApplicationStatus }))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUS_VALUES.map((status) => (
+                  <SelectItem key={status} value={status}>
+                    {APPLICATION_STATUS_LABELS[status]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <div className="md:col-span-2">
+              <Input
+                value={draft.nextAction}
+                onChange={(event) => setDraft((current) => ({ ...current, nextAction: event.target.value }))}
+                placeholder="Next action"
+              />
+            </div>
+            <div className="md:col-span-2">
+              <Textarea
+                value={draft.notes}
+                onChange={(event) => setDraft((current) => ({ ...current, notes: event.target.value }))}
+                rows={4}
+                placeholder="Notes"
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setCreateOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={() => void handleCreateApplication()} disabled={!draft.companyId || !draft.roleId}>
+              Save Application
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={Boolean(detailApplication)} onOpenChange={(open) => !open && setDetailId(null)}>
+        <DialogContent className="max-w-2xl">
+          {detailApplication && detailDraft ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>
+                  {companiesById.get(detailApplication.companyId)?.name ?? "Unknown company"}
+                </DialogTitle>
+                <DialogDescription>
+                  {rolesById.get(detailApplication.roleId)?.title ?? "Unknown role"}
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-1">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Applied
+                  </div>
+                  <div className="text-sm text-foreground">{detailApplication.dateApplied}</div>
+                </div>
+                <div className="space-y-1">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Channel
+                  </div>
+                  <div className="text-sm text-foreground">{detailApplication.channel}</div>
+                </div>
+                <div className="md:col-span-2">
+                  <Select value={detailDraft.status} onValueChange={(value) => setDetailDraft((current) => current ? { ...current, status: value as ApplicationStatus } : current)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {STATUS_VALUES.map((status) => (
+                        <SelectItem key={status} value={status}>
+                          {APPLICATION_STATUS_LABELS[status]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="md:col-span-2">
+                  <Input
+                    value={detailDraft.nextAction}
+                    onChange={(event) => setDetailDraft((current) => current ? { ...current, nextAction: event.target.value } : current)}
+                    placeholder="Next action"
+                  />
+                </div>
+                <div className="md:col-span-2">
+                  <Textarea
+                    value={detailDraft.notes}
+                    onChange={(event) => setDetailDraft((current) => current ? { ...current, notes: event.target.value } : current)}
+                    rows={5}
+                    placeholder="Notes"
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-wrap justify-between gap-2">
+                <div className="flex gap-2">
+                  <Button asChild variant="outline">
+                    <Link to={`/cv-optimizer?applicationId=${detailApplication.id}`}>Tailor CV</Link>
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    className="text-red-500"
+                    onClick={() => {
+                      void removeApplication(detailApplication.id);
+                      setDetailId(null);
+                    }}
+                  >
+                    Delete
+                  </Button>
+                </div>
+                <Button onClick={() => void handleSaveDetails()}>
+                  Save Changes
+                </Button>
+              </div>
+            </>
+          ) : null}
+        </DialogContent>
+      </Dialog>
     </JobOsLayout>
   );
 }

--- a/src/app/pages/job-os/JobOsCompaniesPage.tsx
+++ b/src/app/pages/job-os/JobOsCompaniesPage.tsx
@@ -6,7 +6,9 @@ import {
   ChevronDown,
   ChevronRight,
   Download,
+  Eye,
   Link,
+  Trash2,
   Upload,
 } from "lucide-react";
 import { Button } from "../../components/ui/button";
@@ -35,6 +37,12 @@ import {
 } from "../../components/ui/table";
 import { Textarea } from "../../components/ui/textarea";
 import { Checkbox } from "../../components/ui/checkbox";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../../components/ui/tooltip";
 import { useApp } from "../../context";
 import { useJobOs } from "../../hooks/useJobOs";
 import { JobOsLayout } from "../../components/job-os/JobOsLayout";
@@ -132,7 +140,7 @@ export default function JobOsCompaniesPage() {
   } = useJobOs(session?.userId ?? null);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [addFormOpen, setAddFormOpen] = useState(true);
+  const [addFormOpen, setAddFormOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [isImporting, setIsImporting] = useState(false);
   const [bulkText, setBulkText] = useState("");
@@ -656,6 +664,7 @@ export default function JobOsCompaniesPage() {
           </div>
         </CardHeader>
         <CardContent>
+          <TooltipProvider delayDuration={150}>
           <Table>
             <TableHeader>
               <TableRow>
@@ -681,7 +690,7 @@ export default function JobOsCompaniesPage() {
                 <TableHead>
                   <SortHeader label="Notes" column="notes" />
                 </TableHead>
-                <TableHead />
+                <TableHead className="text-right">Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -699,28 +708,47 @@ export default function JobOsCompaniesPage() {
                   <TableCell className="max-w-[260px] truncate">
                     {company.notes || "-"}
                   </TableCell>
-                  <TableCell className="flex gap-2">
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => setSelectedCompanyId(company.id)}
-                    >
-                      View
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="text-red-500"
-                      disabled={companyListLocked}
-                      onClick={() => void removeCompany(company.id)}
-                    >
-                      Delete
-                    </Button>
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-1">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex">
+                            <Button
+                              size="icon"
+                              variant="outline"
+                              onClick={() => setSelectedCompanyId(company.id)}
+                              aria-label="View company"
+                            >
+                              <Eye className="h-4 w-4" />
+                            </Button>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">View</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex">
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/20"
+                              disabled={companyListLocked}
+                              onClick={() => void removeCompany(company.id)}
+                              aria-label="Delete company"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">Delete</TooltipContent>
+                      </Tooltip>
+                    </div>
                   </TableCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
+          </TooltipProvider>
         </CardContent>
       </Card>
 
@@ -1029,6 +1057,7 @@ export default function JobOsCompaniesPage() {
         addCompany={addCompany}
         updateCompany={updateCompany}
         addRole={addRole}
+        addApplication={addApplication}
       />
     </JobOsLayout>
   );

--- a/src/app/pages/job-os/JobOsRolesPage.tsx
+++ b/src/app/pages/job-os/JobOsRolesPage.tsx
@@ -1,12 +1,28 @@
 import { Link } from "react-router";
 import { useMemo, useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  BriefcaseBusiness,
+  Check,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Pencil,
+  Rocket,
+  Trash2,
+  WandSparkles,
+  X,
+} from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../../components/ui/dialog";
 import { Input } from "../../components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { Textarea } from "../../components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../../components/ui/tooltip";
 import { useApp } from "../../context";
 import { useJobOs } from "../../hooks/useJobOs";
 import { JobOsLayout } from "../../components/job-os/JobOsLayout";
@@ -15,10 +31,29 @@ import { getRecommendedCvForTrack } from "../../services/cvAssets";
 import type { JobOsRole, JobTrack, RoleStatus } from "../../types/jobOs";
 
 type RoleOrigin = "self_sourced" | "recruiter";
+type RoleSortKey =
+  | "company"
+  | "title"
+  | "location"
+  | "seniority"
+  | "track"
+  | "fitScore"
+  | "status";
 
 const ROLE_STATUSES: RoleStatus[] = ["to_apply", "applied", "interview", "rejected", "offer", "closed"];
 const SENIORITY_OPTIONS = ["Senior", "Middle", "Junior"] as const;
 const LOCATION_SUGGESTIONS = ["Remote", "Hybrid"] as const;
+const FIT_FILTER_VALUES = ["all", "2", "3", "4", "5"] as const;
+
+interface RoleTableFilters {
+  company: string;
+  title: string;
+  location: string;
+  seniority: string;
+  track: string;
+  fitMin: string;
+  status: string;
+}
 
 function normalizeSeniority(value: string): string {
   const trimmed = value.trim().toLowerCase();
@@ -46,13 +81,23 @@ export default function JobOsRolesPage() {
     replaceState,
   } = useJobOs(session?.userId ?? null);
 
-  const [filterTrack, setFilterTrack] = useState<string>("all");
-  const [filterStatus, setFilterStatus] = useState<string>("all");
   const [addFormOpen, setAddFormOpen] = useState(false);
   const [editingRoleId, setEditingRoleId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState<Omit<JobOsRole, "id" | "createdAt" | "updatedAt"> | null>(null);
   const [formNotice, setFormNotice] = useState<string | null>(null);
   const [actionNotice, setActionNotice] = useState<{ tone: "success" | "error"; message: string } | null>(null);
+  const [sortKey, setSortKey] = useState<RoleSortKey>("title");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+  const [tableFilters, setTableFilters] = useState<RoleTableFilters>({
+    company: "",
+    title: "",
+    location: "",
+    seniority: "all",
+    track: "all",
+    fitMin: "all",
+    status: "all",
+  });
+  const [selectedJdRoleId, setSelectedJdRoleId] = useState<string | null>(null);
   const [draft, setDraft] = useState<Omit<JobOsRole, "id" | "createdAt" | "updatedAt">>({
     companyId: "",
     title: "",
@@ -67,20 +112,126 @@ export default function JobOsRolesPage() {
     jobDescriptionUpdatedAt: undefined,
   });
 
-  const filtered = useMemo(
-    () =>
-      roles.filter((role) => {
-        if (filterTrack !== "all" && role.track !== filterTrack) return false;
-        if (filterStatus !== "all" && role.status !== filterStatus) return false;
-        return true;
-      }),
-    [roles, filterStatus, filterTrack]
+  const companiesById = useMemo(
+    () => new Map(companies.map((company) => [company.id, company])),
+    [companies]
   );
+
+  const filtered = useMemo(() => {
+    const companyQuery = tableFilters.company.trim().toLowerCase();
+    const titleQuery = tableFilters.title.trim().toLowerCase();
+    const locationQuery = tableFilters.location.trim().toLowerCase();
+
+    return roles.filter((role) => {
+      const companyName = companiesById.get(role.companyId)?.name ?? "";
+
+      if (companyQuery && !companyName.toLowerCase().includes(companyQuery)) return false;
+      if (titleQuery && !role.title.toLowerCase().includes(titleQuery)) return false;
+      if (locationQuery && !role.location.toLowerCase().includes(locationQuery)) return false;
+      if (
+        tableFilters.seniority !== "all" &&
+        normalizeSeniority(role.seniority) !== tableFilters.seniority
+      ) {
+        return false;
+      }
+      if (tableFilters.track !== "all" && role.track !== tableFilters.track) return false;
+      if (tableFilters.status !== "all" && role.status !== tableFilters.status) return false;
+      if (tableFilters.fitMin !== "all" && role.fitScore < Number(tableFilters.fitMin)) {
+        return false;
+      }
+
+      return true;
+    });
+  }, [companiesById, roles, tableFilters]);
+
+  const sortedRoles = useMemo(() => {
+    const statusRank: Record<RoleStatus, number> = {
+      to_apply: 0,
+      applied: 1,
+      interview: 2,
+      offer: 3,
+      rejected: 4,
+      closed: 5,
+    };
+    const seniorityRank: Record<string, number> = {
+      Junior: 0,
+      Middle: 1,
+      Senior: 2,
+    };
+
+    return [...filtered].sort((a, b) => {
+      const companyA = companiesById.get(a.companyId)?.name ?? "";
+      const companyB = companiesById.get(b.companyId)?.name ?? "";
+
+      let cmp = 0;
+      switch (sortKey) {
+        case "company":
+          cmp = companyA.localeCompare(companyB, undefined, { sensitivity: "base" });
+          break;
+        case "fitScore":
+          cmp = a.fitScore - b.fitScore;
+          break;
+        case "status":
+          cmp = statusRank[a.status] - statusRank[b.status];
+          break;
+        case "seniority":
+          cmp =
+            (seniorityRank[normalizeSeniority(a.seniority)] ?? 999) -
+            (seniorityRank[normalizeSeniority(b.seniority)] ?? 999);
+          break;
+        case "location":
+        case "title":
+        case "track":
+        default:
+          cmp = String(a[sortKey] ?? "").localeCompare(String(b[sortKey] ?? ""), undefined, {
+            sensitivity: "base",
+          });
+      }
+
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+  }, [companiesById, filtered, sortDir, sortKey]);
 
   const applicationRoleIds = useMemo(
     () => new Set(applications.map((application) => application.roleId).filter(Boolean)),
     [applications]
   );
+  const selectedJdRole =
+    selectedJdRoleId ? roles.find((role) => role.id === selectedJdRoleId) ?? null : null;
+  const selectedJdDraft =
+    selectedJdRole && editingRoleId === selectedJdRole.id && editDraft ? editDraft : null;
+
+  function toggleSort(nextKey: RoleSortKey): void {
+    if (sortKey === nextKey) {
+      setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortKey(nextKey);
+    setSortDir("asc");
+  }
+
+  function SortHeader({ label, column }: { label: string; column: RoleSortKey }) {
+    const active = sortKey === column;
+    return (
+      <button
+        type="button"
+        onClick={() => toggleSort(column)}
+        className="inline-flex items-center gap-1 font-medium text-foreground hover:text-primary transition-colors"
+      >
+        {label}
+        {!active && <ArrowUpDown className="w-3.5 h-3.5 opacity-60" />}
+        {active && sortDir === "asc" && <ArrowUp className="w-3.5 h-3.5 text-primary" />}
+        {active && sortDir === "desc" && <ArrowDown className="w-3.5 h-3.5 text-primary" />}
+      </button>
+    );
+  }
+
+  function updateTableFilter<K extends keyof RoleTableFilters>(
+    key: K,
+    value: RoleTableFilters[K]
+  ): void {
+    setTableFilters((current) => ({ ...current, [key]: value }));
+  }
 
   function startEdit(role: JobOsRole): void {
     setEditingRoleId(role.id);
@@ -298,24 +449,6 @@ export default function JobOsRolesPage() {
       <Card>
         <CardHeader>
           <CardTitle className="text-sm">Roles Pipeline</CardTitle>
-          <div className="flex gap-2">
-            <Select value={filterTrack} onValueChange={setFilterTrack}>
-              <SelectTrigger className="w-52"><SelectValue placeholder="Track" /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All Tracks</SelectItem>
-                <SelectItem value="TPM">TPM</SelectItem>
-                <SelectItem value="Product Engineer">Product Engineer</SelectItem>
-                <SelectItem value="Systems PM">Systems PM</SelectItem>
-              </SelectContent>
-            </Select>
-            <Select value={filterStatus} onValueChange={setFilterStatus}>
-              <SelectTrigger className="w-52"><SelectValue placeholder="Status" /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All Statuses</SelectItem>
-                {ROLE_STATUSES.map((status) => <SelectItem key={status} value={status}>{status}</SelectItem>)}
-              </SelectContent>
-            </Select>
-          </div>
         </CardHeader>
         <CardContent>
           {actionNotice ? (
@@ -329,22 +462,121 @@ export default function JobOsRolesPage() {
               {actionNotice.message}
             </div>
           ) : null}
+          <TooltipProvider delayDuration={150}>
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Company</TableHead>
-                <TableHead>Title</TableHead>
-                <TableHead>Location</TableHead>
-                <TableHead>Seniority</TableHead>
-                <TableHead>Track</TableHead>
-                <TableHead>Fit</TableHead>
-                <TableHead>Status</TableHead>
+                <TableHead><SortHeader label="Company" column="company" /></TableHead>
+                <TableHead><SortHeader label="Title" column="title" /></TableHead>
+                <TableHead><SortHeader label="Location" column="location" /></TableHead>
+                <TableHead><SortHeader label="Seniority" column="seniority" /></TableHead>
+                <TableHead><SortHeader label="Track" column="track" /></TableHead>
+                <TableHead><SortHeader label="Fit" column="fitScore" /></TableHead>
+                <TableHead><SortHeader label="Status" column="status" /></TableHead>
                 <TableHead>JD</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+              <TableRow className="bg-muted/20 hover:bg-muted/20">
+                <TableHead>
+                  <Input
+                    value={tableFilters.company}
+                    onChange={(event) => updateTableFilter("company", event.target.value)}
+                    placeholder="Filter company"
+                    className="h-8 min-w-[140px]"
+                  />
+                </TableHead>
+                <TableHead>
+                  <Input
+                    value={tableFilters.title}
+                    onChange={(event) => updateTableFilter("title", event.target.value)}
+                    placeholder="Filter title"
+                    className="h-8 min-w-[160px]"
+                  />
+                </TableHead>
+                <TableHead>
+                  <Input
+                    value={tableFilters.location}
+                    onChange={(event) => updateTableFilter("location", event.target.value)}
+                    placeholder="Filter location"
+                    className="h-8 min-w-[130px]"
+                  />
+                </TableHead>
+                <TableHead>
+                  <Select
+                    value={tableFilters.seniority}
+                    onValueChange={(value) => updateTableFilter("seniority", value)}
+                  >
+                    <SelectTrigger className="h-8 min-w-[120px]">
+                      <SelectValue placeholder="All" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All</SelectItem>
+                      {SENIORITY_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {option}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </TableHead>
+                <TableHead>
+                  <Select
+                    value={tableFilters.track}
+                    onValueChange={(value) => updateTableFilter("track", value)}
+                  >
+                    <SelectTrigger className="h-8 min-w-[140px]">
+                      <SelectValue placeholder="All tracks" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All tracks</SelectItem>
+                      <SelectItem value="TPM">TPM</SelectItem>
+                      <SelectItem value="Product Engineer">Product Engineer</SelectItem>
+                      <SelectItem value="Systems PM">Systems PM</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </TableHead>
+                <TableHead>
+                  <Select
+                    value={tableFilters.fitMin}
+                    onValueChange={(value) => updateTableFilter("fitMin", value)}
+                  >
+                    <SelectTrigger className="h-8 min-w-[96px]">
+                      <SelectValue placeholder="All" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All</SelectItem>
+                      {FIT_FILTER_VALUES.filter((value) => value !== "all").map((value) => (
+                        <SelectItem key={value} value={value}>
+                          {value}+
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </TableHead>
+                <TableHead>
+                  <Select
+                    value={tableFilters.status}
+                    onValueChange={(value) => updateTableFilter("status", value)}
+                  >
+                    <SelectTrigger className="h-8 min-w-[130px]">
+                      <SelectValue placeholder="All statuses" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All statuses</SelectItem>
+                      {ROLE_STATUSES.map((status) => (
+                        <SelectItem key={status} value={status}>
+                          {status}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </TableHead>
+                <TableHead />
                 <TableHead />
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filtered.map((role) => (
+              {sortedRoles.map((role) => (
                 <TableRow key={role.id}>
                   <TableCell>
                     {editingRoleId === role.id && editDraft ? (
@@ -358,7 +590,7 @@ export default function JobOsRolesPage() {
                         </SelectContent>
                       </Select>
                     ) : (
-                      companies.find((company) => company.id === role.companyId)?.name ?? "-"
+                      companiesById.get(role.companyId)?.name ?? "-"
                     )}
                   </TableCell>
                   <TableCell className="font-medium">
@@ -473,58 +705,219 @@ export default function JobOsRolesPage() {
                       </Select>
                     )}
                   </TableCell>
-                  <TableCell className="max-w-[260px] align-top">
-                    {editingRoleId === role.id && editDraft ? (
-                      <Textarea
-                        value={editDraft.jobDescription ?? ""}
-                        onChange={(event) => setEditDraft((current) => (current ? { ...current, jobDescription: event.target.value } : current))}
-                        rows={5}
-                        className="min-w-[240px]"
-                      />
-                    ) : role.jobDescription ? (
-                      <div className="line-clamp-4 text-sm text-muted-foreground">{role.jobDescription}</div>
+                  <TableCell className="whitespace-nowrap">
+                    {role.jobDescription || (editingRoleId === role.id && editDraft?.jobDescription) ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setSelectedJdRoleId(role.id)}
+                      >
+                        {editingRoleId === role.id ? "Edit JD" : "View JD"}
+                      </Button>
                     ) : (
-                      <span className="text-sm text-muted-foreground">No stored JD</span>
-                    )}
-                  </TableCell>
-                  <TableCell className="flex gap-2">
-                    {editingRoleId === role.id ? (
-                      <>
-                        <Button size="sm" variant="default" onClick={() => void saveEdit(role.id)}>Save</Button>
-                        <Button size="sm" variant="outline" onClick={cancelEdit}>Cancel</Button>
-                      </>
-                    ) : (
-                      <Button size="sm" variant="outline" onClick={() => startEdit(role)}>
-                        Edit
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setSelectedJdRoleId(role.id)}
+                      >
+                        Add JD
                       </Button>
                     )}
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={applicationRoleIds.has(role.id)}
-                      onClick={() => void handleAddApplication(role)}
-                    >
-                      {applicationRoleIds.has(role.id) ? "Application logged" : "Add application"}
-                    </Button>
-                    <Button asChild size="sm" variant="secondary">
-                      <Link to={`/cv-optimizer?roleId=${role.id}`}>Tailor CV</Link>
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      disabled={!role.url}
-                      onClick={() => window.open(role.url, "_blank", "noopener,noreferrer")}
-                    >
-                      Quick apply
-                    </Button>
-                    <Button size="sm" variant="ghost" className="text-red-500" onClick={() => void removeRole(role.id)}>Delete</Button>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-1">
+                    {editingRoleId === role.id ? (
+                      <>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="inline-flex">
+                              <Button
+                                size="icon"
+                                variant="default"
+                                onClick={() => void saveEdit(role.id)}
+                                aria-label="Save role"
+                              >
+                                <Check className="h-4 w-4" />
+                              </Button>
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="top">Save</TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="inline-flex">
+                              <Button
+                                size="icon"
+                                variant="outline"
+                                onClick={cancelEdit}
+                                aria-label="Cancel editing"
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="top">Cancel</TooltipContent>
+                        </Tooltip>
+                      </>
+                    ) : (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex">
+                            <Button
+                              size="icon"
+                              variant="outline"
+                              onClick={() => startEdit(role)}
+                              aria-label="Edit role"
+                            >
+                              <Pencil className="h-4 w-4" />
+                            </Button>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">Edit</TooltipContent>
+                      </Tooltip>
+                    )}
+                    {applicationRoleIds.has(role.id) ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex">
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="text-emerald-600 hover:text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-950/30"
+                              aria-label="Application already logged"
+                            >
+                              <CheckCircle2 className="h-4 w-4" />
+                            </Button>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">Application logged</TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex">
+                            <Button
+                              size="icon"
+                              variant="outline"
+                              onClick={() => void handleAddApplication(role)}
+                              aria-label="Add application"
+                            >
+                              <BriefcaseBusiness className="h-4 w-4" />
+                            </Button>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">Add application</TooltipContent>
+                      </Tooltip>
+                    )}
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex">
+                          <Button asChild size="icon" variant="secondary" aria-label="Tailor CV">
+                            <Link to={`/cv-optimizer?roleId=${role.id}`}>
+                              <WandSparkles className="h-4 w-4" />
+                            </Link>
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">Tailor CV</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex">
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            disabled={!role.url}
+                            onClick={() => window.open(role.url, "_blank", "noopener,noreferrer")}
+                            aria-label="Quick apply"
+                          >
+                            <Rocket className="h-4 w-4" />
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">Quick apply</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex">
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/20"
+                            onClick={() => void removeRole(role.id)}
+                            aria-label="Delete role"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">Delete</TooltipContent>
+                    </Tooltip>
+                    </div>
                   </TableCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
+          </TooltipProvider>
         </CardContent>
       </Card>
+
+      <Dialog
+        open={!!selectedJdRole}
+        onOpenChange={(open) => {
+          if (!open) setSelectedJdRoleId(null);
+        }}
+      >
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>{selectedJdRole?.title ?? "Job Description"}</DialogTitle>
+          </DialogHeader>
+          {selectedJdRole ? (
+            <div className="space-y-4">
+              <div className="grid gap-2 text-sm text-muted-foreground md:grid-cols-2">
+                <div>
+                  <span className="font-medium text-foreground">Company:</span>{" "}
+                  {companiesById.get(selectedJdRole.companyId)?.name ?? "-"}
+                </div>
+                <div>
+                  <span className="font-medium text-foreground">Location:</span>{" "}
+                  {(selectedJdDraft?.location ?? selectedJdRole.location) || "-"}
+                </div>
+                <div>
+                  <span className="font-medium text-foreground">Seniority:</span>{" "}
+                  {normalizeSeniority(selectedJdDraft?.seniority ?? selectedJdRole.seniority) || "-"}
+                </div>
+                <div>
+                  <span className="font-medium text-foreground">Track:</span>{" "}
+                  {selectedJdDraft?.track ?? selectedJdRole.track}
+                </div>
+                <div>
+                  <span className="font-medium text-foreground">Fit:</span>{" "}
+                  {selectedJdDraft?.fitScore ?? selectedJdRole.fitScore}/5
+                </div>
+              </div>
+              {selectedJdDraft ? (
+                <Textarea
+                  value={selectedJdDraft.jobDescription ?? ""}
+                  onChange={(event) =>
+                    setEditDraft((current) =>
+                      current ? { ...current, jobDescription: event.target.value } : current
+                    )
+                  }
+                  rows={18}
+                  className="min-h-[26rem]"
+                  placeholder="Paste or refine the full job description here."
+                />
+              ) : (
+                <div className="max-h-[60vh] overflow-y-auto rounded-md border bg-muted/10 p-4 text-sm leading-6 whitespace-pre-wrap">
+                  {selectedJdRole.jobDescription || "No job description stored."}
+                </div>
+              )}
+            </div>
+          ) : null}
+        </DialogContent>
+      </Dialog>
     </JobOsLayout>
   );
 }

--- a/src/app/services/ingestion/companyIngestionService.ts
+++ b/src/app/services/ingestion/companyIngestionService.ts
@@ -4,8 +4,11 @@ import type {
   NormalizedImportResult,
   NormalizedCompanyDraft,
   NormalizedRoleDraft,
+  JobImportEnrichmentResponse,
+  JobSourceData,
   SourceAdapter,
 } from "./types";
+import type { AiImportEnrichmentV1, JobTrack } from "../../types/jobOs";
 import { greenhouseAdapter } from "./sourceAdapters/greenhouseAdapter";
 import { leverAdapter } from "./sourceAdapters/leverAdapter";
 import { ashbyAdapter } from "./sourceAdapters/ashbyAdapter";
@@ -13,9 +16,23 @@ import { himalayasAdapter } from "./sourceAdapters/himalayasAdapter";
 import { linkedInAdapter } from "./sourceAdapters/linkedInAdapter";
 import { genericAdapter } from "./sourceAdapters/genericAdapter";
 import {
+  cleanCompanyCandidate,
+  cleanLocationCandidate,
+  cleanTitleCandidate,
+  extractJsonLdJobPosting,
+  extractMetaDescription,
+  extractMetaTags,
+  extractMetaTitle,
+  extractPrimaryHeading,
   inferPortfolioNote,
   inferEnglishFirst,
   inferTrack,
+  inferEmploymentType,
+  inferPostedDate,
+  isLikelyCompanyName,
+  isLikelyJobTitle,
+  isLikelyLocation,
+  preprocessJobDescription,
   humanizeSlug,
 } from "./utils";
 import type { JobOsCompany } from "../../types/jobOs";
@@ -36,7 +53,8 @@ export async function parseFromInput(
 ): Promise<ParsedImportResult> {
   const adapter =
     ADAPTERS.find((a) => a.canHandle(input.url)) ?? genericAdapter;
-  return adapter.parse(input);
+  const parsed = await adapter.parse(input);
+  return finalizeParsedImportResult(parsed, input.url, input.pastedText);
 }
 
 /**
@@ -48,10 +66,10 @@ export function normalizeImportResult(
   sourceUrl: string,
   existingCompanies: JobOsCompany[]
 ): NormalizedImportResult {
-  const { extracted, sourcePlatform, sourceType, confidence } = parsed;
+  const { extracted, sourcePlatform, sourceType, confidence, aiEnrichment, jobSource } = parsed;
 
   const combinedText = [
-    extracted.jobDescription ?? "",
+    jobSource.rawJobDescription ?? extracted.jobDescription ?? "",
     extracted.industryHint ?? "",
     extracted.notes ?? "",
   ]
@@ -60,6 +78,7 @@ export function normalizeImportResult(
 
   // --- Company ---
   const companyName =
+    jobSource.companyName?.trim() ||
     extracted.companyName?.trim() ||
     extractCompanyNameFallback(sourceUrl);
 
@@ -76,31 +95,67 @@ export function normalizeImportResult(
     notes: noteParts.join(". "),
     website: extracted.website,
     careersUrl: extracted.careersUrl,
-    location: extracted.locationHint,
+    location: jobSource.rawLocation ?? extracted.locationHint,
     englishFirst:
       extracted.englishFirstHint ?? inferEnglishFirst(combinedText),
     sourceUrl,
     sourcePlatform,
     importConfidence: confidence,
     sourceType: "link",
+    aiEnrichment: aiEnrichment
+      ? {
+          ...aiEnrichment,
+          normalized: {
+            ...aiEnrichment.normalized,
+            company: {
+              ...aiEnrichment.normalized?.company,
+              name: companyName,
+              industry: extracted.industryHint ?? "",
+              size: extracted.sizeHint ?? "",
+              remotePolicy: extracted.remotePolicyHint ?? "",
+              location: extracted.locationHint,
+              englishFirst:
+                extracted.englishFirstHint ?? inferEnglishFirst(combinedText),
+            },
+          },
+        }
+      : undefined,
   };
 
   // --- Role ---
   let role: NormalizedRoleDraft | undefined;
-  if (sourceType === "job" || extracted.roleTitle) {
-    const roleTitle = extracted.roleTitle?.trim() || "New Role";
+  if (sourceType === "job" || jobSource.rawJobTitle || extracted.roleTitle) {
+    const roleTitle = jobSource.rawJobTitle?.trim() || extracted.roleTitle?.trim() || "New Role";
     role = {
       title: roleTitle,
       url: extracted.roleUrl ?? sourceUrl,
-      location: extracted.roleLocation ?? extracted.locationHint ?? "",
+      location: jobSource.rawLocation ?? extracted.roleLocation ?? extracted.locationHint ?? "",
       seniority: extracted.seniorityHint ?? "Mid",
       track: inferTrack(roleTitle),
       fitScore: 3,
       status: "to_apply",
-      jobDescription: extracted.jobDescription,
+      jobDescription: jobSource.rawJobDescription ?? extracted.jobDescription,
       sourcePlatform,
       importConfidence: confidence,
       sourceType: "link",
+      aiEnrichment: aiEnrichment
+        ? {
+            ...aiEnrichment,
+            normalized: {
+              ...aiEnrichment.normalized,
+              role: {
+                ...aiEnrichment.normalized?.role,
+                title: roleTitle,
+                url: extracted.roleUrl ?? sourceUrl,
+                location: extracted.roleLocation ?? extracted.locationHint ?? "",
+                seniority: extracted.seniorityHint ?? "Mid",
+                track: inferTrack(roleTitle),
+                fitScore: 3,
+                status: "to_apply",
+              },
+            },
+          }
+        : undefined,
     };
   }
 
@@ -116,10 +171,478 @@ export function normalizeImportResult(
     confidence,
     company,
     role,
+    aiEnrichment,
     duplicateMatch: duplicateMatch
       ? { companyId: duplicateMatch.id, companyName: duplicateMatch.name }
       : undefined,
   };
+}
+
+function finalizeParsedImportResult(
+  parsed: ParsedImportResult,
+  sourceUrl: string,
+  pastedText?: string
+): ParsedImportResult {
+  const html = parsed.raw.html ?? "";
+  const meta = parsed.raw.meta ?? (html ? extractMetaTags(html) : {});
+  const jsonLd = html ? extractJsonLdJobPosting(html) : null;
+  const heading = html ? extractPrimaryHeading(html) : "";
+  const combinedText = [
+    parsed.raw.text ?? "",
+    pastedText ?? "",
+    parsed.extracted.jobDescription ?? "",
+  ]
+    .join("\n")
+    .trim();
+
+  const titleResult = selectJobTitle({
+    platform: parsed.sourcePlatform,
+    extractedTitle: parsed.extracted.roleTitle,
+    metaTitle: extractMetaTitle(meta),
+    heading,
+    jsonLdTitle: asString(jsonLd?.title),
+    combinedText,
+  });
+
+  const companyResult = selectCompanyName({
+    platform: parsed.sourcePlatform,
+    extractedCompany: parsed.extracted.companyName,
+    metaCompany: meta["og:site_name"],
+    jsonLdCompany: asHiringOrganizationName(jsonLd),
+    sourceUrl,
+  });
+
+  const locationResult = selectLocation({
+    extractedLocation: parsed.extracted.roleLocation ?? parsed.extracted.locationHint,
+    jsonLdLocation: asJobLocation(jsonLd),
+    metaLocation: meta["job:location"] || meta["twitter:label1"],
+    combinedText,
+  });
+
+  const descriptionResult = selectDescription({
+    extractedDescription: parsed.extracted.jobDescription,
+    metaDescription: extractMetaDescription(meta),
+    pastedText,
+    rawText: parsed.raw.text,
+  });
+
+  const employmentType =
+    parsed.extracted.employmentTypeHint?.trim() ||
+    asEmploymentType(jsonLd) ||
+    inferEmploymentType(combinedText) ||
+    undefined;
+  const postedDate =
+    parsed.extracted.postedDateHint?.trim() ||
+    asDatePosted(jsonLd) ||
+    inferPostedDate(combinedText) ||
+    undefined;
+
+  const jobSource: JobSourceData = {
+    sourceUrl,
+    sourcePlatform: parsed.sourcePlatform,
+    sourceType: parsed.sourceType,
+    companyName: companyResult.value,
+    rawJobTitle: titleResult.value,
+    rawLocation: locationResult.value,
+    rawJobDescription: descriptionResult.value,
+    employmentType,
+    postedDate,
+    debug: {
+      titleSource: titleResult.source,
+      companySource: companyResult.source,
+      locationSource: locationResult.source,
+      descriptionSource: descriptionResult.source,
+    },
+  };
+
+  const confidence = scoreParsedJobSource(jobSource);
+
+  return {
+    ...parsed,
+    confidence,
+    raw: {
+      ...parsed.raw,
+      meta: Object.keys(meta).length > 0 ? meta : parsed.raw.meta,
+    },
+    extracted: {
+      ...parsed.extracted,
+      companyName: jobSource.companyName,
+      roleTitle: jobSource.rawJobTitle,
+      roleLocation: jobSource.rawLocation,
+      locationHint: jobSource.rawLocation ?? parsed.extracted.locationHint,
+      jobDescription: jobSource.rawJobDescription,
+      employmentTypeHint: employmentType,
+      postedDateHint: postedDate,
+    },
+    jobSource,
+  };
+}
+
+function selectJobTitle(input: {
+  platform: ParsedImportResult["sourcePlatform"];
+  extractedTitle?: string;
+  metaTitle?: string;
+  heading?: string;
+  jsonLdTitle?: string;
+  combinedText: string;
+}): { value?: string; source?: JobSourceData["debug"]["titleSource"] } {
+  const candidates: Array<{ value?: string; source: NonNullable<JobSourceData["debug"]>["titleSource"] }> = [
+    { value: input.jsonLdTitle, source: "jsonld" },
+    { value: input.metaTitle, source: "meta" },
+    { value: input.heading, source: "h1" },
+    { value: input.extractedTitle, source: "selector" },
+    { value: fallbackTitleFromText(input.combinedText, input.platform), source: "fallback" },
+  ];
+
+  for (const candidate of candidates) {
+    const cleaned = cleanTitleCandidate(candidate.value ?? "");
+    if (isLikelyJobTitle(cleaned)) {
+      return { value: cleaned, source: candidate.source };
+    }
+  }
+
+  return {};
+}
+
+function selectCompanyName(input: {
+  platform: ParsedImportResult["sourcePlatform"];
+  extractedCompany?: string;
+  metaCompany?: string;
+  jsonLdCompany?: string;
+  sourceUrl: string;
+}): { value?: string; source?: JobSourceData["debug"]["companySource"] } {
+  const domainFallback = extractCompanyNameFallback(input.sourceUrl);
+  const candidates: Array<{ value?: string; source: NonNullable<JobSourceData["debug"]>["companySource"] }> = [
+    { value: input.jsonLdCompany, source: "jsonld" },
+    { value: input.extractedCompany, source: "selector" },
+    { value: input.metaCompany, source: "meta" },
+    { value: domainFallback, source: "domain" },
+  ];
+
+  for (const candidate of candidates) {
+    const cleaned = cleanCompanyCandidate(candidate.value ?? "");
+    if (isLikelyCompanyName(cleaned)) {
+      return { value: cleaned, source: candidate.source };
+    }
+  }
+
+  return {};
+}
+
+function selectLocation(input: {
+  extractedLocation?: string;
+  jsonLdLocation?: string;
+  metaLocation?: string;
+  combinedText: string;
+}): { value?: string; source?: JobSourceData["debug"]["locationSource"] } {
+  const fallback = fallbackLocationFromText(input.combinedText);
+  const candidates: Array<{ value?: string; source: NonNullable<JobSourceData["debug"]>["locationSource"] }> = [
+    { value: input.jsonLdLocation, source: "jsonld" },
+    { value: input.extractedLocation, source: "selector" },
+    { value: input.metaLocation, source: "meta" },
+    { value: fallback, source: "text" },
+  ];
+
+  for (const candidate of candidates) {
+    const cleaned = cleanLocationCandidate(candidate.value ?? "");
+    if (isLikelyLocation(cleaned)) {
+      return { value: cleaned, source: candidate.source };
+    }
+  }
+
+  return {};
+}
+
+function selectDescription(input: {
+  extractedDescription?: string;
+  metaDescription?: string;
+  pastedText?: string;
+  rawText?: string;
+}): { value?: string; source?: JobSourceData["debug"]["descriptionSource"] } {
+  const candidates: Array<{ value?: string; source: NonNullable<JobSourceData["debug"]>["descriptionSource"] }> = [
+    { value: input.extractedDescription, source: "selector" },
+    { value: input.pastedText, source: "pasted_text" },
+    { value: input.rawText, source: "text" },
+    { value: input.metaDescription, source: "meta" },
+  ];
+
+  for (const candidate of candidates) {
+    const cleaned = preprocessJobDescription(candidate.value);
+    if (cleaned && cleaned.length >= 120) {
+      return { value: cleaned, source: candidate.source };
+    }
+  }
+
+  return {};
+}
+
+function fallbackTitleFromText(text: string, platform: ParsedImportResult["sourcePlatform"]): string {
+  const lines = text
+    .split("\n")
+    .map((line) => cleanTitleCandidate(line))
+    .filter(Boolean);
+
+  for (const line of lines.slice(0, platform === "linkedin" ? 12 : 8)) {
+    if (isLikelyJobTitle(line)) {
+      return line;
+    }
+  }
+
+  return "";
+}
+
+function fallbackLocationFromText(text: string): string {
+  const lines = text
+    .split("\n")
+    .map((line) => cleanLocationCandidate(line))
+    .filter(Boolean);
+
+  for (const line of lines.slice(0, 12)) {
+    if (isLikelyLocation(line)) {
+      return line;
+    }
+  }
+
+  return "";
+}
+
+function scoreParsedJobSource(jobSource: JobSourceData): number {
+  let score = 0.2;
+
+  if (jobSource.rawJobTitle) {
+    score += boostForSource(jobSource.debug?.titleSource, 0.24, 0.18, 0.14, 0.08);
+  } else {
+    score -= 0.08;
+  }
+
+  if (jobSource.companyName) {
+    score += boostForSource(jobSource.debug?.companySource, 0.22, 0.16, 0.12, 0.06);
+  } else {
+    score -= 0.08;
+  }
+
+  if (jobSource.rawLocation) {
+    score += boostForSource(jobSource.debug?.locationSource, 0.14, 0.1, 0.08, 0.05);
+  }
+
+  if (jobSource.rawJobDescription && jobSource.rawJobDescription.length >= 400) {
+    score += boostForSource(jobSource.debug?.descriptionSource, 0.18, 0.14, 0.12, 0.08);
+  } else if (jobSource.rawJobDescription) {
+    score += 0.06;
+  } else {
+    score -= 0.06;
+  }
+
+  if (jobSource.employmentType) score += 0.04;
+  if (jobSource.postedDate) score += 0.04;
+
+  return Math.max(0.1, Math.min(0.95, Number(score.toFixed(2))));
+}
+
+function boostForSource(
+  source: string | undefined,
+  structured: number,
+  selector: number,
+  meta: number,
+  fallback: number
+): number {
+  if (source === "jsonld") return structured;
+  if (source === "h1" || source === "selector") return selector;
+  if (source === "meta" || source === "text" || source === "pasted_text") return meta;
+  return fallback;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asHiringOrganizationName(jsonLd: Record<string, unknown> | null): string | undefined {
+  if (!jsonLd) return undefined;
+  const org = jsonLd.hiringOrganization;
+  if (org && typeof org === "object" && !Array.isArray(org)) {
+    return asString((org as Record<string, unknown>).name);
+  }
+  return undefined;
+}
+
+function asJobLocation(jsonLd: Record<string, unknown> | null): string | undefined {
+  if (!jsonLd) return undefined;
+  const jobLocation = jsonLd.jobLocation;
+  const locations = Array.isArray(jobLocation) ? jobLocation : [jobLocation];
+  for (const location of locations) {
+    if (!location || typeof location !== "object") continue;
+    const address = (location as Record<string, unknown>).address;
+    if (!address || typeof address !== "object" || Array.isArray(address)) continue;
+    const record = address as Record<string, unknown>;
+    const locality = asString(record.addressLocality);
+    const region = asString(record.addressRegion);
+    const country = asString(record.addressCountry);
+    const pieces = [locality, region || country].filter(Boolean);
+    if (pieces.length > 0) {
+      return pieces.join(", ");
+    }
+  }
+  return undefined;
+}
+
+function asEmploymentType(jsonLd: Record<string, unknown> | null): string | undefined {
+  if (!jsonLd) return undefined;
+  const employmentType = jsonLd.employmentType;
+  if (Array.isArray(employmentType)) {
+    return asString(employmentType[0]);
+  }
+  return asString(employmentType);
+}
+
+function asDatePosted(jsonLd: Record<string, unknown> | null): string | undefined {
+  if (!jsonLd) return undefined;
+  const datePosted = asString(jsonLd.datePosted);
+  if (!datePosted) return undefined;
+  const isoDate = datePosted.match(/^\d{4}-\d{2}-\d{2}/);
+  return isoDate ? isoDate[0] : datePosted;
+}
+
+export function mergeImportEnrichment(
+  normalized: NormalizedImportResult,
+  enrichment: JobImportEnrichmentResponse
+): NormalizedImportResult {
+  const aiEnrichment = buildAiEnrichment(normalized, enrichment);
+  const nextCompany = { ...normalized.company };
+  const nextRole = normalized.role ? { ...normalized.role } : undefined;
+
+  if (!nextCompany.industry.trim() && enrichment.industry !== "Unknown") {
+    nextCompany.industry = enrichment.industry;
+  }
+
+  if (!nextCompany.size.trim() && enrichment.companySizeBand !== "Unknown") {
+    nextCompany.size = enrichment.companySizeBand;
+  }
+
+  if (!nextCompany.remotePolicy.trim() && enrichment.workplaceMode !== "Unknown") {
+    nextCompany.remotePolicy = enrichment.workplaceMode;
+  }
+
+  if (nextCompany.priority === "B" && enrichment.priorityBand !== "Unknown") {
+    nextCompany.priority = enrichment.priorityBand;
+  }
+
+  nextCompany.aiEnrichment = {
+    ...aiEnrichment,
+    normalized: {
+      ...aiEnrichment.normalized,
+      company: {
+        ...aiEnrichment.normalized?.company,
+        name: nextCompany.name,
+        industry: nextCompany.industry,
+        size: nextCompany.size,
+        remotePolicy: nextCompany.remotePolicy,
+        location: nextCompany.location,
+        englishFirst: nextCompany.englishFirst as "Yes" | "Mostly" | "Unknown" | undefined,
+      },
+    },
+  };
+
+  if (nextRole) {
+    if (
+      (nextRole.title.trim() === "" || nextRole.title === "New Role") &&
+      enrichment.canonicalTitle !== "Unknown"
+    ) {
+      nextRole.title = enrichment.canonicalTitle;
+    }
+
+    if (
+      (!nextRole.seniority.trim() || nextRole.seniority === "Mid") &&
+      enrichment.seniority !== "Unknown"
+    ) {
+      nextRole.seniority = mapAiSeniorityToRoleValue(enrichment.seniority);
+    }
+
+    if (enrichment.roleTrack !== "Unknown") {
+      nextRole.track = enrichment.roleTrack as JobTrack;
+    }
+
+    nextRole.fitScore = enrichment.fitScore;
+
+    if (!nextRole.nextAction?.trim() && enrichment.nextBestAction !== "Archive") {
+      nextRole.nextAction = enrichment.nextBestAction;
+    }
+
+    nextRole.aiEnrichment = {
+      ...aiEnrichment,
+      normalized: {
+        ...aiEnrichment.normalized,
+        role: {
+          ...aiEnrichment.normalized?.role,
+          title: nextRole.title,
+          url: nextRole.url,
+          location: nextRole.location,
+          seniority: nextRole.seniority,
+          track: nextRole.track,
+          fitScore: nextRole.fitScore,
+          status: nextRole.status,
+          nextAction: nextRole.nextAction,
+        },
+      },
+    };
+  }
+
+  return {
+    ...normalized,
+    company: nextCompany,
+    role: nextRole,
+    aiEnrichment,
+  };
+}
+
+function buildAiEnrichment(
+  normalized: NormalizedImportResult,
+  enrichment: JobImportEnrichmentResponse
+): AiImportEnrichmentV1 {
+  return {
+    schemaVersion: enrichment.schemaVersion,
+    rawExtracted: normalized.aiEnrichment?.rawExtracted ??
+      normalized.company.aiEnrichment?.rawExtracted ??
+      normalized.role?.aiEnrichment?.rawExtracted,
+    normalized: {
+      company: {
+        ...normalized.company.aiEnrichment?.normalized?.company,
+      },
+      role: normalized.role
+        ? {
+            ...normalized.role.aiEnrichment?.normalized?.role,
+          }
+        : undefined,
+    },
+    enriched: {
+      company: {
+        industry: enrichment.industry,
+        sizeBand: enrichment.companySizeBand,
+        companyStage: enrichment.companyStage,
+      },
+      role: normalized.role
+        ? {
+            track: enrichment.roleTrack,
+            seniority: enrichment.seniority,
+            nextBestAction: enrichment.nextBestAction,
+            applicationReadiness:
+              enrichment.nextBestAction === "Apply"
+                ? "ready_to_apply"
+                : enrichment.nextBestAction === "Tailor CV"
+                  ? "needs_tailoring"
+                  : "needs_research",
+          }
+        : undefined,
+    },
+    confidence: enrichment.confidence,
+    reviewFlags: enrichment.reviewFlags,
+    model: enrichment.model,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function mapAiSeniorityToRoleValue(value: JobImportEnrichmentResponse["seniority"]): string {
+  if (value === "Middle") return "Mid";
+  return value;
 }
 
 function normalizeForDedupe(value: string): string {

--- a/src/app/services/ingestion/jobImportEnrichmentGateway.ts
+++ b/src/app/services/ingestion/jobImportEnrichmentGateway.ts
@@ -1,0 +1,200 @@
+import type {
+  JobImportEnrichmentRequest,
+  JobImportEnrichmentResponse,
+  NormalizedImportResult,
+  ParsedImportResult,
+} from "./types";
+import { preprocessImportExtractedFields, preprocessImportText } from "./preprocessImportText";
+
+const FALLBACK_FIELD_KEYS = [
+  "canonicalTitle",
+  "roleTrack",
+  "seniority",
+  "industry",
+  "companyStage",
+  "companySizeBand",
+  "workplaceMode",
+  "fitScore",
+  "priorityBand",
+  "nextBestAction",
+] as const;
+
+function remoteBaseUrl(): string {
+  return (import.meta.env.VITE_JSPRINT_REMOTE_API_URL || "").trim();
+}
+
+export function isRemoteJobImportEnrichmentEnabled(): boolean {
+  return Boolean(remoteBaseUrl());
+}
+
+export function buildJobImportEnrichmentRequest(input: {
+  parsed: ParsedImportResult;
+  normalized?: NormalizedImportResult;
+  sourceUrl?: string;
+}): JobImportEnrichmentRequest {
+  const { parsed, normalized, sourceUrl } = input;
+
+  return {
+    sourceUrl,
+    sourcePlatform: parsed.sourcePlatform,
+    sourceType: parsed.sourceType,
+    importConfidence: parsed.confidence,
+    rawExtracted: preprocessImportExtractedFields(parsed.extracted),
+    normalized: normalized
+      ? {
+          company: {
+            name: preprocessImportText(normalized.company.name),
+            industry: preprocessImportText(normalized.company.industry),
+            size: preprocessImportText(normalized.company.size),
+            remotePolicy: preprocessImportText(normalized.company.remotePolicy),
+            location: preprocessImportText(normalized.company.location),
+            englishFirst: preprocessImportText(normalized.company.englishFirst),
+          },
+          role: normalized.role
+            ? {
+                title: preprocessImportText(normalized.role.title),
+                url: preprocessImportText(normalized.role.url),
+                location: preprocessImportText(normalized.role.location),
+                seniority: preprocessImportText(normalized.role.seniority),
+                track: preprocessImportText(normalized.role.track),
+                fitScore: normalized.role.fitScore,
+                status: preprocessImportText(normalized.role.status),
+                nextAction: preprocessImportText(normalized.role.nextAction),
+              }
+            : undefined,
+        }
+      : undefined,
+  };
+}
+
+export async function requestRemoteJobImportEnrichment(input: {
+  parsed: ParsedImportResult;
+  normalized?: NormalizedImportResult;
+  sourceUrl?: string;
+}): Promise<JobImportEnrichmentResponse | null> {
+  const baseUrl = remoteBaseUrl();
+  if (!baseUrl) {
+    return null;
+  }
+
+  try {
+    const payload = buildJobImportEnrichmentRequest(input);
+    const response = await fetch(`${baseUrl}/job-import-enrich`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      console.warn("Remote job import enrichment failed", response.status);
+      return null;
+    }
+
+    const data = await response.json();
+    return coerceJobImportEnrichmentResponse(data);
+  } catch (error) {
+    console.warn("Remote job import enrichment unavailable", error);
+    return null;
+  }
+}
+
+function coerceJobImportEnrichmentResponse(value: unknown): JobImportEnrichmentResponse | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const data = value as Record<string, unknown>;
+  if (data.schemaVersion !== "ai_import_v1") {
+    return null;
+  }
+
+  const confidenceFields = asRecord(data.confidence);
+  const fieldConfidence = asRecord(confidenceFields?.fields);
+  const overallConfidence = asConfidenceField(confidenceFields?.overall);
+
+  if (!overallConfidence) {
+    return null;
+  }
+
+  const fields = Object.fromEntries(
+    FALLBACK_FIELD_KEYS.map((key) => [key, asConfidenceField(fieldConfidence?.[key])])
+  ) as JobImportEnrichmentResponse["confidence"]["fields"];
+
+  return {
+    schemaVersion: "ai_import_v1",
+    canonicalTitle: asString(data.canonicalTitle) ?? "Unknown",
+    roleTrack: (asString(data.roleTrack) as JobImportEnrichmentResponse["roleTrack"]) ?? "Unknown",
+    seniority: (asString(data.seniority) as JobImportEnrichmentResponse["seniority"]) ?? "Unknown",
+    industry: (asString(data.industry) as JobImportEnrichmentResponse["industry"]) ?? "Unknown",
+    companyStage:
+      (asString(data.companyStage) as JobImportEnrichmentResponse["companyStage"]) ?? "Unknown",
+    companySizeBand:
+      (asString(data.companySizeBand) as JobImportEnrichmentResponse["companySizeBand"]) ?? "Unknown",
+    workplaceMode:
+      (asString(data.workplaceMode) as JobImportEnrichmentResponse["workplaceMode"]) ?? "Unknown",
+    fitScore: asFitScore(data.fitScore) ?? 3,
+    priorityBand:
+      (asString(data.priorityBand) as JobImportEnrichmentResponse["priorityBand"]) ?? "Unknown",
+    nextBestAction:
+      (asString(data.nextBestAction) as JobImportEnrichmentResponse["nextBestAction"]) ??
+      "Research",
+    confidence: {
+      overall: overallConfidence,
+      fields,
+    },
+    reviewFlags: Array.isArray(data.reviewFlags)
+      ? data.reviewFlags.filter(isReviewFlag)
+      : [],
+    model: asString(data.model) ?? "remote",
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function asFitScore(value: unknown): 1 | 2 | 3 | 4 | 5 | undefined {
+  return value === 1 || value === 2 || value === 3 || value === 4 || value === 5
+    ? value
+    : undefined;
+}
+
+function asConfidenceField(value: unknown) {
+  const record = asRecord(value);
+  const score = record && typeof record.score === "number" ? record.score : undefined;
+  const level = record && asString(record.level);
+  const source = record && asString(record.source);
+
+  if (score == null || !level || !source) {
+    return undefined;
+  }
+
+  return {
+    score,
+    level,
+    evidence: Array.isArray(record.evidence)
+      ? record.evidence.filter((item): item is string => typeof item === "string")
+      : [],
+    source,
+  };
+}
+
+function isReviewFlag(value: unknown): value is JobImportEnrichmentResponse["reviewFlags"][number] {
+  const record = asRecord(value);
+  return Boolean(
+    record &&
+      asString(record.code) &&
+      asString(record.severity) &&
+      asString(record.message) &&
+      typeof record.fieldPath === "string"
+  );
+}

--- a/src/app/services/ingestion/preprocessImportText.ts
+++ b/src/app/services/ingestion/preprocessImportText.ts
@@ -1,0 +1,53 @@
+import type { AiImportRawExtractedFields } from "../../types/jobOs";
+
+const DEFAULT_MAX_CHARS = 600;
+const LONG_TEXT_MAX_CHARS = 12000;
+
+export function preprocessImportText(
+  value: string | undefined,
+  options?: { maxChars?: number }
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+
+  const normalized = value
+    .normalize("NFKC")
+    .replace(/\u00A0/g, " ")
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  if (!normalized) return undefined;
+
+  const maxChars = options?.maxChars ?? DEFAULT_MAX_CHARS;
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+export function preprocessImportExtractedFields(
+  fields: AiImportRawExtractedFields
+): AiImportRawExtractedFields {
+  return {
+    companyName: preprocessImportText(fields.companyName),
+    website: preprocessImportText(fields.website),
+    careersUrl: preprocessImportText(fields.careersUrl),
+    industryHint: preprocessImportText(fields.industryHint),
+    sizeHint: preprocessImportText(fields.sizeHint),
+    locationHint: preprocessImportText(fields.locationHint),
+    remotePolicyHint: preprocessImportText(fields.remotePolicyHint),
+    englishFirstHint: preprocessImportText(fields.englishFirstHint),
+    roleTitle: preprocessImportText(fields.roleTitle),
+    roleUrl: preprocessImportText(fields.roleUrl),
+    roleLocation: preprocessImportText(fields.roleLocation),
+    seniorityHint: preprocessImportText(fields.seniorityHint),
+    jobDescription: preprocessImportText(fields.jobDescription, {
+      maxChars: LONG_TEXT_MAX_CHARS,
+    }),
+    notes: preprocessImportText(fields.notes, {
+      maxChars: 2000,
+    }),
+  };
+}

--- a/src/app/services/ingestion/sourceAdapters/ashbyAdapter.ts
+++ b/src/app/services/ingestion/sourceAdapters/ashbyAdapter.ts
@@ -89,6 +89,15 @@ export const ashbyAdapter: SourceAdapter = {
       sourcePlatform: "ashby",
       sourceType: jobId ? "job" : "company",
       confidence,
+      jobSource: {
+        sourceUrl: input.url,
+        sourcePlatform: "ashby",
+        sourceType: jobId ? "job" : "company",
+        companyName: extracted.companyName,
+        rawJobTitle: extracted.roleTitle,
+        rawLocation: extracted.locationHint,
+        rawJobDescription: extracted.jobDescription,
+      },
       raw: { html: html || undefined, text: rawText || undefined },
       extracted,
     };

--- a/src/app/services/ingestion/sourceAdapters/genericAdapter.ts
+++ b/src/app/services/ingestion/sourceAdapters/genericAdapter.ts
@@ -105,6 +105,15 @@ export const genericAdapter: SourceAdapter = {
       sourcePlatform: "generic",
       sourceType: isJobPath ? "job" : "unknown",
       confidence,
+      jobSource: {
+        sourceUrl: input.url,
+        sourcePlatform: "generic",
+        sourceType: isJobPath ? "job" : "unknown",
+        companyName: extracted.companyName,
+        rawJobTitle: extracted.roleTitle,
+        rawLocation: extracted.locationHint,
+        rawJobDescription: extracted.jobDescription,
+      },
       raw: { html: html || undefined, text: rawText || undefined },
       extracted,
     };

--- a/src/app/services/ingestion/sourceAdapters/greenhouseAdapter.ts
+++ b/src/app/services/ingestion/sourceAdapters/greenhouseAdapter.ts
@@ -11,9 +11,12 @@ import {
   fetchWithTimeout,
 } from "../utils";
 
-// Matches both legacy and new Greenhouse board domains
+// Matches legacy and regionalized Greenhouse board domains like:
+// - boards.greenhouse.io/acme/jobs/123
+// - job-boards.greenhouse.io/acme/jobs/123
+// - job-boards.eu.greenhouse.io/acme/jobs/123
 const GREENHOUSE_RE =
-  /https?:\/\/(?:boards|job-boards)\.greenhouse\.io\/([^/?#]+)(?:\/jobs\/(\d+))?/i;
+  /https?:\/\/(?:boards|job-boards(?:\.[a-z0-9-]+)?)\.greenhouse\.io\/([^/?#]+)(?:\/jobs\/(\d+))?/i;
 
 export const greenhouseAdapter: SourceAdapter = {
   canHandle(url: string): boolean {
@@ -25,8 +28,9 @@ export const greenhouseAdapter: SourceAdapter = {
     const companySlug = match?.[1] ?? "";
     const jobId = match?.[2] ?? "";
     const companyName = humanizeSlug(companySlug);
+    const boardHost = input.url.match(/^https?:\/\/([^/]+)/i)?.[1] ?? "boards.greenhouse.io";
     const careersUrl = companySlug
-      ? `https://boards.greenhouse.io/${companySlug}`
+      ? `https://${boardHost}/${companySlug}`
       : undefined;
 
     const extracted: ParsedImportResult["extracted"] = {
@@ -91,6 +95,15 @@ export const greenhouseAdapter: SourceAdapter = {
       sourcePlatform: "greenhouse",
       sourceType: jobId ? "job" : "company",
       confidence,
+      jobSource: {
+        sourceUrl: input.url,
+        sourcePlatform: "greenhouse",
+        sourceType: jobId ? "job" : "company",
+        companyName: extracted.companyName,
+        rawJobTitle: extracted.roleTitle,
+        rawLocation: extracted.locationHint,
+        rawJobDescription: extracted.jobDescription,
+      },
       raw: { html: html || undefined, text: rawText || undefined },
       extracted,
     };

--- a/src/app/services/ingestion/sourceAdapters/himalayasAdapter.ts
+++ b/src/app/services/ingestion/sourceAdapters/himalayasAdapter.ts
@@ -97,6 +97,15 @@ export const himalayasAdapter: SourceAdapter = {
       sourcePlatform: "himalayas",
       sourceType: isJobUrl ? "job" : "company",
       confidence,
+      jobSource: {
+        sourceUrl: input.url,
+        sourcePlatform: "himalayas",
+        sourceType: isJobUrl ? "job" : "company",
+        companyName: extracted.companyName,
+        rawJobTitle: extracted.roleTitle,
+        rawLocation: extracted.locationHint,
+        rawJobDescription: extracted.jobDescription,
+      },
       raw: { html: html || undefined, text: rawText || undefined },
       extracted,
     };

--- a/src/app/services/ingestion/sourceAdapters/leverAdapter.ts
+++ b/src/app/services/ingestion/sourceAdapters/leverAdapter.ts
@@ -95,6 +95,15 @@ export const leverAdapter: SourceAdapter = {
       sourcePlatform: "lever",
       sourceType: jobId ? "job" : "company",
       confidence,
+      jobSource: {
+        sourceUrl: input.url,
+        sourcePlatform: "lever",
+        sourceType: jobId ? "job" : "company",
+        companyName: extracted.companyName,
+        rawJobTitle: extracted.roleTitle,
+        rawLocation: extracted.locationHint,
+        rawJobDescription: extracted.jobDescription,
+      },
       raw: { html: html || undefined, text: rawText || undefined },
       extracted,
     };

--- a/src/app/services/ingestion/sourceAdapters/linkedInAdapter.ts
+++ b/src/app/services/ingestion/sourceAdapters/linkedInAdapter.ts
@@ -1,5 +1,15 @@
 import type { SourceAdapter, ParseInput, ParsedImportResult } from "../types";
-import { inferIndustry, inferRemotePolicy, inferSeniority } from "../utils";
+import {
+  cleanCompanyCandidate,
+  cleanLocationCandidate,
+  cleanTitleCandidate,
+  inferIndustry,
+  inferRemotePolicy,
+  inferSeniority,
+  isLikelyCompanyName,
+  isLikelyJobTitle,
+  isLikelyLocation,
+} from "../utils";
 
 const LINKEDIN_RE = /https?:\/\/(?:www\.)?linkedin\.com\//i;
 
@@ -34,11 +44,21 @@ export const linkedInAdapter: SourceAdapter = {
         .map((l) => l.trim())
         .filter(Boolean);
 
-      if (!extracted.roleTitle && lines[0]) {
-        extracted.roleTitle = lines[0];
+      if (!extracted.roleTitle) {
+        const titleLine = lines.find((line) => isLikelyJobTitle(cleanTitleCandidate(line)));
+        if (titleLine) {
+          extracted.roleTitle = cleanTitleCandidate(titleLine);
+        }
       }
-      if (!extracted.companyName && lines[1] && lines[1].length < 80) {
-        extracted.companyName = lines[1];
+      if (!extracted.companyName) {
+        const companyLine = lines.find((line) => isLikelyCompanyName(cleanCompanyCandidate(line)));
+        if (companyLine && companyLine !== extracted.roleTitle) {
+          extracted.companyName = cleanCompanyCandidate(companyLine);
+        }
+      }
+      const locationLine = lines.find((line) => isLikelyLocation(cleanLocationCandidate(line)));
+      if (locationLine) {
+        extracted.roleLocation = cleanLocationCandidate(locationLine);
       }
 
       extracted.jobDescription = text.slice(0, 3000);
@@ -53,6 +73,15 @@ export const linkedInAdapter: SourceAdapter = {
       sourcePlatform: "linkedin",
       sourceType: "job",
       confidence,
+      jobSource: {
+        sourceUrl: input.url,
+        sourcePlatform: "linkedin",
+        sourceType: "job",
+        companyName: extracted.companyName,
+        rawJobTitle: extracted.roleTitle,
+        rawLocation: extracted.roleLocation,
+        rawJobDescription: extracted.jobDescription,
+      },
       raw: { text: input.pastedText },
       extracted,
     };

--- a/src/app/services/ingestion/types.ts
+++ b/src/app/services/ingestion/types.ts
@@ -71,6 +71,7 @@ export interface NormalizedRoleDraft {
   track: "TPM" | "Product Engineer" | "Systems PM";
   fitScore: 1 | 2 | 3 | 4 | 5;
   status: "to_apply" | "applied" | "interview" | "rejected" | "offer" | "closed";
+  nextAction?: string;
   jobDescription?: string;
   sourcePlatform?: string;
   importConfidence?: number;

--- a/src/app/services/ingestion/types.ts
+++ b/src/app/services/ingestion/types.ts
@@ -1,3 +1,18 @@
+import type {
+  AiImportEnrichmentV1,
+  AiImportFieldConfidence,
+  AiImportIndustry,
+  AiImportCompanySizeBand,
+  AiImportCompanyStage,
+  AiImportNextBestAction,
+  AiImportPriorityBand,
+  AiImportRawExtractedFields,
+  AiImportReviewFlag,
+  AiImportRoleTrack,
+  AiImportSeniority,
+  AiImportWorkplaceMode,
+} from "../../types/jobOs";
+
 export type IngestionSourcePlatform =
   | "greenhouse"
   | "lever"
@@ -17,6 +32,86 @@ export interface ParseInput {
   fetchHtml?: (url: string) => Promise<string>;
 }
 
+export interface JobSourceData {
+  sourceUrl: string;
+  sourcePlatform: IngestionSourcePlatform;
+  sourceType: IngestionSourceType;
+  companyName?: string;
+  rawJobTitle?: string;
+  rawLocation?: string;
+  rawJobDescription?: string;
+  employmentType?: string;
+  postedDate?: string;
+  debug?: {
+    titleSource?: "jsonld" | "meta" | "h1" | "selector" | "fallback";
+    companySource?: "jsonld" | "meta" | "selector" | "domain" | "fallback";
+    locationSource?: "jsonld" | "meta" | "selector" | "text" | "fallback";
+    descriptionSource?: "jsonld" | "meta" | "selector" | "pasted_text" | "text" | "fallback";
+  };
+}
+
+export interface JobImportEnrichmentRequest {
+  sourceUrl?: string;
+  sourcePlatform?: IngestionSourcePlatform;
+  sourceType?: IngestionSourceType;
+  importConfidence?: number;
+  rawExtracted: AiImportRawExtractedFields;
+  normalized?: {
+    company?: {
+      name?: string;
+      industry?: string;
+      size?: string;
+      remotePolicy?: string;
+      location?: string;
+      englishFirst?: string;
+    };
+    role?: {
+      title?: string;
+      url?: string;
+      location?: string;
+      seniority?: string;
+      track?: string;
+      fitScore?: number;
+      status?: string;
+      nextAction?: string;
+    };
+  };
+}
+
+export interface JobImportEnrichmentResponse {
+  schemaVersion: "ai_import_v1";
+  canonicalTitle: string;
+  roleTrack: AiImportRoleTrack;
+  seniority: AiImportSeniority;
+  industry: AiImportIndustry;
+  companyStage: AiImportCompanyStage;
+  companySizeBand: AiImportCompanySizeBand;
+  workplaceMode: AiImportWorkplaceMode;
+  fitScore: 1 | 2 | 3 | 4 | 5;
+  priorityBand: AiImportPriorityBand;
+  nextBestAction: AiImportNextBestAction;
+  confidence: {
+    overall: AiImportFieldConfidence;
+    fields: Partial<
+      Record<
+        | "canonicalTitle"
+        | "roleTrack"
+        | "seniority"
+        | "industry"
+        | "companyStage"
+        | "companySizeBand"
+        | "workplaceMode"
+        | "fitScore"
+        | "priorityBand"
+        | "nextBestAction",
+        AiImportFieldConfidence
+      >
+    >;
+  };
+  reviewFlags: AiImportReviewFlag[];
+  model: string;
+}
+
 export interface ParsedImportResult {
   sourcePlatform: IngestionSourcePlatform;
   sourceType: IngestionSourceType;
@@ -27,22 +122,8 @@ export interface ParsedImportResult {
     text?: string;
     meta?: Record<string, string>;
   };
-  extracted: {
-    companyName?: string;
-    website?: string;
-    careersUrl?: string;
-    industryHint?: string;
-    sizeHint?: string;
-    locationHint?: string;
-    remotePolicyHint?: string;
-    englishFirstHint?: string;
-    roleTitle?: string;
-    roleUrl?: string;
-    roleLocation?: string;
-    seniorityHint?: string;
-    jobDescription?: string;
-    notes?: string;
-  };
+  extracted: AiImportRawExtractedFields;
+  aiEnrichment?: AiImportEnrichmentV1;
 }
 
 export interface NormalizedCompanyDraft {
@@ -61,6 +142,7 @@ export interface NormalizedCompanyDraft {
   sourcePlatform?: string;
   importConfidence?: number;
   sourceType?: "manual" | "csv" | "link" | "generated";
+  aiEnrichment?: AiImportEnrichmentV1;
 }
 
 export interface NormalizedRoleDraft {
@@ -76,14 +158,17 @@ export interface NormalizedRoleDraft {
   sourcePlatform?: string;
   importConfidence?: number;
   sourceType?: "manual" | "csv" | "link" | "generated";
+  aiEnrichment?: AiImportEnrichmentV1;
 }
 
 export interface NormalizedImportResult {
   sourcePlatform: IngestionSourcePlatform;
   sourceType: IngestionSourceType;
   confidence: number;
+  jobSource: JobSourceData;
   company: NormalizedCompanyDraft;
   role?: NormalizedRoleDraft;
+  aiEnrichment?: AiImportEnrichmentV1;
   duplicateMatch?: {
     companyId: string;
     companyName: string;

--- a/src/app/services/ingestion/utils.ts
+++ b/src/app/services/ingestion/utils.ts
@@ -182,3 +182,188 @@ export function extractLocationHint(text: string): string {
   if (city) return city[0].trim();
   return "";
 }
+
+export function extractJsonLdJobPosting(html: string): Record<string, unknown> | null {
+  const matches = html.matchAll(/<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi);
+
+  for (const match of matches) {
+    const raw = match[1]?.trim();
+    if (!raw) continue;
+
+    const parsed = safeJsonParse(raw);
+    const jobPosting = findJobPosting(parsed);
+    if (jobPosting) {
+      return jobPosting;
+    }
+  }
+
+  return null;
+}
+
+export function extractPrimaryHeading(html: string): string {
+  const headingMatch = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  return headingMatch ? stripHtml(headingMatch[1]) : "";
+}
+
+export function extractMetaTitle(meta: Record<string, string>): string {
+  return meta["og:title"] || meta["twitter:title"] || "";
+}
+
+export function extractMetaDescription(meta: Record<string, string>): string {
+  return meta["og:description"] || meta["twitter:description"] || meta["description"] || "";
+}
+
+export function cleanTitleCandidate(value: string): string {
+  return value
+    .replace(/\s+at\s+[^|–—-]+$/i, "")
+    .replace(/\s+[-|–—]\s+[^|–—-]+$/i, "")
+    .replace(/\s*\|.*$/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function isLikelyJobTitle(value: string): boolean {
+  const candidate = cleanTitleCandidate(value);
+  if (!candidate || candidate.length < 2 || candidate.length > 120) return false;
+  if (/[.!?].{15,}$/.test(candidate)) return false;
+  if (candidate.split(/\s+/).length > 12) return false;
+  if (/^(join|about|what|who|we|our|the)\b/i.test(candidate)) return false;
+  if (/\b(apply|team|mission|culture|benefits|company|opportunity)\b/i.test(candidate) && candidate.split(/\s+/).length > 8) return false;
+  return /\b(manager|engineer|developer|designer|lead|head|director|specialist|analyst|consultant|scientist|architect|product|program|operations|marketing|sales|recruiter|coordinator)\b/i.test(candidate)
+    || /\bpm\b|\btpm\b/i.test(candidate);
+}
+
+export function cleanCompanyCandidate(value: string): string {
+  return value
+    .replace(/\s+/g, " ")
+    .replace(/\s+(is hiring|careers|jobs?)$/i, "")
+    .trim();
+}
+
+export function isLikelyCompanyName(value: string): boolean {
+  const candidate = cleanCompanyCandidate(value);
+  if (!candidate || candidate.length < 2 || candidate.length > 80) return false;
+  if (candidate.split(/\s+/).length > 8) return false;
+  if (/[.!?]/.test(candidate)) return false;
+  if (/^(join|about|what|who|our|the)\b/i.test(candidate)) return false;
+  if (/\b(team|mission|culture|benefits|role|responsibilities|requirements)\b/i.test(candidate)) return false;
+  return true;
+}
+
+export function cleanLocationCandidate(value: string): string {
+  return value
+    .replace(/\s+/g, " ")
+    .replace(/\bworldwide\b/i, "Remote")
+    .replace(/\bglobal\b/i, "Remote")
+    .trim();
+}
+
+export function isLikelyLocation(value: string): boolean {
+  const candidate = cleanLocationCandidate(value);
+  if (!candidate || candidate.length > 80) return false;
+  if (/[.!?]/.test(candidate)) return false;
+  if (/^(join|about|what|who|our)\b/i.test(candidate)) return false;
+  return /\bremote\b/i.test(candidate) || /^[A-Z][A-Za-z .'-]+(?:,\s*[A-Z][A-Za-z .'-]+)?(?:\s*\/\s*Remote)?$/.test(candidate);
+}
+
+export function preprocessJobDescription(text: string | undefined, maxChars = 12000): string | undefined {
+  if (typeof text !== "string") return undefined;
+
+  const normalized = text
+    .normalize("NFKC")
+    .replace(/\u00A0/g, " ")
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  if (!normalized) return undefined;
+
+  const lines = normalized
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const dedupedLines = lines.filter((line, index) => {
+    const lower = line.toLowerCase();
+    if (/^(apply now|share this job|report this job|save job|sign in|create account|see who you know|easy apply)$/.test(lower)) {
+      return false;
+    }
+    return lines.findIndex((candidate) => candidate.trim().toLowerCase() === lower) === index;
+  });
+
+  const compact = dedupedLines
+    .filter((line) => !/^linkedin|greenhouse|lever|ashby|himalayas$/i.test(line))
+    .join("\n");
+  if (compact.length <= maxChars) {
+    return compact;
+  }
+
+  return `${compact.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+export function inferEmploymentType(text: string): string {
+  const lower = text.toLowerCase();
+  if (/full[- ]time/.test(lower)) return "Full-time";
+  if (/part[- ]time/.test(lower)) return "Part-time";
+  if (/contract|contractor|freelance/.test(lower)) return "Contract";
+  if (/intern(ship)?/.test(lower)) return "Internship";
+  if (/temporary|temp role/.test(lower)) return "Temporary";
+  return "";
+}
+
+export function inferPostedDate(text: string): string {
+  const lower = text.toLowerCase();
+  const iso = text.match(/\b(20\d{2}-\d{2}-\d{2})\b/);
+  if (iso) return iso[1];
+
+  const slashed = text.match(/\b(\d{1,2}\/\d{1,2}\/20\d{2})\b/);
+  if (slashed) {
+    const [month, day, year] = slashed[1].split("/");
+    return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
+  }
+
+  const recent = lower.match(/\bposted\s+(\d+)\s+(day|days|hour|hours)\s+ago\b/);
+  if (recent) {
+    return recent[0];
+  }
+
+  const simple = lower.match(/\b(today|yesterday|just posted)\b/);
+  if (simple) {
+    return simple[0];
+  }
+
+  return "";
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function findJobPosting(value: unknown): Record<string, unknown> | null {
+  if (!value) return null;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findJobPosting(item);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  if (typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+
+  if (record["@type"] === "JobPosting") {
+    return record;
+  }
+
+  if (record["@graph"]) {
+    return findJobPosting(record["@graph"]);
+  }
+
+  return null;
+}

--- a/src/app/types/jobOs.ts
+++ b/src/app/types/jobOs.ts
@@ -1,5 +1,165 @@
 export type JobTrack = "TPM" | "Product Engineer" | "Systems PM";
 export type CvTargetTrack = "TPM" | "PO" | "Implementation";
+export type AiImportSchemaVersion = "ai_import_v1";
+export type AiImportConfidenceLevel = "low" | "medium" | "high";
+export type AiImportReviewSeverity = "info" | "review" | "warning";
+export type AiImportRoleTrack = JobTrack | "Unknown";
+export type AiImportSeniority =
+  | "Junior"
+  | "Middle"
+  | "Senior"
+  | "Lead"
+  | "Staff"
+  | "Principal"
+  | "Director"
+  | "VP"
+  | "Executive"
+  | "Unknown";
+export type AiImportIndustry =
+  | "AI / Data"
+  | "Cybersecurity"
+  | "Developer Tools"
+  | "E-Commerce / Marketplace"
+  | "EdTech"
+  | "Fintech / Finance"
+  | "Healthcare"
+  | "HR / Talent"
+  | "Logistics"
+  | "Media / Content"
+  | "PropTech"
+  | "SaaS / Software"
+  | "Unknown";
+export type AiImportCompanySizeBand =
+  | "1-10"
+  | "11-50"
+  | "51-200"
+  | "201-500"
+  | "501-1000"
+  | "1001-5000"
+  | "5000+"
+  | "Unknown";
+export type AiImportCompanyStage =
+  | "Pre-seed"
+  | "Seed"
+  | "Series A"
+  | "Series B"
+  | "Series C+"
+  | "Private Growth"
+  | "Bootstrapped"
+  | "Public"
+  | "Enterprise"
+  | "Unknown";
+export type AiImportWorkplaceMode = "Remote" | "Hybrid" | "On-site" | "Unknown";
+export type AiImportPriorityBand = CompanyPriority | "Unknown";
+export type AiImportNextBestAction =
+  | "Research"
+  | "Tailor CV"
+  | "Apply"
+  | "Follow up"
+  | "Network"
+  | "Archive";
+export type AiImportReviewFlagCode =
+  | "missing_company_name"
+  | "missing_role_title"
+  | "missing_job_description"
+  | "unclear_location"
+  | "unclear_seniority"
+  | "unclear_track"
+  | "unclear_industry"
+  | "unclear_company_size"
+  | "unclear_company_stage"
+  | "duplicate_company_match"
+  | "low_confidence_parse"
+  | "manual_review_recommended";
+
+export interface AiImportFieldConfidence {
+  score: number;
+  level: AiImportConfidenceLevel;
+  evidence?: string[];
+  source?: "rules" | "model" | "human";
+}
+
+export interface AiImportReviewFlag {
+  code: AiImportReviewFlagCode;
+  severity: AiImportReviewSeverity;
+  message: string;
+  fieldPath?: string;
+}
+
+export interface AiImportRawExtractedFields {
+  companyName?: string;
+  website?: string;
+  careersUrl?: string;
+  industryHint?: string;
+  sizeHint?: string;
+  locationHint?: string;
+  remotePolicyHint?: string;
+  englishFirstHint?: string;
+  roleTitle?: string;
+  roleUrl?: string;
+  roleLocation?: string;
+  seniorityHint?: string;
+  employmentTypeHint?: string;
+  postedDateHint?: string;
+  jobDescription?: string;
+  notes?: string;
+}
+
+export interface AiImportNormalizedCompanyFields {
+  name?: string;
+  industry?: string;
+  size?: string;
+  remotePolicy?: string;
+  location?: string;
+  englishFirst?: "Yes" | "Mostly" | "Unknown";
+}
+
+export interface AiImportNormalizedRoleFields {
+  title?: string;
+  url?: string;
+  location?: string;
+  seniority?: string;
+  track?: JobTrack;
+  fitScore?: 1 | 2 | 3 | 4 | 5;
+  status?: RoleStatus;
+  nextAction?: string;
+}
+
+export interface AiImportCompanyEnrichment {
+  industry?: AiImportIndustry;
+  sizeBand?: AiImportCompanySizeBand;
+  companyStage?: AiImportCompanyStage;
+  hiringSignal?: string;
+  operatingRegion?: string;
+}
+
+export interface AiImportRoleEnrichment {
+  track?: AiImportRoleTrack;
+  seniority?: AiImportSeniority;
+  nextBestAction?: AiImportNextBestAction;
+  applicationReadiness?: "ready_to_apply" | "needs_tailoring" | "needs_research";
+  keyRequirements?: string[];
+}
+
+export interface AiImportEnrichmentV1 {
+  schemaVersion: AiImportSchemaVersion;
+  rawExtracted?: AiImportRawExtractedFields;
+  normalized?: {
+    company?: AiImportNormalizedCompanyFields;
+    role?: AiImportNormalizedRoleFields;
+  };
+  enriched?: {
+    company?: AiImportCompanyEnrichment;
+    role?: AiImportRoleEnrichment;
+  };
+  confidence?: {
+    overall?: AiImportFieldConfidence;
+    fields?: Record<string, AiImportFieldConfidence>;
+  };
+  reviewFlags?: AiImportReviewFlag[];
+  model?: string;
+  generatedAt?: string;
+}
 
 export type CompanyPriority = "A" | "B" | "C";
 export type CompanyStatus =
@@ -87,6 +247,7 @@ export interface JobOsCompany {
   sourceUrl?: string;
   sourcePlatform?: string;
   importConfidence?: number;
+  aiEnrichment?: AiImportEnrichmentV1;
   // Execution engine metadata
   lastInteractionAt?: string;
   createdAt: string;
@@ -112,6 +273,7 @@ export interface JobOsRole {
   sourceType?: "manual" | "csv" | "link" | "generated";
   sourcePlatform?: string;
   importConfidence?: number;
+  aiEnrichment?: AiImportEnrichmentV1;
   // Execution engine metadata
   lastInteractionAt?: string;
   hasApplication?: boolean;
@@ -137,6 +299,7 @@ export interface JobOsApplication {
   tailoredCvSummary?: string;
   tailoredCvText?: string;
   tailoredCvUpdatedAt?: string;
+  aiEnrichment?: AiImportEnrichmentV1;
   // Execution engine metadata
   lastResponseAt?: string;
   createdAt: string;

--- a/src/app/types/jobOs.ts
+++ b/src/app/types/jobOs.ts
@@ -104,6 +104,7 @@ export interface JobOsRole {
   track: JobTrack;
   fitScore: 1 | 2 | 3 | 4 | 5;
   status: RoleStatus;
+  nextAction?: string;
   origin?: "self_sourced" | "recruiter"; // how the candidate discovered the role
   jobDescription?: string;
   jobDescriptionUpdatedAt?: string;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -178,10 +178,12 @@
     font-family: 'Inter', system-ui, -apple-system, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
   }
 
   html {
     font-size: var(--font-size);
+    scrollbar-gutter: stable;
   }
 
   h1 {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -186,6 +186,20 @@
     scrollbar-gutter: stable;
   }
 
+  body[data-scroll-locked] {
+    margin-right: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  body[data-scroll-locked]:has([data-slot="select-content"]) {
+    overflow: auto !important;
+    overscroll-behavior: auto !important;
+    position: static !important;
+    margin-right: 0 !important;
+    padding-right: 0 !important;
+    --removed-body-scroll-bar-size: 0px;
+  }
+
   h1 {
     font-size: var(--text-2xl);
     font-weight: 700;


### PR DESCRIPTION
## Summary
This PR improves the Job OS product surface and extends the Paste Link ingestion system into a stronger import pipeline.

It includes:
- top-nav and secondary-nav cleanup
- dashboard, onboarding, applications, roles, and companies UX refinements
- shared page shell and layout consistency improvements
- deterministic job parsing improvements before AI enrichment
- AI import schema, frontend gateway, backend endpoint, and review-flow integration

## Product UX Updates
- simplified top navigation to `Action`, `Pipeline`, and `System`
- made Job OS secondary navigation contextual instead of duplicated
- refactored `/job-os/applications` into the real visible Pipeline surface
- improved dashboard hierarchy around one dominant next action
- simplified first-run onboarding into a paste-link-first flow
- reduced clutter across Roles and Companies tables with compact action rails and better filtering
- stabilized page layout and dropdown behavior across System pages

## Import Flow Improvements
- extended Paste Link flow to:
  - parse deterministically first
  - optionally enrich with AI
  - review extracted facts separately from AI recommendations
  - set initial stage and next action before save
- preserved deterministic parsing as the source of truth
- preserved graceful fallback when AI enrichment is unavailable

## Deterministic Parsing Improvements
- introduced a normalized parsed job shape before enrichment
- improved extraction priority for:
  - title
  - company
  - location
  - job description
- added stronger JD preprocessing and preview cleanup
- replaced weak confidence behavior with deterministic extraction confidence
- added lightweight extraction-source debug metadata
- fixed Greenhouse adapter matching for regional `job-boards.*.greenhouse.io` hosts

## AI Import Enrichment Foundation
- added AI import schema documentation
- added typed enrichment structures in the app
- added backend endpoint for structured AI enrichment
- added frontend preprocessing and typed gateway
- merged enrichment into import review in a backward-compatible way
- persisted AI enrichment metadata and next-best-action data on saved entities

## Backward Compatibility
- existing routes and pages are preserved
- deterministic import still works if AI enrichment fails
- existing saved company/role/application records remain valid
- new enrichment metadata is optional and nested

## Testing
- `npm run build`

## Follow-ups
- further strengthen LinkedIn-specific deterministic extraction
- surface enrichment/debug evidence more explicitly for parser QA
- consider splitting this branch into smaller follow-up PRs if review needs to be staged
