### PR TITLE
feat(dashboard): unified add modal, add_jd next action, quick action trigger

### DIFF
--- a/src/app/components/dashboard/FocusedNextAction.tsx
+++ b/src/app/components/dashboard/FocusedNextAction.tsx
@@ -16,6 +16,7 @@ const TYPE_ACCENTS: Record<NextAction["type"], string> = {
   optimize_cv: "from-emerald-600/15 to-green-500/10 text-emerald-700 dark:text-emerald-300",
   add_role: "from-teal-600/15 to-emerald-500/10 text-teal-700 dark:text-teal-300",
   research: "from-indigo-600/15 to-blue-500/10 text-indigo-700 dark:text-indigo-300",
+  add_jd: "from-amber-600/15 to-yellow-500/10 text-amber-700 dark:text-amber-300",
   archive: "from-neutral-500/10 to-neutral-400/10 text-neutral-700 dark:text-neutral-300",
 };
 

--- a/src/app/components/dashboard/NextActionCard.tsx
+++ b/src/app/components/dashboard/NextActionCard.tsx
@@ -16,6 +16,7 @@ const TYPE_COLORS: Record<NextAction["type"], string> = {
   optimize_cv: "border-l-green-500",
   add_role: "border-l-teal-500",
   research: "border-l-indigo-500",
+  add_jd: "border-l-amber-500",
   archive: "border-l-neutral-400",
 };
 

--- a/src/app/components/dashboard/QuickActions.tsx
+++ b/src/app/components/dashboard/QuickActions.tsx
@@ -1,62 +1,77 @@
 import { Link } from "react-router";
-import { PlusCircle, FileText, Building2, ClipboardList } from "lucide-react";
+import { PlusCircle, FileText, ClipboardList, Rocket } from "lucide-react";
 
