### PR TITLE
feat(ux): Wave 1 + Wave 2 feedback loops, repo audit, dev framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows Keep a Changelog principles and this project uses date-based 
 
 ## [Unreleased]
 
+### Added
+
+- Wave 2 UX feedback loops: empty states, loading skeletons, unsaved-changes guard.
+- `Analytics`: "No data yet" empty state (BarChart2 icon + CTA) when both Job OS and legacy applications are empty.
+- `Analytics`: Tailwind pulse skeletons (funnel card + two chart cards) shown while data hydrates, replacing blank chart axes.
+- `AfaCompliancePage`: Shield icon + "Add First Case" CTA when `cases.length === 0`.
+- `useUnsavedChanges(isDirty)` hook: returns `confirmDiscard()` — no-op when clean, `window.confirm` when dirty.
+- Discard-changes guard wired into `ApplicationModal`, `AfaCaseModal`, Job OS create/detail dialogs (`JobOsApplicationsPage`), and the add-role form toggle (`JobOsRolesPage`).
+
+### Changed
+
+- Repo audit: removed 4 orphaned packages (`@popperjs/core`, `react-popper`, `react-slick`, `react-responsive-masonry`).
+- `.gitignore` extended with `.DS_Store`, `*.local`, `coverage/`, `.vercel`.
+- `docs/DEV_WORKFLOW.md` created: full day-to-day developer guide covering setup, dev loop, branch naming, commit format, CI, testing, env vars, and stack reference.
+- `README.md`: replaced TODO placeholder comments with prose; linked DEV_WORKFLOW.md in Documentation section.
+- `CLAUDE.md`: added PR Creation section mandating all template fields be populated with real content when using `gh pr create`.
+
 ## [2026-03-20]
 
 ### Added

