### PR TITLE
fix(error-boundary): auto-reload on stale chunk load errors after red…

### DIFF
--- a/src/app/components/AppErrorBoundary.tsx
+++ b/src/app/components/AppErrorBoundary.tsx
@@ -10,6 +10,15 @@ interface AppErrorBoundaryState {
   hasError: boolean;
 }
 
+function isChunkLoadError(error: Error): boolean {
+  return (
+    error.message.includes("Failed to fetch dynamically imported module") ||
+    error.message.includes("ChunkLoadError") ||
+    error.message.includes("Loading chunk") ||
+    error.name === "ChunkLoadError"
+  );
+}
+
 export class AppErrorBoundary extends Component<
   AppErrorBoundaryProps,
   AppErrorBoundaryState
@@ -19,12 +28,20 @@ export class AppErrorBoundary extends Component<
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError() {
+  static getDerivedStateFromError(error: Error) {
+    // Stale deployment: chunk filenames changed after redeploy.
+    // Reload the page to fetch fresh HTML + new asset URLs.
+    if (isChunkLoadError(error)) {
+      window.location.reload();
+      return { hasError: false };
+    }
     return { hasError: true };
   }
 
   componentDidCatch(error: Error, info: { componentStack: string }) {
-    console.error("Unhandled app error:", error, info.componentStack);
+    if (!isChunkLoadError(error)) {
+      console.error("Unhandled app error:", error, info.componentStack);
+    }
   }
 
   render() {


### PR DESCRIPTION
…eploy

After a Vercel redeploy, content-hashed chunk filenames change. Any tab still open on the old HTML tries to fetch the old URLs (now gone), causing "Failed to fetch dynamically imported module". The error boundary now detects these chunk-load errors and calls window.location.reload() so users get the fresh HTML + new asset URLs automatically instead of seeing an error screen.

Closes #45

## What

Describe the concrete change in this PR.

## Why

Explain the problem this PR solves and why now.

## How To Test

1. 
2. 
3. 

## Evidence

- Issue: `#`
- Demo artifact (screenshot/Loom): 

## Risk and Rollback

- Risk level: low / medium / high
- Rollback plan:

## Checklist

- [ ] Linked to an issue with clear acceptance criteria
- [ ] Scope is limited to the issue
- [ ] Local checks pass (`npm run build`)
- [ ] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated
- [ ] Demo artifact attached