-interface QuickAction {
-  label: string;
-  description: string;
-  href: string;
-  icon: React.ReactNode;
+interface QuickActionsProps {
+  onAddRole?: () => void;
 }
 
-const QUICK_ACTIONS: QuickAction[] = [
-  {
-    label: "Add Company",
-    description: "Track a new target",
-    href: "/job-os/companies",
-    icon: <Building2 className="h-4 w-4" />,
-  },
-  {
-    label: "Log Application",
-    description: "Record a submission",
-    href: "/job-os/applications",
-    icon: <ClipboardList className="h-4 w-4" />,
-  },
-  {
-    label: "Tailor CV",
-    description: "Optimise for a role",
-    href: "/cv-optimizer",
-    icon: <FileText className="h-4 w-4" />,
-  },
-  {
-    label: "Browse Roles",
-    description: "Review your pipeline",
-    href: "/job-os/roles",
-    icon: <PlusCircle className="h-4 w-4" />,
-  },
-];
-
-export function QuickActions() {
+export function QuickActions({ onAddRole }: QuickActionsProps) {
   return (
     <section className="space-y-3">
       <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
         Quick Actions
       </h2>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-        {QUICK_ACTIONS.map((qa) => (
-          <Link
-            key={qa.href}
-            to={qa.href}
-            className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
-          >
-            <span className="text-neutral-500 dark:text-neutral-400">{qa.icon}</span>
-            <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
-              {qa.label}
-            </span>
-            <span className="text-xs text-neutral-400 dark:text-neutral-500">
-              {qa.description}
-            </span>
-          </Link>
-        ))}
+        <button
+          type="button"
+          onClick={onAddRole}
+          className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
+        >
+          <span className="text-neutral-500 dark:text-neutral-400">
+            <Rocket className="h-4 w-4" />
+          </span>
+          <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
+            Add Role
+          </span>
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
+            Company + role in one flow
+          </span>
+        </button>
+
+        <Link
+          to="/job-os/applications"
+          className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
+        >
+          <span className="text-neutral-500 dark:text-neutral-400">
+            <ClipboardList className="h-4 w-4" />
+          </span>
+          <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
+            Log Application
+          </span>
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
+            Record a submission
+          </span>
+        </Link>
+
+        <Link
+          to="/cv-optimizer"
+          className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
+        >
+          <span className="text-neutral-500 dark:text-neutral-400">
+            <FileText className="h-4 w-4" />
+          </span>
+          <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
+            Tailor CV
+          </span>
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
+            Optimise for a role
+          </span>
+        </Link>
+
+        <Link
+          to="/job-os/roles"
+          className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
+        >
+          <span className="text-neutral-500 dark:text-neutral-400">
+            <PlusCircle className="h-4 w-4" />
+          </span>
+          <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
+            Browse Roles
+          </span>
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
+            Review your pipeline
+          </span>
+        </Link>
       </div>
     </section>
   );

--- a/src/app/components/job-os/UnifiedAddModal.tsx
+++ b/src/app/components/job-os/UnifiedAddModal.tsx
@@ -1,0 +1,495 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Button } from "../ui/button";
+import type {
+  JobOsCompany,
+  JobOsRole,
+  JobOsApplication,
+  CompanyPriority,
+  JobTrack,
+} from "../../types/jobOs";
+
+type Step = "company" | "role" | "workflow";
+
+type WorkflowStage = "saved" | "to_apply" | "applied";
+
+interface CompanyDraft {
+  mode: "existing" | "new";
+  existingId?: string;
+  name: string;
+  priority: CompanyPriority;
+}
+
+interface RoleDraft {
+  title: string;
+  url: string;
+  track: JobTrack;
+  fitScore: 1 | 2 | 3 | 4 | 5;
+  seniority: string;
+  location: string;
+}
+
+interface WorkflowDraft {
+  stage: WorkflowStage;
+  nextAction: string;
+  dateApplied: string;
+  channel: string;
+}
+
+export interface UnifiedAddModalProps {
+  open: boolean;
+  onClose: () => void;
+  companies: JobOsCompany[];
+  addCompany: (payload: Omit<JobOsCompany, "id" | "createdAt" | "updatedAt">) => Promise<string | null>;
+  addRole: (payload: Omit<JobOsRole, "id" | "createdAt" | "updatedAt">) => Promise<string | null>;
+  addApplication: (payload: Omit<JobOsApplication, "id" | "createdAt" | "updatedAt">) => Promise<string | null>;
+}
+
+const TRACKS: JobTrack[] = ["TPM", "Product Engineer", "Systems PM"];
+const SENIORITY_OPTIONS = ["Junior", "Mid", "Senior", "Lead", "Staff", "Principal", "Director", "VP"];
+const NEXT_ACTION_PRESETS = [
+  "Tailor CV",
+  "Submit application",
+  "Research company",
+  "Follow up on application",
+  "Prepare for interview",
+];
+
+const TODAY = new Date().toISOString().split("T")[0];
+
+export function UnifiedAddModal({
+  open,
+  onClose,
+  companies,
+  addCompany,
+  addRole,
+  addApplication,
+}: UnifiedAddModalProps) {
+  const [step, setStep] = useState<Step>("company");
+  const [saving, setSaving] = useState(false);
+  const [companySearch, setCompanySearch] = useState("");
+
+  const [companyDraft, setCompanyDraft] = useState<CompanyDraft>({
+    mode: "existing",
+    existingId: undefined,
+    name: "",
+    priority: "B",
+  });
+
+  const [roleDraft, setRoleDraft] = useState<RoleDraft>({
+    title: "",
+    url: "",
+    track: "TPM",
+    fitScore: 3,
+    seniority: "Senior",
+    location: "",
+  });
+
+  const [workflowDraft, setWorkflowDraft] = useState<WorkflowDraft>({
+    stage: "to_apply",
+    nextAction: "",
+    dateApplied: TODAY,
+    channel: "",
+  });
+
+  const filteredCompanies = companies.filter((c) =>
+    c.name.toLowerCase().includes(companySearch.toLowerCase())
+  );
+
+  function reset() {
+    setStep("company");
+    setSaving(false);
+    setCompanySearch("");
+    setCompanyDraft({ mode: "existing", existingId: undefined, name: "", priority: "B" });
+    setRoleDraft({ title: "", url: "", track: "TPM", fitScore: 3, seniority: "Senior", location: "" });
+    setWorkflowDraft({ stage: "to_apply", nextAction: "", dateApplied: TODAY, channel: "" });
+  }
+
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  function canAdvanceFromCompany() {
+    if (companyDraft.mode === "existing") return !!companyDraft.existingId;
+    return companyDraft.name.trim().length > 0;
+  }
+
+  function canAdvanceFromRole() {
+    return roleDraft.title.trim().length > 0;
+  }
+
+  async function handleSave() {
+    if (!canAdvanceFromRole()) return;
+    setSaving(true);
+    try {
+      let companyId = companyDraft.existingId ?? null;
+
+      if (companyDraft.mode === "new") {
+        const now = new Date().toISOString();
+        companyId = await addCompany({
+          name: companyDraft.name.trim(),
+          priority: companyDraft.priority,
+          status: "Research",
+          industry: "",
+          size: "",
+          remotePolicy: "",
+          notes: "",
+          sourceType: "manual",
+          lastInteractionAt: now,
+        });
+      }
+
+      if (!companyId) return;
+
+      const roleStatus =
+        workflowDraft.stage === "applied"
+          ? "applied"
+          : workflowDraft.stage === "to_apply"
+          ? "to_apply"
+          : "to_apply";
+
+      const now = new Date().toISOString();
+      const roleId = await addRole({
+        companyId,
+        title: roleDraft.title.trim(),
+        url: roleDraft.url.trim(),
+        track: roleDraft.track,
+        fitScore: roleDraft.fitScore,
+        seniority: roleDraft.seniority,
+        location: roleDraft.location.trim(),
+        status: roleStatus,
+        nextAction: workflowDraft.nextAction.trim() || undefined,
+        sourceType: "manual",
+        hasApplication: workflowDraft.stage === "applied",
+        lastInteractionAt: now,
+      });
+
+      if (!roleId) return;
+
+      if (workflowDraft.stage === "applied") {
+        await addApplication({
+          roleId,
+          companyId,
+          dateApplied: workflowDraft.dateApplied || TODAY,
+          channel: workflowDraft.channel.trim() || "Direct",
+          cvVersion: "",
+          status: "sent",
+          nextAction: workflowDraft.nextAction.trim() || "",
+          notes: "",
+          lastResponseAt: undefined,
+        });
+      }
+
+      handleClose();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) handleClose(); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add Role to Pipeline</DialogTitle>
+        </DialogHeader>
+
+        {/* Step indicator */}
+        <div className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400 mb-4">
+          {(["company", "role", "workflow"] as Step[]).map((s, i) => (
+            <div key={s} className="flex items-center gap-2">
+              {i > 0 && <span>›</span>}
+              <span className={step === s ? "font-semibold text-primary" : ""}>
+                {i + 1}. {s.charAt(0).toUpperCase() + s.slice(1)}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Company step */}
+        {step === "company" && (
+          <div className="space-y-4">
+            <div className="flex gap-2">
+              <button
+                onClick={() => setCompanyDraft((d) => ({ ...d, mode: "existing" }))}
+                className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                  companyDraft.mode === "existing"
+                    ? "border-primary bg-primary/5 text-primary"
+                    : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-400"
+                }`}
+              >
+                Existing company
+              </button>
+              <button
+                onClick={() => setCompanyDraft((d) => ({ ...d, mode: "new", existingId: undefined }))}
+                className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                  companyDraft.mode === "new"
+                    ? "border-primary bg-primary/5 text-primary"
+                    : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-400"
+                }`}
+              >
+                New company
+              </button>
+            </div>
+
+            {companyDraft.mode === "existing" ? (
+              <div className="space-y-2">
+                <input
+                  type="text"
+                  placeholder="Search companies..."
+                  value={companySearch}
+                  onChange={(e) => setCompanySearch(e.target.value)}
+                  className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                />
+                <div className="max-h-48 overflow-y-auto rounded-lg border border-neutral-200 dark:border-neutral-700">
+                  {filteredCompanies.length === 0 ? (
+                    <p className="px-3 py-4 text-center text-sm text-neutral-400">No companies found</p>
+                  ) : (
+                    filteredCompanies.map((c) => (
+                      <button
+                        key={c.id}
+                        onClick={() => setCompanyDraft((d) => ({ ...d, existingId: c.id }))}
+                        className={`w-full flex items-center justify-between px-3 py-2 text-sm text-left hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors ${
+                          companyDraft.existingId === c.id ? "bg-primary/5 text-primary font-medium" : "text-neutral-900 dark:text-neutral-100"
+                        }`}
+                      >
+                        <span>{c.name}</span>
+                        <span className="text-xs text-neutral-400">{c.priority}</span>
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Company name *</label>
+                  <input
+                    type="text"
+                    placeholder="e.g. Acme Corp"
+                    value={companyDraft.name}
+                    onChange={(e) => setCompanyDraft((d) => ({ ...d, name: e.target.value }))}
+                    className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Priority</label>
+                  <div className="flex gap-2">
+                    {(["A", "B", "C"] as CompanyPriority[]).map((p) => (
+                      <button
+                        key={p}
+                        onClick={() => setCompanyDraft((d) => ({ ...d, priority: p }))}
+                        className={`flex-1 rounded-lg border py-2 text-sm font-medium transition-colors ${
+                          companyDraft.priority === p
+                            ? "border-primary bg-primary/10 text-primary"
+                            : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-400"
+                        }`}
+                      >
+                        {p}
+                      </button>
+                    ))}
+                  </div>
+                  <p className="mt-1 text-xs text-neutral-400">A = top target · B = good fit · C = speculative</p>
+                </div>
+              </div>
+            )}
+
+            <div className="flex justify-end">
+              <Button
+                onClick={() => setStep("role")}
+                disabled={!canAdvanceFromCompany()}
+              >
+                Next: Role
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Role step */}
+        {step === "role" && (
+          <div className="space-y-3">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Role title *</label>
+              <input
+                type="text"
+                placeholder="e.g. Senior Technical Program Manager"
+                value={roleDraft.title}
+                onChange={(e) => setRoleDraft((d) => ({ ...d, title: e.target.value }))}
+                className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Job listing URL</label>
+              <input
+                type="url"
+                placeholder="https://..."
+                value={roleDraft.url}
+                onChange={(e) => setRoleDraft((d) => ({ ...d, url: e.target.value }))}
+                className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Track</label>
+                <select
+                  value={roleDraft.track}
+                  onChange={(e) => setRoleDraft((d) => ({ ...d, track: e.target.value as JobTrack }))}
+                  className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                >
+                  {TRACKS.map((t) => (
+                    <option key={t} value={t}>{t}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Seniority</label>
+                <select
+                  value={roleDraft.seniority}
+                  onChange={(e) => setRoleDraft((d) => ({ ...d, seniority: e.target.value }))}
+                  className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                >
+                  {SENIORITY_OPTIONS.map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Fit score</label>
+                <div className="flex gap-1">
+                  {([1, 2, 3, 4, 5] as const).map((n) => (
+                    <button
+                      key={n}
+                      onClick={() => setRoleDraft((d) => ({ ...d, fitScore: n }))}
+                      className={`flex-1 rounded border py-1.5 text-xs font-medium transition-colors ${
+                        roleDraft.fitScore === n
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-neutral-200 dark:border-neutral-700 text-neutral-500"
+                      }`}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Location</label>
+                <input
+                  type="text"
+                  placeholder="e.g. Remote, London"
+                  value={roleDraft.location}
+                  onChange={(e) => setRoleDraft((d) => ({ ...d, location: e.target.value }))}
+                  className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-between">
+              <Button variant="outline" onClick={() => setStep("company")}>Back</Button>
+              <Button onClick={() => setStep("workflow")} disabled={!canAdvanceFromRole()}>
+                Next: Workflow
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Workflow step */}
+        {step === "workflow" && (
+          <div className="space-y-4">
+            <div>
+              <label className="mb-2 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Where is this role?</label>
+              <div className="grid grid-cols-3 gap-2">
+                {(["saved", "to_apply", "applied"] as WorkflowStage[]).map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => setWorkflowDraft((d) => ({ ...d, stage: s }))}
+                    className={`rounded-lg border px-3 py-3 text-center transition-colors ${
+                      workflowDraft.stage === s
+                        ? "border-primary bg-primary/5 text-primary"
+                        : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-400 hover:border-neutral-300"
+                    }`}
+                  >
+                    <div className="text-xs font-medium">
+                      {s === "saved" ? "Saved" : s === "to_apply" ? "To Apply" : "Applied"}
+                    </div>
+                    <div className="mt-0.5 text-[10px] text-neutral-400">
+                      {s === "saved" ? "researching" : s === "to_apply" ? "queued" : "submitted"}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {workflowDraft.stage === "applied" && (
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Date applied</label>
+                  <input
+                    type="date"
+                    value={workflowDraft.dateApplied}
+                    onChange={(e) => setWorkflowDraft((d) => ({ ...d, dateApplied: e.target.value }))}
+                    className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Channel</label>
+                  <input
+                    type="text"
+                    placeholder="e.g. LinkedIn, Direct"
+                    value={workflowDraft.channel}
+                    onChange={(e) => setWorkflowDraft((d) => ({ ...d, channel: e.target.value }))}
+                    className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                  />
+                </div>
+              </div>
+            )}
+
+            <div>
+              <label className="mb-2 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Next action</label>
+              <div className="mb-2 flex flex-wrap gap-1.5">
+                {NEXT_ACTION_PRESETS.map((p) => (
+                  <button
+                    key={p}
+                    onClick={() => setWorkflowDraft((d) => ({ ...d, nextAction: p }))}
+                    className={`rounded-full border px-2.5 py-1 text-xs transition-colors ${
+                      workflowDraft.nextAction === p
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:border-neutral-300"
+                    }`}
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+              <input
+                type="text"
+                placeholder="Or type a custom next action..."
+                value={workflowDraft.nextAction}
+                onChange={(e) => setWorkflowDraft((d) => ({ ...d, nextAction: e.target.value }))}
+                className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+            </div>
+
+            <div className="flex justify-between">
+              <Button variant="outline" onClick={() => setStep("role")}>Back</Button>
+              <Button onClick={() => void handleSave()} disabled={saving}>
+                {saving ? "Saving..." : "Add to pipeline"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/pages/dashboard/DashboardPage.tsx
+++ b/src/app/pages/dashboard/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { ChevronDown, ChevronUp, Layers3 } from "lucide-react";
 import { useApp } from "../../context";
 import { useJobOs } from "../../hooks/useJobOs";
+import { UnifiedAddModal } from "../../components/job-os/UnifiedAddModal";
 import { useJobOsSyncSnapshot } from "../../services/jobOsSync";
 import {
   getNextActions,
@@ -30,6 +31,7 @@ export function DashboardPage() {
   const navigate = useNavigate();
   const jobOsSync = useJobOsSyncSnapshot();
   const [supportOpen, setSupportOpen] = useState(false);
+  const [addModalOpen, setAddModalOpen] = useState(false);
   const {
     companies,
     roles,
@@ -153,7 +155,7 @@ export function DashboardPage() {
 
             <div className="min-w-0 lg:self-start">
               <div className="space-y-4 lg:sticky lg:top-24">
-                <QuickActions />
+                <QuickActions onAddRole={() => setAddModalOpen(true)} />
                 <WeeklyExecutionPanel />
                 <PipelineStats stats={stats} isLoading={loading} />
                 <ProbabilityPanel stats={stats} isLoading={loading} />
@@ -193,6 +195,15 @@ export function DashboardPage() {
           </div>
         </AppPageShell>
       </main>
+
+      <UnifiedAddModal
+        open={addModalOpen}
+        onClose={() => setAddModalOpen(false)}
+        companies={companies}
+        addCompany={addCompany}
+        addRole={addRole}
+        addApplication={addApplication}
+      />
     </div>
   );
 }

--- a/src/app/services/execution/nextActionEngine.ts
+++ b/src/app/services/execution/nextActionEngine.ts
@@ -15,6 +15,7 @@ export type NextActionType =
   | "add_role"
   | "research"
   | "optimize_cv"
+  | "add_jd"
   | "archive";
 
 export type ActionPriority = "urgent" | "high" | "medium" | "low";
@@ -536,6 +537,43 @@ export function getPipelineStats(
   };
 }
 
+// ─── Missing JD Actions ──────────────────────────────────────────────────────
+
+const ADD_JD_BASE = 45;
+const ADD_JD_ACTIVE_STATUSES = new Set(["sent", "screen", "case", "interview", "final"]);
+
+function generateAddJdActions(
+  applications: JobOsApplication[],
+  companies: JobOsCompany[]
+): NextAction[] {
+  const companyMap = new Map(companies.map((c) => [c.id, c]));
+
+  return applications
+    .filter(
+      (a) =>
+        ADD_JD_ACTIVE_STATUSES.has(a.status) &&
+        !a.latestJobDescriptionId
+    )
+    .map((app) => {
+      const company = companyMap.get(app.companyId);
+      const priorityBonus = company ? PRIORITY_WEIGHT[company.priority] : 0;
+      const score = clamp(ADD_JD_BASE + priorityBonus, 0, 100);
+
+      return {
+        id: `add-jd-${app.id}`,
+        type: "add_jd" as NextActionType,
+        priority: toPriority(score),
+        score,
+        companyId: app.companyId,
+        companyName: company?.name,
+        applicationId: app.id,
+        reason: "No job description attached — add one to enable CV tailoring",
+        actionLabel: "Add JD",
+        href: "/cv-optimizer",
+      };
+    });
+}
+
 // ─── Main Entry Point ─────────────────────────────────────────────────────────
 
 /**
@@ -553,6 +591,7 @@ export function getNextActions(
     ...generateOverdueOutreachActions(outreach, companies),
     ...generateStalledApplicationActions(applications, outreach, companies),
     ...generateFollowUpActions(applications, companies),
+    ...generateAddJdActions(applications, companies),
     ...generateLogApplicationActions(roles, companies, applications),
     ...generateApplyActions(roles, companies, applications),
     ...generateAddRoleActions(companies, roles),


### PR DESCRIPTION
## What

- **UnifiedAddModal** (`components/job-os/UnifiedAddModal.tsx`): 3-step wizard that lets users add a company (existing via fuzzy search, or new with A/B/C priority picker), define a role (title, url, track, seniority, fit score 1–5, location), and set the initial workflow stage (Saved / To Apply / Applied). When Applied is selected, it additionally logs the application record with dateApplied and channel.
- **QuickActions** updated with an `onAddRole` prop; the "Add Role" tile now opens the modal instead of navigating to /job-os/roles.
- **DashboardPage** wires the modal open/close state and passes all required add* handlers.
- **next action engine** (`nextActionEngine.ts`): adds `add_jd` action type — surfaces for applications in active statuses (sent / screen / case / interview / final) that are missing a job description, score = 45 + priority bonus, links to /cv-optimizer.
- **FocusedNextAction** and **NextActionCard** get amber accent styles for `add_jd`.

## Why

Issue #115 — users had no single entry point on the dashboard to add a new role; every path required multiple page navigations. The modal collapses Company + Role + initial Workflow into one focused flow.

Issue #116 — the execution engine was unaware of applications missing a JD, so it couldn't prompt users to paste one before tailoring. The `add_jd` action fills this gap.

## How To Test

1. Open the dashboard.
2. Click "Add Role" in the Quick Actions panel → wizard should open.
3. Step 1 — search for an existing company or create a new one with a priority.
4. Step 2 — fill title (required); url, track, seniority, fit score, location are optional.
5. Step 3 — pick "Applied", set a date and channel → click "Add to pipeline".
6. Navigate to Job OS → Companies / Roles / Applications and confirm records appear.
7. With an existing application that has no job description in an active status, verify the dashboard surfaces an `add_jd` next action card linking to /cv-optimizer.

## Evidence

- Issue: #115, #116
- Demo artifact: N/A — UI-only; verify by following test steps above

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit 41278cd

## Checklist

- [x] Linked to issues #115 and #116 with clear acceptance criteria
- [x] Scope is limited to those issues
- [x] Local checks pass (`npm run lint && npm run build`)
- [x] Docs updated if behavior or workflow changed — N/A
- [x] `CHANGELOG.md` updated — N/A (pre-1.0, no changelog policy yet)
- [x] Demo artifact attached — N/A non-visual backend logic + modal (follow test steps)