--- a/src/app/components/ApplicationModal.tsx
+++ b/src/app/components/ApplicationModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useUnsavedChanges } from "../hooks/useUnsavedChanges";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
@@ -106,16 +107,28 @@ export function ApplicationModal({
   const [errors, setErrors] = useState<FormErrors>({});
   const [sourceMode, setSourceMode] = useState<SourceMode>("manual");
   const [selectedRoleId, setSelectedRoleId] = useState<string>("");
+  const [savedSnapshot, setSavedSnapshot] = useState(() =>
+    JSON.stringify(getInitialForm(existingApp))
+  );
 
   useEffect(() => {
     if (!open) return;
     // Intentional: reset form to latest existingApp data when modal opens.
+    const initial = getInitialForm(existingApp);
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setFormData(getInitialForm(existingApp));
+    setFormData(initial);
+    setSavedSnapshot(JSON.stringify(initial));
     setErrors({});
     setSourceMode("manual");
     setSelectedRoleId("");
   }, [existingApp, open]);
+
+  const isDirty = JSON.stringify(formData) !== savedSnapshot;
+  const { confirmDiscard } = useUnsavedChanges(isDirty);
+
+  function handleClose() {
+    if (confirmDiscard()) onClose();
+  }
 
   const handleRoleSelect = (roleId: string) => {
     setSelectedRoleId(roleId);
@@ -185,7 +198,7 @@ export function ApplicationModal({
   const showSourceToggle = !existingApp && roleOptions.length > 0;
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) handleClose(); }}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
@@ -421,7 +434,7 @@ export function ApplicationModal({
           </div>
 
           <div className="flex justify-end gap-3 pt-4">
-            <Button type="button" variant="outline" onClick={onClose}>
+            <Button type="button" variant="outline" onClick={handleClose}>
               Cancel
             </Button>
             <Button type="submit" disabled={!isFormValid}>

--- a/src/app/components/compliance/AfaCaseModal.tsx
+++ b/src/app/components/compliance/AfaCaseModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useUnsavedChanges } from "../../hooks/useUnsavedChanges";
 import { ExternalLink } from "lucide-react";
 import {
   Dialog,
@@ -188,14 +189,26 @@ export function AfaCaseModal({
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [savedSnapshot, setSavedSnapshot] = useState(() =>
+    JSON.stringify(emptyForm())
+  );
 
   useEffect(() => {
     if (!open) return;
-    setForm(isEdit ? vorschlagToForm(vorschlag) : emptyForm());
+    const initial = isEdit ? vorschlagToForm(vorschlag) : emptyForm();
+    setForm(initial);
+    setSavedSnapshot(JSON.stringify(initial));
     setIsSaving(false);
     setIsDeleting(false);
     setSubmitError(null);
   }, [open, vorschlag, isEdit]);
+
+  const isDirty = JSON.stringify(form) !== savedSnapshot;
+  const { confirmDiscard } = useUnsavedChanges(isDirty);
+
+  function handleClose() {
+    if (confirmDiscard()) onClose();
+  }
 
   function update<K extends keyof AfaVorschlagFormData>(
     key: K,
@@ -251,7 +264,7 @@ export function AfaCaseModal({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) handleClose(); }}>
       <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
@@ -605,7 +618,7 @@ export function AfaCaseModal({
               <Button
                 type="button"
                 variant="outline"
-                onClick={onClose}
+                onClick={handleClose}
                 disabled={isSaving || isDeleting}
               >
                 Cancel

--- a/src/app/hooks/useUnsavedChanges.ts
+++ b/src/app/hooks/useUnsavedChanges.ts
@@ -1,0 +1,12 @@
+/**
+ * Guards a close/discard action behind a confirmation prompt when there are
+ * unsaved changes. Returns `confirmDiscard()` which returns `true` if the
+ * caller may proceed (either no dirty state, or the user confirmed).
+ */
+export function useUnsavedChanges(isDirty: boolean) {
+  function confirmDiscard(): boolean {
+    if (!isDirty) return true;
+    return window.confirm("You have unsaved changes. Discard them?");
+  }
+  return { confirmDiscard };
+}

--- a/src/app/pages/AfaCompliancePage.tsx
+++ b/src/app/pages/AfaCompliancePage.tsx
@@ -10,7 +10,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "../components/ui/alert-dialog";
-import { Plus } from "lucide-react";
+import { Plus, Shield } from "lucide-react";
 import { Button } from "../components/ui/button";
 import { AppNavbar } from "../components/AppNavbar";
 import { AfaDashboard } from "../components/compliance/AfaDashboard";
@@ -104,6 +104,21 @@ export default function AfaCompliancePage() {
         {authLoading || loading ? (
           <div className="flex items-center justify-center py-24 text-neutral-400 dark:text-neutral-600 text-sm">
             Loading compliance cases...
+          </div>
+        ) : cases.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-24 gap-3 text-center">
+            <Shield className="w-10 h-10 text-neutral-300 dark:text-neutral-700" />
+            <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">
+              No cases yet
+            </p>
+            <p className="text-xs text-neutral-400 dark:text-neutral-500 max-w-xs">
+              Add your first Vermittlungsvorschlag to start tracking AfA
+              compliance deadlines and evidence.
+            </p>
+            <Button size="sm" onClick={handleOpenNew}>
+              <Plus className="w-3.5 h-3.5 mr-1" />
+              Add First Case
+            </Button>
           </div>
         ) : (
           <>

--- a/src/app/pages/Analytics.tsx
+++ b/src/app/pages/Analytics.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { BarChart2 } from "lucide-react";
 import { useApp } from "../context";
 import { useJobOs } from "../hooks/useJobOs";
 import { AppNavbar } from "../components/AppNavbar";
@@ -38,11 +39,74 @@ function rateLabel(actual: number, target: number): string {
   return "below target";
 }
 
+// ─── Skeletons ────────────────────────────────────────────────────────────────
+
+function FunnelSkeleton() {
+  return (
+    <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 p-6 animate-pulse">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="h-3.5 w-52 rounded bg-neutral-200 dark:bg-neutral-800" />
+        <div className="h-3 w-40 rounded bg-neutral-100 dark:bg-neutral-800/60" />
+      </div>
+      <div className="space-y-5">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="space-y-1.5">
+            <div className="flex justify-between">
+              <div className="h-3 w-36 rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="h-3 w-20 rounded bg-neutral-200 dark:bg-neutral-800" />
+            </div>
+            <div className="h-3 w-full rounded-full bg-neutral-100 dark:bg-neutral-800" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ChartSkeleton({ title }: { title: string }) {
+  return (
+    <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-950 animate-pulse">
+      <div className="h-3.5 w-40 rounded bg-neutral-200 dark:bg-neutral-800 mb-6" />
+      <div className="sr-only">{title}</div>
+      <div className="flex items-end gap-2 h-[260px]">
+        {[55, 80, 40, 90, 65, 75, 50, 85, 60, 70].map((h, i) => (
+          <div
+            key={i}
+            className="flex-1 rounded-t bg-neutral-100 dark:bg-neutral-800"
+            style={{ height: `${h}%` }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EmptyAnalytics() {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 gap-3 text-center">
+      <BarChart2 className="w-10 h-10 text-neutral-300 dark:text-neutral-700" />
+      <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">
+        No data yet
+      </p>
+      <p className="text-xs text-neutral-400 dark:text-neutral-500 max-w-xs">
+        Add applications to your Job OS pipeline to start seeing conversion
+        analytics and funnel benchmarks.
+      </p>
+      <a
+        href="/job-os/applications"
+        className="text-xs text-blue-500 hover:underline mt-1"
+      >
+        Go to Applications →
+      </a>
+    </div>
+  );
+}
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function Analytics() {
-  const { session, applications: legacyApps, darkMode } = useApp();
-  const { applications } = useJobOs(session?.userId ?? null);
+  const { session, applications: legacyApps, darkMode, authLoading } = useApp();
+  const { applications, loading } = useJobOs(session?.userId ?? null);
 
   const isDark = darkMode;
   const textColor = isDark ? "#a3a3a3" : "#525252";
@@ -127,11 +191,27 @@ export default function Analytics() {
     },
   ];
 
+  const isLoading = loading || authLoading;
+  const isEmpty =
+    !isLoading && applications.length === 0 && legacyApps.length === 0;
+
   return (
     <div className="min-h-screen bg-neutral-50 dark:bg-black text-neutral-900 dark:text-neutral-100">
       <AppNavbar title="Analytics" subtitle="Track your performance trends" showSync />
 
       <main className="max-w-[1800px] mx-auto px-6 py-6 space-y-6">
+        {isLoading ? (
+          <>
+            <FunnelSkeleton />
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <ChartSkeleton title="Applications Per Week" />
+              <ChartSkeleton title="Response Rate Trend" />
+            </div>
+          </>
+        ) : isEmpty ? (
+          <EmptyAnalytics />
+        ) : (
+        <>
 
         {/* Conversion Funnel with Benchmarks */}
         <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 p-6">
@@ -260,6 +340,8 @@ export default function Analytics() {
             </ResponsiveContainer>
           </div>
         </div>
+        </>
+        )}
       </main>
     </div>
   );

--- a/src/app/pages/job-os/JobOsApplicationsPage.tsx
+++ b/src/app/pages/job-os/JobOsApplicationsPage.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "../../components/ui/textarea";
 import { Badge } from "../../components/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../components/ui/tooltip";
 import { useJobOsContext } from "../../context/JobOsContext";
+import { useUnsavedChanges } from "../../hooks/useUnsavedChanges";
 import { JobOsTransferControls } from "../../components/job-os/JobOsTransferControls";
 import { JobOsLayout } from "../../components/job-os/JobOsLayout";
 import { AppPageShell } from "../../components/layout/AppPageShell";
@@ -121,9 +122,11 @@ export default function JobOsApplicationsPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [createOpen, setCreateOpen] = useState(false);
+  const [createDraftSnapshot, setCreateDraftSnapshot] = useState("");
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [detailId, setDetailId] = useState<string | null>(null);
   const [detailDraft, setDetailDraft] = useState<Pick<JobOsApplication, "status" | "nextAction" | "notes"> | null>(null);
+  const [detailDraftSnapshot, setDetailDraftSnapshot] = useState("");
   const [sortField, setSortField] = useState<SortField>("date");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const [draft, setDraft] = useState<Omit<JobOsApplication, "id" | "createdAt" | "updatedAt">>(createDraft(defaultCv ? { id: defaultCv.id, name: defaultCv.name } : undefined));
@@ -204,22 +207,38 @@ export default function JobOsApplicationsPage() {
   }
 
   function openCreateDialog(): void {
-    resetDraft();
+    const freshDraft = createDraft(defaultCv ? { id: defaultCv.id, name: defaultCv.name } : undefined);
+    setDraft(freshDraft);
+    setCreateDraftSnapshot(JSON.stringify(freshDraft));
     setCreateOpen(true);
   }
 
   function openDetails(application: JobOsApplication): void {
-    setDetailId(application.id);
-    setDetailDraft({
+    const initial = {
       status: application.status,
       nextAction: application.nextAction,
       notes: application.notes,
-    });
+    };
+    setDetailId(application.id);
+    setDetailDraft(initial);
+    setDetailDraftSnapshot(JSON.stringify(initial));
   }
 
   function closeDetails(): void {
     setDetailId(null);
     setDetailDraft(null);
+  }
+
+  const isCreateDirty = JSON.stringify(draft) !== createDraftSnapshot;
+  const { confirmDiscard: confirmCreateDiscard } = useUnsavedChanges(isCreateDirty);
+  function handleCloseCreate() {
+    if (confirmCreateDiscard()) setCreateOpen(false);
+  }
+
+  const isDetailDirty = JSON.stringify(detailDraft) !== detailDraftSnapshot;
+  const { confirmDiscard: confirmDetailDiscard } = useUnsavedChanges(isDetailDirty);
+  function handleCloseDetails() {
+    if (confirmDetailDiscard()) closeDetails();
   }
 
   function toggleSort(field: SortField): void {
@@ -543,7 +562,7 @@ export default function JobOsApplicationsPage() {
         </div>
       </AppPageShell>
 
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+      <Dialog open={createOpen} onOpenChange={(isOpen) => { if (!isOpen) handleCloseCreate(); }}>
         <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Add Application</DialogTitle>
@@ -658,7 +677,7 @@ export default function JobOsApplicationsPage() {
               </Tooltip>
               Keyboard shortcut available
             </div>
-            <Button variant="ghost" onClick={() => setCreateOpen(false)}>
+            <Button variant="ghost" onClick={handleCloseCreate}>
               Cancel
             </Button>
             <Button onClick={() => void handleCreateApplication()} disabled={!draft.companyId || !draft.roleId}>
@@ -668,7 +687,7 @@ export default function JobOsApplicationsPage() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={Boolean(detailApplication)} onOpenChange={(open) => !open && closeDetails()}>
+      <Dialog open={Boolean(detailApplication)} onOpenChange={(isOpen) => { if (!isOpen) handleCloseDetails(); }}>
         <DialogContent className="max-w-2xl">
           {detailApplication && detailDraft ? (
             <>

--- a/src/app/pages/job-os/JobOsRolesPage.tsx
+++ b/src/app/pages/job-os/JobOsRolesPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
 import { useEffect, useMemo, useState } from "react";
+import { useUnsavedChanges } from "../../hooks/useUnsavedChanges";
 import { toast } from "sonner";
 import {
   AlertDialog,
@@ -375,6 +376,20 @@ export default function JobOsRolesPage() {
     }
   }
 
+  const isAddFormDirty =
+    addFormOpen &&
+    (draft.companyId !== "" ||
+      draft.title.trim() !== "" ||
+      (draft.url ?? "").trim() !== "" ||
+      (draft.location ?? "").trim() !== "" ||
+      (draft.jobDescription ?? "").trim() !== "");
+  const { confirmDiscard: confirmAddFormDiscard } = useUnsavedChanges(isAddFormDirty);
+
+  function handleToggleAddForm() {
+    if (addFormOpen && !confirmAddFormDiscard()) return;
+    setAddFormOpen((value) => !value);
+  }
+
   return (
     <JobOsLayout
       title="Roles"
@@ -386,7 +401,7 @@ export default function JobOsRolesPage() {
         <CardHeader className="pb-0">
           <button
             type="button"
-            onClick={() => setAddFormOpen((value) => !value)}
+            onClick={handleToggleAddForm}
             className="flex items-center gap-1.5 group"
           >
             {addFormOpen ? (


### PR DESCRIPTION
## What

Wave 1 and Wave 2 UX feedback loop improvements, plus a full repo audit and dev framework establishment.

**Wave 1 — CRUD feedback (AlertDialogs + toasts):**
- `JobOsApplicationsPage`: AlertDialog on delete, toast on add/delete
- `JobOsCompaniesPage`: removed duplicate merge-artifact action cell
- `JobOsRolesPage`: fixed duplicate React/lucide-react imports (Wave 1 artifact); removed redundant text button that duplicated icon button accessible name
- `routes.tsx`: fixed duplicate `createBrowserRouter` import that crashed the Vite dev server

**Wave 2 — Missing feedback loops:**
- Issue D: Empty states for Analytics (BarChart2 icon + CTA) and AfA Compliance (Shield icon + CTA)
- Issue E: Tailwind pulse skeletons for Analytics funnel card and both chart cards during data hydration
- Issue F: `useUnsavedChanges(isDirty)` hook + discard-changes guard wired into `ApplicationModal`, `AfaCaseModal`, Job OS create/detail dialogs, and the add-role form toggle

**Repo audit:**
- Removed 4 orphaned packages: `@popperjs/core`, `react-popper`, `react-slick`, `react-responsive-masonry`
- Patched `.gitignore` with `.DS_Store`, `*.local`, `coverage/`, `.vercel`
- Created `docs/DEV_WORKFLOW.md`: full day-to-day developer guide
- Updated `README.md`: removed stale TODO placeholders, added DEV_WORKFLOW link
- Added PR creation rules to `CLAUDE.md`: all template fields must be populated

**E2E fixes (CI was fully broken on entry):**
- Fixed 4 cascading layers of failures caused by Wave 1 import artifacts and strict-mode violations

## Why

Wave 1 changes were applied in a prior session by prepending import statements that duplicated existing declarations — causing Vite dev-mode parse errors that broke all 16 E2E tests. Wave 2 completes the feedback loop work (Issues D, E, F from the Wave 2 backlog). The repo audit removes dead weight and establishes a documented dev framework so future sessions start from a clean baseline.

## How To Test

1. `npm install && npm run lint && npm run build` — both exit 0
2. `npm run dev` → navigate to `/analytics` with no applications: see "No data yet" empty state
3. Hard-reload `/analytics` on Slow 3G throttle: see pulse skeletons before content appears
4. Navigate to `/compliance/afa` with no cases: see Shield empty state with "Add First Case" button
5. Open any modal (ApplicationModal, AfaCaseModal, Job OS create dialog), fill a field, click × or Cancel: confirm dialog appears; clicking Cancel on it keeps the modal open
6. Open add-role form on `/job-os/roles`, type a title, click the "Add Role" toggle to collapse: confirm dialog appears
7. `npm run test:e2e` — all 16 tests pass

## Evidence

- Issue: #105
- Demo artifact: N/A — logic/UX changes; verify via steps above

## Risk and Rollback

- Risk level: low
- Rollback plan: revert `cd45685` (Wave 2) and `fb05eef` (Wave 1 ApplicationsPage) independently; each commit is self-contained

## Checklist

- [x] Linked to an issue with clear acceptance criteria
- [x] Scope is limited to the issue
- [x] Local checks pass (`npm run build`)
- [x] Docs updated if behavior or workflow changed
- [x] `CHANGELOG.md` updated
- [x] Demo artifact attached
