### PR TITLE
Add public AfA report and pipeline refinements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ VITE_FIREBASE_APP_ID=
 VITE_FIREBASE_MEASUREMENT_ID=
 VITE_FIREBASE_STORAGE_BUCKET=
 VITE_FIREBASE_MESSAGING_SENDER_ID=
+
+# Optional: user-scoped Job OS data source for the public /job-os/afa-report page.
+# Configure Firestore rules so this user ID's report collections are readable without app sign-in.
+VITE_PUBLIC_AFA_REPORT_USER_ID=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -43,12 +43,12 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-assign and label issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR policy
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/weekly-sync.yml
+++ b/.github/workflows/weekly-sync.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create weekly roadmap sync issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const today = new Date().toISOString().slice(0, 10);

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,21 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isOwner(userId) {
+      return request.auth != null && request.auth.uid == userId;
+    }
+
+    function isPublicAfaReportCollection(collectionName) {
+      return collectionName in ['applications', 'companies', 'roles'];
+    }
+
+    match /users/{userId}/{document=**} {
+      allow read, write: if isOwner(userId);
+    }
+
+    match /users/JeUm6rAA1XOZrfqHtFPPXCtXpZ2/{collectionName}/{documentId} {
+      allow read: if isPublicAfaReportCollection(collectionName);
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4429,9 +4429,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4657,15 +4657,6 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/@xmldom/xmldom": {
-            "version": "0.8.12",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-            "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/acorn": {
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -4806,9 +4797,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5738,9 +5729,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-            "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -6491,6 +6482,16 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/mammoth/node_modules/@xmldom/xmldom": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+            "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+            "deprecated": "this version has critical issues, please update to the latest version",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/mammoth/node_modules/argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -6786,9 +6787,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6908,9 +6909,9 @@
             "license": "MIT"
         },
         "node_modules/protobufjs": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+            "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -7529,9 +7530,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-            "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+            "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {

--- a/src/app/components/AppNavbar.tsx
+++ b/src/app/components/AppNavbar.tsx
@@ -153,11 +153,11 @@ export function AppNavbar({
                     Private Access
                   </div>
                   <Link
-                    to="/compliance/afa"
+                    to="/job-os/afa-report"
                     className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-neutral-700 transition-colors hover:bg-neutral-100 dark:text-neutral-200 dark:hover:bg-neutral-900"
                   >
                     <Lock className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
-                    <span>AfA Compliance</span>
+                    <span>AfA Report</span>
                   </Link>
                 </div>
               </DropdownMenuContent>
@@ -227,11 +227,11 @@ export function AppNavbar({
             <div className="pt-2 border-t border-neutral-200 dark:border-neutral-800 mt-2">
               <SheetClose asChild>
                 <Link
-                  to="/compliance/afa"
+                  to="/job-os/afa-report"
                   className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
                 >
                   <Lock className="w-4 h-4 shrink-0 text-neutral-500" />
-                  AfA Compliance
+                  AfA Report
                 </Link>
               </SheetClose>
             </div>

--- a/src/app/components/dashboard/FocusedNextAction.tsx
+++ b/src/app/components/dashboard/FocusedNextAction.tsx
@@ -16,6 +16,7 @@ const TYPE_ACCENTS: Record<NextAction["type"], string> = {
   optimize_cv: "from-emerald-600/15 to-green-500/10 text-emerald-700 dark:text-emerald-300",
   add_role: "from-teal-600/15 to-emerald-500/10 text-teal-700 dark:text-teal-300",
   research: "from-indigo-600/15 to-blue-500/10 text-indigo-700 dark:text-indigo-300",
+  add_jd: "from-amber-600/15 to-yellow-500/10 text-amber-700 dark:text-amber-300",
   archive: "from-neutral-500/10 to-neutral-400/10 text-neutral-700 dark:text-neutral-300",
 };
 

--- a/src/app/components/dashboard/NextActionCard.tsx
+++ b/src/app/components/dashboard/NextActionCard.tsx
@@ -16,6 +16,7 @@ const TYPE_COLORS: Record<NextAction["type"], string> = {
   optimize_cv: "border-l-green-500",
   add_role: "border-l-teal-500",
   research: "border-l-indigo-500",
+  add_jd: "border-l-amber-500",
   archive: "border-l-neutral-400",
 };
 

--- a/src/app/components/dashboard/QuickActions.tsx
+++ b/src/app/components/dashboard/QuickActions.tsx
@@ -1,62 +1,77 @@
 import { Link } from "react-router";
-import { PlusCircle, FileText, Building2, ClipboardList } from "lucide-react";
+import { PlusCircle, FileText, ClipboardList, Rocket } from "lucide-react";
 
-interface QuickAction {
-  label: string;
-  description: string;
-  href: string;
-  icon: React.ReactNode;
+interface QuickActionsProps {
+  onAddRole?: () => void;
 }
 
-const QUICK_ACTIONS: QuickAction[] = [
-  {
-    label: "Add Company",
-    description: "Track a new target",
-    href: "/job-os/companies",
-    icon: <Building2 className="h-4 w-4" />,
-  },
-  {
-    label: "Log Application",
-    description: "Record a submission",
-    href: "/job-os/applications",
-    icon: <ClipboardList className="h-4 w-4" />,
-  },
-  {
-    label: "Tailor CV",
-    description: "Optimise for a role",
-    href: "/cv-optimizer",
-    icon: <FileText className="h-4 w-4" />,
-  },
-  {
-    label: "Browse Roles",
-    description: "Review your pipeline",
-    href: "/job-os/roles",
-    icon: <PlusCircle className="h-4 w-4" />,
-  },
-];
-
-export function QuickActions() {
+export function QuickActions({ onAddRole }: QuickActionsProps) {
   return (
     <section className="space-y-3">
       <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
         Quick Actions
       </h2>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-        {QUICK_ACTIONS.map((qa) => (
-          <Link
-            key={qa.href}
-            to={qa.href}
-            className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
-          >
-            <span className="text-neutral-500 dark:text-neutral-400">{qa.icon}</span>
-            <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
-              {qa.label}
-            </span>
-            <span className="text-xs text-neutral-400 dark:text-neutral-500">
-              {qa.description}
-            </span>
-          </Link>
-        ))}
+        <button
+          type="button"
+          onClick={onAddRole}
+          className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
+        >
+          <span className="text-neutral-500 dark:text-neutral-400">
+            <Rocket className="h-4 w-4" />
+          </span>
+          <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
+            Add Role
+          </span>
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
+            Company + role in one flow
+          </span>
+        </button>
+
+        <Link
+          to="/job-os/applications"
+          className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
+        >
+          <span className="text-neutral-500 dark:text-neutral-400">
+            <ClipboardList className="h-4 w-4" />
+          </span>
+          <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
+            Log Application
+          </span>
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
+            Record a submission
+          </span>
+        </Link>
+
+        <Link
+          to="/cv-optimizer"
+          className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
+        >
+          <span className="text-neutral-500 dark:text-neutral-400">
+            <FileText className="h-4 w-4" />
+          </span>
+          <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
+            Tailor CV
+          </span>
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
+            Optimise for a role
+          </span>
+        </Link>
+
+        <Link
+          to="/job-os/roles"
+          className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
+        >
+          <span className="text-neutral-500 dark:text-neutral-400">
+            <PlusCircle className="h-4 w-4" />
+          </span>
+          <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
+            Browse Roles
+          </span>
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
+            Review your pipeline
+          </span>
+        </Link>
       </div>
     </section>
   );

--- a/src/app/components/job-os/JobOsPipelineBoard.tsx
+++ b/src/app/components/job-os/JobOsPipelineBoard.tsx
@@ -1,17 +1,13 @@
-import { CalendarDays, FileText, MoveRight } from "lucide-react";
+import { CalendarDays, FileText, MessageSquare, MoveRight } from "lucide-react";
 import { Badge } from "../ui/badge";
+import {
+  APPLICATION_STATUS_LABELS,
+  applicationReachedInterview,
+  getApplicationVisibleNextAction,
+} from "../../services/jobOsApplications";
 import type { ApplicationStatus, JobOsApplication, JobOsCompany, JobOsRole } from "../../types/jobOs";
 
-export const APPLICATION_STATUS_LABELS: Record<ApplicationStatus, string> = {
-  sent: "Submitted",
-  screen: "Screening",
-  case: "Case Study",
-  interview: "Interview",
-  final: "Final Round",
-  offer: "Offer",
-  rejected: "Rejected",
-  ghosted: "Ghosted",
-};
+export { APPLICATION_STATUS_LABELS };
 
 export const APPLICATION_STAGE_GROUPS = {
   active: {
@@ -52,6 +48,8 @@ function JobOsPipelineCard({
   roleTitle: string;
   onClick: () => void;
 }) {
+  const visibleNextAction = getApplicationVisibleNextAction(application);
+
   return (
     <button
       type="button"
@@ -80,9 +78,15 @@ function JobOsPipelineCard({
             CV tailored
           </Badge>
         ) : null}
-        {application.nextAction ? (
+        {applicationReachedInterview(application) ? (
+          <Badge variant="secondary" className="gap-1 rounded-full text-[10px]">
+            <MessageSquare className="h-3 w-3" />
+            Interviewed
+          </Badge>
+        ) : null}
+        {visibleNextAction ? (
           <Badge variant="outline" className="rounded-full text-[10px]">
-            {application.nextAction}
+            {visibleNextAction}
           </Badge>
         ) : null}
         {application.notes ? <FileText className="h-3.5 w-3.5" /> : null}

--- a/src/app/components/job-os/PublicJobOsReportProvider.tsx
+++ b/src/app/components/job-os/PublicJobOsReportProvider.tsx
@@ -1,0 +1,22 @@
+import { Outlet } from "react-router";
+import { useApp } from "../../context";
+import { JobOsContext } from "../../context/JobOsContext";
+import { useJobOs } from "../../hooks/useJobOs";
+
+const DEFAULT_AFA_REPORT_USER_ID = "JeUm6rAA1XOZrfqHtFPPXCtXpZ2";
+
+const PUBLIC_AFA_REPORT_USER_ID = (
+  import.meta.env.VITE_PUBLIC_AFA_REPORT_USER_ID || ""
+).trim() || DEFAULT_AFA_REPORT_USER_ID;
+
+export function PublicJobOsReportProvider() {
+  const { session } = useApp();
+  const reportUserId = session?.userId ?? (PUBLIC_AFA_REPORT_USER_ID || null);
+  const jobOsData = useJobOs(reportUserId);
+
+  return (
+    <JobOsContext.Provider value={jobOsData}>
+      <Outlet />
+    </JobOsContext.Provider>
+  );
+}

--- a/src/app/components/job-os/UnifiedAddModal.tsx
+++ b/src/app/components/job-os/UnifiedAddModal.tsx
@@ -1,0 +1,495 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Button } from "../ui/button";
+import type {
+  JobOsCompany,
+  JobOsRole,
+  JobOsApplication,
+  CompanyPriority,
+  JobTrack,
+} from "../../types/jobOs";
+
+type Step = "company" | "role" | "workflow";
+
+type WorkflowStage = "saved" | "to_apply" | "applied";
+
+interface CompanyDraft {
+  mode: "existing" | "new";
+  existingId?: string;
+  name: string;
+  priority: CompanyPriority;
+}
+
+interface RoleDraft {
+  title: string;
+  url: string;
+  track: JobTrack;
+  fitScore: 1 | 2 | 3 | 4 | 5;
+  seniority: string;
+  location: string;
+}
+
+interface WorkflowDraft {
+  stage: WorkflowStage;
+  nextAction: string;
+  dateApplied: string;
+  channel: string;
+}
+
+export interface UnifiedAddModalProps {
+  open: boolean;
+  onClose: () => void;
+  companies: JobOsCompany[];
+  addCompany: (payload: Omit<JobOsCompany, "id" | "createdAt" | "updatedAt">) => Promise<string | null>;
+  addRole: (payload: Omit<JobOsRole, "id" | "createdAt" | "updatedAt">) => Promise<string | null>;
+  addApplication: (payload: Omit<JobOsApplication, "id" | "createdAt" | "updatedAt">) => Promise<string | null>;
+}
+
+const TRACKS: JobTrack[] = ["TPM", "Product Engineer", "Systems PM"];
+const SENIORITY_OPTIONS = ["Junior", "Mid", "Senior", "Lead", "Staff", "Principal", "Director", "VP"];
+const NEXT_ACTION_PRESETS = [
+  "Tailor CV",
+  "Submit application",
+  "Research company",
+  "Follow up on application",
+  "Prepare for interview",
+];
+
+const TODAY = new Date().toISOString().split("T")[0];
+
+export function UnifiedAddModal({
+  open,
+  onClose,
+  companies,
+  addCompany,
+  addRole,
+  addApplication,
+}: UnifiedAddModalProps) {
+  const [step, setStep] = useState<Step>("company");
+  const [saving, setSaving] = useState(false);
+  const [companySearch, setCompanySearch] = useState("");
+
+  const [companyDraft, setCompanyDraft] = useState<CompanyDraft>({
+    mode: "existing",
+    existingId: undefined,
+    name: "",
+    priority: "B",
+  });
+
+  const [roleDraft, setRoleDraft] = useState<RoleDraft>({
+    title: "",
+    url: "",
+    track: "TPM",
+    fitScore: 3,
+    seniority: "Senior",
+    location: "",
+  });
+
+  const [workflowDraft, setWorkflowDraft] = useState<WorkflowDraft>({
+    stage: "to_apply",
+    nextAction: "",
+    dateApplied: TODAY,
+    channel: "",
+  });
+
+  const filteredCompanies = companies.filter((c) =>
+    c.name.toLowerCase().includes(companySearch.toLowerCase())
+  );
+
+  function reset() {
+    setStep("company");
+    setSaving(false);
+    setCompanySearch("");
+    setCompanyDraft({ mode: "existing", existingId: undefined, name: "", priority: "B" });
+    setRoleDraft({ title: "", url: "", track: "TPM", fitScore: 3, seniority: "Senior", location: "" });
+    setWorkflowDraft({ stage: "to_apply", nextAction: "", dateApplied: TODAY, channel: "" });
+  }
+
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  function canAdvanceFromCompany() {
+    if (companyDraft.mode === "existing") return !!companyDraft.existingId;
+    return companyDraft.name.trim().length > 0;
+  }
+
+  function canAdvanceFromRole() {
+    return roleDraft.title.trim().length > 0;
+  }
+
+  async function handleSave() {
+    if (!canAdvanceFromRole()) return;
+    setSaving(true);
+    try {
+      let companyId = companyDraft.existingId ?? null;
+
+      if (companyDraft.mode === "new") {
+        const now = new Date().toISOString();
+        companyId = await addCompany({
+          name: companyDraft.name.trim(),
+          priority: companyDraft.priority,
+          status: "Research",
+          industry: "",
+          size: "",
+          remotePolicy: "",
+          notes: "",
+          sourceType: "manual",
+          lastInteractionAt: now,
+        });
+      }
+
+      if (!companyId) return;
+
+      const roleStatus =
+        workflowDraft.stage === "applied"
+          ? "applied"
+          : workflowDraft.stage === "to_apply"
+          ? "to_apply"
+          : "to_apply";
+
+      const now = new Date().toISOString();
+      const roleId = await addRole({
+        companyId,
+        title: roleDraft.title.trim(),
+        url: roleDraft.url.trim(),
+        track: roleDraft.track,
+        fitScore: roleDraft.fitScore,
+        seniority: roleDraft.seniority,
+        location: roleDraft.location.trim(),
+        status: roleStatus,
+        nextAction: workflowDraft.nextAction.trim() || undefined,
+        sourceType: "manual",
+        hasApplication: workflowDraft.stage === "applied",
+        lastInteractionAt: now,
+      });
+
+      if (!roleId) return;
+
+      if (workflowDraft.stage === "applied") {
+        await addApplication({
+          roleId,
+          companyId,
+          dateApplied: workflowDraft.dateApplied || TODAY,
+          channel: workflowDraft.channel.trim() || "Direct",
+          cvVersion: "",
+          status: "sent",
+          nextAction: workflowDraft.nextAction.trim() || "",
+          notes: "",
+          lastResponseAt: undefined,
+        });
+      }
+
+      handleClose();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) handleClose(); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add Role to Pipeline</DialogTitle>
+        </DialogHeader>
+
+        {/* Step indicator */}
+        <div className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400 mb-4">
+          {(["company", "role", "workflow"] as Step[]).map((s, i) => (
+            <div key={s} className="flex items-center gap-2">
+              {i > 0 && <span>›</span>}
+              <span className={step === s ? "font-semibold text-primary" : ""}>
+                {i + 1}. {s.charAt(0).toUpperCase() + s.slice(1)}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Company step */}
+        {step === "company" && (
+          <div className="space-y-4">
+            <div className="flex gap-2">
+              <button
+                onClick={() => setCompanyDraft((d) => ({ ...d, mode: "existing" }))}
+                className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                  companyDraft.mode === "existing"
+                    ? "border-primary bg-primary/5 text-primary"
+                    : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-400"
+                }`}
+              >
+                Existing company
+              </button>
+              <button
+                onClick={() => setCompanyDraft((d) => ({ ...d, mode: "new", existingId: undefined }))}
+                className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                  companyDraft.mode === "new"
+                    ? "border-primary bg-primary/5 text-primary"
+                    : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-400"
+                }`}
+              >
+                New company
+              </button>
+            </div>
+
+            {companyDraft.mode === "existing" ? (
+              <div className="space-y-2">
+                <input
+                  type="text"
+                  placeholder="Search companies..."
+                  value={companySearch}
+                  onChange={(e) => setCompanySearch(e.target.value)}
+                  className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                />
+                <div className="max-h-48 overflow-y-auto rounded-lg border border-neutral-200 dark:border-neutral-700">
+                  {filteredCompanies.length === 0 ? (
+                    <p className="px-3 py-4 text-center text-sm text-neutral-400">No companies found</p>
+                  ) : (
+                    filteredCompanies.map((c) => (
+                      <button
+                        key={c.id}
+                        onClick={() => setCompanyDraft((d) => ({ ...d, existingId: c.id }))}
+                        className={`w-full flex items-center justify-between px-3 py-2 text-sm text-left hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors ${
+                          companyDraft.existingId === c.id ? "bg-primary/5 text-primary font-medium" : "text-neutral-900 dark:text-neutral-100"
+                        }`}
+                      >
+                        <span>{c.name}</span>
+                        <span className="text-xs text-neutral-400">{c.priority}</span>
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Company name *</label>
+                  <input
+                    type="text"
+                    placeholder="e.g. Acme Corp"
+                    value={companyDraft.name}
+                    onChange={(e) => setCompanyDraft((d) => ({ ...d, name: e.target.value }))}
+                    className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Priority</label>
+                  <div className="flex gap-2">
+                    {(["A", "B", "C"] as CompanyPriority[]).map((p) => (
+                      <button
+                        key={p}
+                        onClick={() => setCompanyDraft((d) => ({ ...d, priority: p }))}
+                        className={`flex-1 rounded-lg border py-2 text-sm font-medium transition-colors ${
+                          companyDraft.priority === p
+                            ? "border-primary bg-primary/10 text-primary"
+                            : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-400"
+                        }`}
+                      >
+                        {p}
+                      </button>
+                    ))}
+                  </div>
+                  <p className="mt-1 text-xs text-neutral-400">A = top target · B = good fit · C = speculative</p>
+                </div>
+              </div>
+            )}
+
+            <div className="flex justify-end">
+              <Button
+                onClick={() => setStep("role")}
+                disabled={!canAdvanceFromCompany()}
+              >
+                Next: Role
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Role step */}
+        {step === "role" && (
+          <div className="space-y-3">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Role title *</label>
+              <input
+                type="text"
+                placeholder="e.g. Senior Technical Program Manager"
+                value={roleDraft.title}
+                onChange={(e) => setRoleDraft((d) => ({ ...d, title: e.target.value }))}
+                className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Job listing URL</label>
+              <input
+                type="url"
+                placeholder="https://..."
+                value={roleDraft.url}
+                onChange={(e) => setRoleDraft((d) => ({ ...d, url: e.target.value }))}
+                className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Track</label>
+                <select
+                  value={roleDraft.track}
+                  onChange={(e) => setRoleDraft((d) => ({ ...d, track: e.target.value as JobTrack }))}
+                  className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                >
+                  {TRACKS.map((t) => (
+                    <option key={t} value={t}>{t}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Seniority</label>
+                <select
+                  value={roleDraft.seniority}
+                  onChange={(e) => setRoleDraft((d) => ({ ...d, seniority: e.target.value }))}
+                  className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                >
+                  {SENIORITY_OPTIONS.map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Fit score</label>
+                <div className="flex gap-1">
+                  {([1, 2, 3, 4, 5] as const).map((n) => (
+                    <button
+                      key={n}
+                      onClick={() => setRoleDraft((d) => ({ ...d, fitScore: n }))}
+                      className={`flex-1 rounded border py-1.5 text-xs font-medium transition-colors ${
+                        roleDraft.fitScore === n
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-neutral-200 dark:border-neutral-700 text-neutral-500"
+                      }`}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Location</label>
+                <input
+                  type="text"
+                  placeholder="e.g. Remote, London"
+                  value={roleDraft.location}
+                  onChange={(e) => setRoleDraft((d) => ({ ...d, location: e.target.value }))}
+                  className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-between">
+              <Button variant="outline" onClick={() => setStep("company")}>Back</Button>
+              <Button onClick={() => setStep("workflow")} disabled={!canAdvanceFromRole()}>
+                Next: Workflow
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Workflow step */}
+        {step === "workflow" && (
+          <div className="space-y-4">
+            <div>
+              <label className="mb-2 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Where is this role?</label>
+              <div className="grid grid-cols-3 gap-2">
+                {(["saved", "to_apply", "applied"] as WorkflowStage[]).map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => setWorkflowDraft((d) => ({ ...d, stage: s }))}
+                    className={`rounded-lg border px-3 py-3 text-center transition-colors ${
+                      workflowDraft.stage === s
+                        ? "border-primary bg-primary/5 text-primary"
+                        : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-400 hover:border-neutral-300"
+                    }`}
+                  >
+                    <div className="text-xs font-medium">
+                      {s === "saved" ? "Saved" : s === "to_apply" ? "To Apply" : "Applied"}
+                    </div>
+                    <div className="mt-0.5 text-[10px] text-neutral-400">
+                      {s === "saved" ? "researching" : s === "to_apply" ? "queued" : "submitted"}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {workflowDraft.stage === "applied" && (
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Date applied</label>
+                  <input
+                    type="date"
+                    value={workflowDraft.dateApplied}
+                    onChange={(e) => setWorkflowDraft((d) => ({ ...d, dateApplied: e.target.value }))}
+                    className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Channel</label>
+                  <input
+                    type="text"
+                    placeholder="e.g. LinkedIn, Direct"
+                    value={workflowDraft.channel}
+                    onChange={(e) => setWorkflowDraft((d) => ({ ...d, channel: e.target.value }))}
+                    className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                  />
+                </div>
+              </div>
+            )}
+
+            <div>
+              <label className="mb-2 block text-xs font-medium text-neutral-600 dark:text-neutral-400">Next action</label>
+              <div className="mb-2 flex flex-wrap gap-1.5">
+                {NEXT_ACTION_PRESETS.map((p) => (
+                  <button
+                    key={p}
+                    onClick={() => setWorkflowDraft((d) => ({ ...d, nextAction: p }))}
+                    className={`rounded-full border px-2.5 py-1 text-xs transition-colors ${
+                      workflowDraft.nextAction === p
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:border-neutral-300"
+                    }`}
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+              <input
+                type="text"
+                placeholder="Or type a custom next action..."
+                value={workflowDraft.nextAction}
+                onChange={(e) => setWorkflowDraft((d) => ({ ...d, nextAction: e.target.value }))}
+                className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+            </div>
+
+            <div className="flex justify-between">
+              <Button variant="outline" onClick={() => setStep("role")}>Back</Button>
+              <Button onClick={() => void handleSave()} disabled={saving}>
+                {saving ? "Saving..." : "Add to pipeline"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/hooks/useJobOs.ts
+++ b/src/app/hooks/useJobOs.ts
@@ -41,6 +41,7 @@ import {
   MAX_CV_ASSETS,
   normalizeCvDefaults,
 } from "../services/cvAssets";
+import { normalizeApplicationNextActionForStatus } from "../services/jobOsApplications";
 
 const LOCAL_KEY_PREFIX = "job_os_v1";
 const MUTATION_TIMEOUT_MS = 12000;
@@ -261,6 +262,10 @@ function mapApplicationStatusToRoleStatus(
     default:
       return null;
   }
+}
+
+function isInterviewStageStatus(status: ApplicationStatus): boolean {
+  return status === "interview" || status === "final" || status === "offer";
 }
 
 function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
@@ -1258,6 +1263,13 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
                         ? {
                             ...application,
                             status: syncedApplicationStatus,
+                            nextAction: normalizeApplicationNextActionForStatus(
+                              application.nextAction,
+                              syncedApplicationStatus
+                            ),
+                            interviewStageReached:
+                              application.interviewStageReached ||
+                              isInterviewStageStatus(syncedApplicationStatus),
                             updatedAt: now,
                           }
                         : application
@@ -1285,6 +1297,14 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
                         doc(firebase.db, "users", userId, "applications", application.id),
                         {
                           status: syncedApplicationStatus,
+                          nextAction: normalizeApplicationNextActionForStatus(
+                            application.nextAction,
+                            syncedApplicationStatus
+                          ),
+                          ...(application.interviewStageReached ||
+                          isInterviewStageStatus(syncedApplicationStatus)
+                            ? { interviewStageReached: true }
+                            : {}),
                           updatedAt: serverTimestamp(),
                         },
                         { merge: true }
@@ -1306,11 +1326,23 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
             throw new Error("An application for this role already exists.");
           }
 
-          const appId = await addCollectionItem<JobOsApplication>("applications", "app", payload, { hasUpdatedAt: true });
+          const normalizedPayload: Omit<JobOsApplication, "id" | "createdAt" | "updatedAt"> = {
+            ...payload,
+            nextAction: normalizeApplicationNextActionForStatus(
+              payload.nextAction,
+              payload.status
+            ),
+          };
+          const appId = await addCollectionItem<JobOsApplication>(
+            "applications",
+            "app",
+            normalizedPayload,
+            { hasUpdatedAt: true }
+          );
 
           // Propagate: mark the linked role as having an application and sync its status.
           if (roleId) {
-            const syncedRoleStatus = mapApplicationStatusToRoleStatus(payload.status);
+            const syncedRoleStatus = mapApplicationStatusToRoleStatus(normalizedPayload.status);
             const roleUpdates: Partial<JobOsRole> = {
               hasApplication: true,
               ...(syncedRoleStatus != null ? { status: syncedRoleStatus } : {}),
@@ -1343,13 +1375,38 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
           const linkedRoleId = targetApplication?.roleId ?? updates.roleId;
           const syncedRoleStatus =
             updates.status ? mapApplicationStatusToRoleStatus(updates.status) : null;
+          const hasExplicitInterviewMarker = typeof updates.interviewStageReached === "boolean";
+          const shouldMarkInterviewReached =
+            !hasExplicitInterviewMarker &&
+            (Boolean(targetApplication?.interviewStageReached) ||
+              Boolean(updates.status && isInterviewStageStatus(updates.status)));
+          const normalizedUpdates: Partial<JobOsApplication> = {
+            ...updates,
+            ...(shouldMarkInterviewReached ? { interviewStageReached: true } : {}),
+          };
+          const nextStatus = updates.status ?? targetApplication?.status;
+          const nextAction = updates.nextAction ?? targetApplication?.nextAction;
+
+          if (nextStatus && typeof nextAction === "string") {
+            const normalizedNextAction = normalizeApplicationNextActionForStatus(
+              nextAction,
+              nextStatus
+            );
+
+            if (
+              updates.nextAction !== undefined ||
+              normalizedNextAction !== targetApplication?.nextAction
+            ) {
+              normalizedUpdates.nextAction = normalizedNextAction;
+            }
+          }
 
           await mutate(
             "Update applications",
             (prev) => ({
               ...prev,
               applications: prev.applications.map((application) =>
-                application.id === id ? { ...application, ...updates, updatedAt: now } : application
+                application.id === id ? { ...application, ...normalizedUpdates, updatedAt: now } : application
               ),
               roles:
                 !linkedRoleId || syncedRoleStatus == null
@@ -1371,6 +1428,7 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
                     applicationRef,
                     stripUndefinedFields({
                       ...updates,
+                      ...normalizedUpdates,
                       updatedAt: serverTimestamp(),
                     }),
                     { merge: true }

--- a/src/app/pages/dashboard/DashboardPage.tsx
+++ b/src/app/pages/dashboard/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { ChevronDown, ChevronUp, Layers3 } from "lucide-react";
 import { useApp } from "../../context";
 import { useJobOs } from "../../hooks/useJobOs";
+import { UnifiedAddModal } from "../../components/job-os/UnifiedAddModal";
 import { useJobOsSyncSnapshot } from "../../services/jobOsSync";
 import {
   getNextActions,
@@ -30,6 +31,7 @@ export function DashboardPage() {
   const navigate = useNavigate();
   const jobOsSync = useJobOsSyncSnapshot();
   const [supportOpen, setSupportOpen] = useState(false);
+  const [addModalOpen, setAddModalOpen] = useState(false);
   const {
     companies,
     roles,
@@ -153,7 +155,7 @@ export function DashboardPage() {
 
             <div className="min-w-0 lg:self-start">
               <div className="space-y-4 lg:sticky lg:top-24">
-                <QuickActions />
+                <QuickActions onAddRole={() => setAddModalOpen(true)} />
                 <WeeklyExecutionPanel applications={applications} />
                 <PipelineStats stats={stats} isLoading={loading} />
                 <ProbabilityPanel stats={stats} isLoading={loading} />
@@ -193,6 +195,15 @@ export function DashboardPage() {
           </div>
         </AppPageShell>
       </main>
+
+      <UnifiedAddModal
+        open={addModalOpen}
+        onClose={() => setAddModalOpen(false)}
+        companies={companies}
+        addCompany={addCompany}
+        addRole={addRole}
+        addApplication={addApplication}
+      />
     </div>
   );
 }

--- a/src/app/pages/job-os/JobOsAfaReportPage.tsx
+++ b/src/app/pages/job-os/JobOsAfaReportPage.tsx
@@ -1,0 +1,303 @@
+import { useMemo, useState } from "react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Download } from "lucide-react";
+import { Badge } from "../../components/ui/badge";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent } from "../../components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { useJobOsContext } from "../../context/JobOsContext";
+import {
+  APPLICATION_STATUS_LABELS,
+  CLOSED_APPLICATION_STATUSES,
+  applicationHasActiveInterview,
+  applicationReachedInterview,
+  getApplicationInterviewMetrics,
+  getApplicationVisibleNextAction,
+  sortJobOsApplications,
+  type ApplicationSortField,
+  type SortDirection,
+} from "../../services/jobOsApplications";
+import type { ApplicationStatus, JobOsCompany, JobOsRole } from "../../types/jobOs";
+
+type ReportLanguage = "en" | "de";
+
+const DE_STATUS_LABELS: Record<ApplicationStatus, string> = {
+  sent: "Eingereicht",
+  screen: "Screening",
+  case: "Case Study",
+  interview: "Interview",
+  final: "Finalrunde",
+  offer: "Angebot",
+  rejected: "Abgelehnt",
+  ghosted: "Keine Rückmeldung",
+};
+
+const COPY = {
+  en: {
+    eyebrow: "AfA advisor report",
+    title: "JobSprint Application Pipeline",
+    generated: "Generated",
+    source: "Based on the same application records used in Job OS.",
+    employee: "Arbeitnehmer:",
+    developedBy: "Entwickelt von:",
+    downloadPdf: "Download PDF",
+    number: "#",
+    company: "Company",
+    role: "Role",
+    status: "Status",
+    applied: "Applied",
+    channel: "Channel",
+    nextAction: "Next Action",
+    notes: "Notes",
+    interviewed: "Interviewed",
+    empty: "No application records available.",
+    loading: "Loading application records...",
+    nextActions: "Next Actions",
+    numberOfInterviews: "Number of interviews:",
+    activeInterviews: "Active interviews:",
+  },
+  de: {
+    eyebrow: "AfA-Bericht",
+    title: "JobSprint Bewerbungspipeline",
+    generated: "Erstellt am",
+    source: "Basierend auf denselben Bewerbungsdaten wie in Job OS.",
+    employee: "Employee:",
+    developedBy: "Developed by:",
+    downloadPdf: "PDF herunterladen",
+    number: "#",
+    company: "Unternehmen",
+    role: "Position",
+    status: "Status",
+    applied: "Beworben am",
+    channel: "Kanal",
+    nextAction: "Nächster Schritt",
+    notes: "Notizen",
+    interviewed: "Interview geführt",
+    empty: "Keine Bewerbungsdaten verfügbar.",
+    loading: "Bewerbungsdaten werden geladen...",
+    nextActions: "Nächste Schritte",
+    numberOfInterviews: "Anzahl Interviews:",
+    activeInterviews: "Aktive Interviews:",
+  },
+} as const;
+
+export default function JobOsAfaReportPage() {
+  const { applications, companies, roles, loading } = useJobOsContext();
+  const [language, setLanguage] = useState<ReportLanguage>("en");
+  const [sortField, setSortField] = useState<ApplicationSortField>("date");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const copy = COPY[language];
+  const statusLabels = language === "de" ? DE_STATUS_LABELS : APPLICATION_STATUS_LABELS;
+
+  const companiesById = useMemo(
+    () => new Map(companies.map((company) => [company.id, company])),
+    [companies]
+  );
+  const rolesById = useMemo(
+    () => new Map(roles.map((role) => [role.id, role])),
+    [roles]
+  );
+  const visibleApplications = useMemo(
+    () =>
+      sortJobOsApplications(
+        applications,
+        companiesById as Map<string, JobOsCompany>,
+        rolesById as Map<string, JobOsRole>,
+        sortField,
+        sortDirection
+      ),
+    [applications, companiesById, rolesById, sortDirection, sortField]
+  );
+  const interviewMetrics = useMemo(
+    () => getApplicationInterviewMetrics(applications),
+    [applications]
+  );
+  const generatedAt = new Date().toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  function toggleSort(field: ApplicationSortField): void {
+    if (sortField === field) {
+      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
+      return;
+    }
+
+    setSortField(field);
+    setSortDirection(field === "date" ? "desc" : "asc");
+  }
+
+  function renderSortHeader(label: string, field: ApplicationSortField): React.ReactNode {
+    const active = sortField === field;
+
+    return (
+      <button
+        type="button"
+        onClick={() => toggleSort(field)}
+        className="inline-flex items-center gap-1 font-medium text-neutral-800 transition-colors hover:text-neutral-950 print:text-neutral-950"
+      >
+        <span>{label}</span>
+        {!active ? <ArrowUpDown className="h-3.5 w-3.5 opacity-50" /> : null}
+        {active && sortDirection === "asc" ? <ArrowUp className="h-3.5 w-3.5" /> : null}
+        {active && sortDirection === "desc" ? <ArrowDown className="h-3.5 w-3.5" /> : null}
+      </button>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-white px-6 py-8 text-neutral-950 print:px-0 print:py-0">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <header className="flex flex-col gap-4 border-b border-neutral-200 pb-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+              {copy.eyebrow}
+            </p>
+            <h1 className="mt-1 text-2xl font-semibold tracking-tight">
+              {copy.title}
+            </h1>
+            <div className="mt-3 space-y-1 text-sm text-neutral-700">
+              <p>
+                <span className="font-medium">{copy.employee}</span> Roman Mazuryk
+              </p>
+              <p>
+                <span className="font-medium">{copy.developedBy}</span>{" "}
+                <a
+                  href="https://mazuryk.dev"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium text-blue-700 underline underline-offset-2 print:text-neutral-950"
+                >
+                  mazuryk.dev
+                </a>
+              </p>
+            </div>
+            <p className="mt-2 text-sm text-neutral-600">
+              {copy.generated} {generatedAt}. {copy.source}
+            </p>
+          </div>
+
+          <div className="flex shrink-0 flex-wrap items-center gap-2 print:hidden">
+            <div className="flex rounded-md border border-neutral-200 bg-white p-1">
+              <Button
+                type="button"
+                size="sm"
+                variant={language === "en" ? "secondary" : "ghost"}
+                onClick={() => setLanguage("en")}
+              >
+                ENG
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant={language === "de" ? "secondary" : "ghost"}
+                onClick={() => setLanguage("de")}
+              >
+                DEU
+              </Button>
+            </div>
+            <Button type="button" size="sm" variant="outline" onClick={() => window.print()}>
+              <Download className="h-4 w-4" />
+              {copy.downloadPdf}
+            </Button>
+          </div>
+        </header>
+
+        <Card className="rounded-md border-neutral-200 shadow-none print:border-0">
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-12">{copy.number}</TableHead>
+                  <TableHead>{renderSortHeader(copy.company, "company")}</TableHead>
+                  <TableHead>{renderSortHeader(copy.role, "role")}</TableHead>
+                  <TableHead>{renderSortHeader(copy.status, "status")}</TableHead>
+                  <TableHead>{renderSortHeader(copy.applied, "date")}</TableHead>
+                  <TableHead>{renderSortHeader(copy.channel, "channel")}</TableHead>
+                  <TableHead>{renderSortHeader(copy.nextAction, "nextAction")}</TableHead>
+                  <TableHead>{renderSortHeader(copy.notes, "notes")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {visibleApplications.map((application, index) => {
+                  const isClosed = CLOSED_APPLICATION_STATUSES.has(application.status);
+                  const isActiveInterview = applicationHasActiveInterview(application);
+                  const reachedInterview = applicationReachedInterview(application);
+                  const visibleNextAction = getApplicationVisibleNextAction(application);
+                  const shouldShowInterviewedBlurb =
+                    isClosed && reachedInterview;
+                  const rowClassName = isActiveInterview
+                    ? "bg-emerald-50/70 font-semibold print:bg-emerald-50"
+                    : isClosed
+                      ? `bg-red-50/60 print:bg-red-50 ${reachedInterview ? "font-semibold" : ""}`
+                      : reachedInterview
+                        ? "font-semibold"
+                        : undefined;
+
+                  return (
+                    <TableRow key={application.id} className={rowClassName}>
+                      <TableCell className="font-medium">{index + 1}</TableCell>
+                      <TableCell>
+                        {companiesById.get(application.companyId)?.name ?? "-"}
+                      </TableCell>
+                      <TableCell>
+                        <div>{rolesById.get(application.roleId)?.title ?? "-"}</div>
+                        {shouldShowInterviewedBlurb ? (
+                          <div className="mt-1 text-xs font-medium text-neutral-600">
+                            {copy.interviewed}
+                          </div>
+                        ) : null}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className="rounded-full bg-white/70">
+                          {statusLabels[application.status]}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{application.dateApplied || "-"}</TableCell>
+                      <TableCell>{application.channel || "-"}</TableCell>
+                      <TableCell className="max-w-[220px] whitespace-normal">
+                        {visibleNextAction || "-"}
+                      </TableCell>
+                      <TableCell className="max-w-[260px] whitespace-normal">
+                        {application.notes || "-"}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+                {!loading && visibleApplications.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={8} className="py-10 text-center text-sm text-neutral-500">
+                      {copy.empty}
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+                {loading ? (
+                  <TableRow>
+                    <TableCell colSpan={8} className="py-10 text-center text-sm text-neutral-500">
+                      {copy.loading}
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <section className="rounded-md border border-neutral-200 bg-neutral-50 p-4 print:bg-white">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+            {copy.nextActions}
+          </h2>
+          <div className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
+            <div>
+              <span className="font-medium">{copy.numberOfInterviews}</span>{" "}
+              {interviewMetrics.interviewCount}
+            </div>
+            <div>
+              <span className="font-medium">{copy.activeInterviews}</span>{" "}
+              {interviewMetrics.activeInterviewCount}
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/pages/job-os/JobOsApplicationsPage.tsx
+++ b/src/app/pages/job-os/JobOsApplicationsPage.tsx
@@ -13,9 +13,10 @@ import {
 } from "../../components/ui/alert-dialog";
 import { usePagination } from "../../hooks/usePagination";
 import { PaginationControls } from "../../components/ui/PaginationControls";
-import { ArrowDown, ArrowUp, ArrowUpDown, CircleHelp, KanbanSquare, List, Plus, Search } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, CircleHelp, KanbanSquare, List, MessageSquare, Plus, Search } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
+import { Checkbox } from "../../components/ui/checkbox";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog";
 import { Input } from "../../components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
@@ -31,9 +32,16 @@ import { JobOsLayout } from "../../components/job-os/JobOsLayout";
 import { AppPageShell } from "../../components/layout/AppPageShell";
 import {
   APPLICATION_STAGE_GROUPS,
-  APPLICATION_STATUS_LABELS,
   JobOsPipelineBoard,
 } from "../../components/job-os/JobOsPipelineBoard";
+import {
+  APPLICATION_STATUS_LABELS,
+  INTERVIEW_RELATED_APPLICATION_STATUSES,
+  applicationReachedInterview,
+  sortJobOsApplications,
+  type ApplicationSortField,
+  type SortDirection,
+} from "../../services/jobOsApplications";
 import { getApplicationCvLabel, getDefaultCvAsset } from "../../services/cvAssets";
 import { ApplicationQualityBadge } from "../../components/job-os/ApplicationQualityBadge";
 import type { ApplicationStatus, JobOsApplication, JobOsCompany, JobOsRole } from "../../types/jobOs";
@@ -51,8 +59,8 @@ const STATUS_VALUES: ApplicationStatus[] = [
 
 type PipelineViewMode = "board" | "list";
 type ApplicationStageGroup = keyof typeof APPLICATION_STAGE_GROUPS;
-type SortField = "company" | "role" | "status" | "date" | "nextAction";
-type SortDirection = "asc" | "desc";
+type SortField = ApplicationSortField;
+type ClosedInterviewFilter = "all" | "withInterview";
 
 const EMPTY_APPLICATION_DRAFT = {
   dateApplied: new Date().toISOString().slice(0, 10),
@@ -64,6 +72,7 @@ const EMPTY_APPLICATION_DRAFT = {
   status: "sent" as ApplicationStatus,
   nextAction: "",
   notes: "",
+  interviewStageReached: false,
   latestJobDescriptionId: undefined,
   latestCvTailoringRunId: undefined,
   tailoredCvHeadline: "",
@@ -102,7 +111,13 @@ export default function JobOsApplicationsPage() {
     roleId: string,
     newStatus: ApplicationStatus
   ): Promise<void> {
-    await updateApplication(applicationId, { status: newStatus });
+    const application = applications.find((item) => item.id === applicationId);
+    await updateApplication(applicationId, {
+      status: newStatus,
+      ...(application?.interviewStageReached || INTERVIEW_RELATED_APPLICATION_STATUSES.has(newStatus)
+        ? { interviewStageReached: true }
+        : {}),
+    });
 
     const closingStatuses: ApplicationStatus[] = ["interview", "final", "offer", "rejected", "ghosted"];
     if (closingStatuses.includes(newStatus)) {
@@ -119,13 +134,14 @@ export default function JobOsApplicationsPage() {
   const defaultCv = getDefaultCvAsset(assets.cvs);
   const [viewMode, setViewMode] = useState<PipelineViewMode>("list");
   const [stageGroup, setStageGroup] = useState<ApplicationStageGroup>("active");
+  const [closedInterviewFilter, setClosedInterviewFilter] = useState<ClosedInterviewFilter>("all");
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [createOpen, setCreateOpen] = useState(false);
   const [createDraftSnapshot, setCreateDraftSnapshot] = useState("");
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [detailId, setDetailId] = useState<string | null>(null);
-  const [detailDraft, setDetailDraft] = useState<Pick<JobOsApplication, "status" | "nextAction" | "notes"> | null>(null);
+  const [detailDraft, setDetailDraft] = useState<Pick<JobOsApplication, "dateApplied" | "channel" | "status" | "nextAction" | "notes" | "interviewStageReached"> | null>(null);
   const [detailDraftSnapshot, setDetailDraftSnapshot] = useState("");
   const [sortField, setSortField] = useState<SortField>("date");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
@@ -142,6 +158,13 @@ export default function JobOsApplicationsPage() {
 
     const visibleApplications = applications.filter((application) => {
       if (!groupStatuses.includes(application.status)) return false;
+      if (
+        stageGroup === "closed" &&
+        closedInterviewFilter === "withInterview" &&
+        !applicationReachedInterview(application)
+      ) {
+        return false;
+      }
       if (!query) return true;
 
       const companyName = companiesById.get(application.companyId)?.name ?? "";
@@ -150,8 +173,9 @@ export default function JobOsApplicationsPage() {
         companyName,
         roleTitle,
         application.channel,
-        application.nextAction,
+        stageGroup === "closed" ? "" : application.nextAction,
         application.notes,
+        applicationReachedInterview(application) ? "interview interviewed" : "",
       ]
         .join(" ")
         .toLowerCase();
@@ -159,31 +183,8 @@ export default function JobOsApplicationsPage() {
       return haystack.includes(query);
     });
 
-    return [...visibleApplications].sort((left, right) => {
-      const leftCompany = companiesById.get(left.companyId)?.name ?? "";
-      const rightCompany = companiesById.get(right.companyId)?.name ?? "";
-      const leftRole = rolesById.get(left.roleId)?.title ?? "";
-      const rightRole = rolesById.get(right.roleId)?.title ?? "";
-
-      const comparison = (() => {
-        switch (sortField) {
-          case "company":
-            return leftCompany.localeCompare(rightCompany);
-          case "role":
-            return leftRole.localeCompare(rightRole);
-          case "status":
-            return APPLICATION_STATUS_LABELS[left.status].localeCompare(APPLICATION_STATUS_LABELS[right.status]);
-          case "nextAction":
-            return (left.nextAction || "").localeCompare(right.nextAction || "");
-          case "date":
-          default:
-            return left.dateApplied.localeCompare(right.dateApplied);
-        }
-      })();
-
-      return sortDirection === "asc" ? comparison : -comparison;
-    });
-  }, [applications, companiesById, groupStatuses, rolesById, searchTerm, sortDirection, sortField]);
+    return sortJobOsApplications(visibleApplications, companiesById, rolesById, sortField, sortDirection);
+  }, [applications, closedInterviewFilter, companiesById, groupStatuses, rolesById, searchTerm, sortDirection, sortField, stageGroup]);
 
   const PAGE_SIZE = 10;
   const {
@@ -196,7 +197,7 @@ export default function JobOsApplicationsPage() {
 
   useEffect(() => {
     resetAppPage();
-  }, [resetAppPage, searchTerm, stageGroup, sortField, sortDirection]);
+  }, [closedInterviewFilter, resetAppPage, searchTerm, stageGroup, sortField, sortDirection]);
 
   function resetDraft(): void {
     setDraft(createDraft(defaultCv ? { id: defaultCv.id, name: defaultCv.name } : undefined));
@@ -215,9 +216,12 @@ export default function JobOsApplicationsPage() {
 
   function openDetails(application: JobOsApplication): void {
     const initial = {
+      dateApplied: application.dateApplied,
+      channel: application.channel,
       status: application.status,
       nextAction: application.nextAction,
       notes: application.notes,
+      interviewStageReached: applicationReachedInterview(application),
     };
     setDetailId(application.id);
     setDetailDraft(initial);
@@ -242,6 +246,8 @@ export default function JobOsApplicationsPage() {
   }
 
   function toggleSort(field: SortField): void {
+    if (stageGroup === "closed" && field === "nextAction") return;
+
     if (sortField === field) {
       setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
       return;
@@ -268,7 +274,17 @@ export default function JobOsApplicationsPage() {
   }
 
   async function applyBulkStatus(status: ApplicationStatus): Promise<void> {
-    await Promise.all(selectedIds.map((id) => updateApplication(id, { status })));
+    await Promise.all(
+      selectedIds.map((id) => {
+        const application = applications.find((item) => item.id === id);
+        return updateApplication(id, {
+          status,
+          ...(application?.interviewStageReached || INTERVIEW_RELATED_APPLICATION_STATUSES.has(status)
+            ? { interviewStageReached: true }
+            : {}),
+        });
+      })
+    );
     setSelectedIds([]);
   }
 
@@ -279,7 +295,10 @@ export default function JobOsApplicationsPage() {
 
   async function handleCreateApplication(): Promise<void> {
     if (!draft.companyId || !draft.roleId) return;
-    await addApplication(draft);
+    await addApplication({
+      ...draft,
+      interviewStageReached: draft.interviewStageReached || INTERVIEW_RELATED_APPLICATION_STATUSES.has(draft.status),
+    });
     toast.success("Application added");
     resetDraft();
     setCreateOpen(false);
@@ -287,9 +306,24 @@ export default function JobOsApplicationsPage() {
 
   async function handleSaveDetails(): Promise<void> {
     if (!detailApplication || !detailDraft) return;
-    await updateApplication(detailApplication.id, detailDraft);
+    await updateApplication(detailApplication.id, {
+      ...detailDraft,
+      interviewStageReached:
+        detailDraft.interviewStageReached || INTERVIEW_RELATED_APPLICATION_STATUSES.has(detailDraft.status),
+    });
     closeDetails();
   }
+
+  const closedInterviewCount = useMemo(
+    () =>
+      applications.filter(
+        (application) =>
+          APPLICATION_STAGE_GROUPS.closed.statuses.includes(application.status) &&
+          applicationReachedInterview(application)
+      ).length,
+    [applications]
+  );
+  const isClosedStageGroup = stageGroup === "closed";
 
   function handleCreateDialogKeyDown(
     event: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -352,7 +386,14 @@ export default function JobOsApplicationsPage() {
     <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
       <Tabs
         value={stageGroup}
-        onValueChange={(value) => setStageGroup(value as ApplicationStageGroup)}
+        onValueChange={(value) => {
+          const nextStageGroup = value as ApplicationStageGroup;
+          setStageGroup(nextStageGroup);
+          if (nextStageGroup === "closed" && sortField === "nextAction") {
+            setSortField("date");
+            setSortDirection("desc");
+          }
+        }}
         className="gap-3"
       >
         <TabsList className="h-auto w-full flex-wrap justify-start rounded-2xl bg-muted/70 p-1 sm:w-fit">
@@ -374,14 +415,43 @@ export default function JobOsApplicationsPage() {
         </TabsList>
       </Tabs>
 
-      <div className="relative w-full xl:max-w-sm">
-        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          value={searchTerm}
-          onChange={(event) => setSearchTerm(event.target.value)}
-          placeholder="Search company, role, next action, notes"
-          className="pl-9"
-        />
+      <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center xl:max-w-2xl xl:justify-end">
+        {stageGroup === "closed" ? (
+          <div className="flex items-center gap-1 rounded-xl border border-border/70 bg-background/70 p-1">
+            <Button
+              type="button"
+              size="sm"
+              variant={closedInterviewFilter === "all" ? "secondary" : "ghost"}
+              className="rounded-lg"
+              onClick={() => setClosedInterviewFilter("all")}
+            >
+              All
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={closedInterviewFilter === "withInterview" ? "secondary" : "ghost"}
+              className="rounded-lg gap-1.5"
+              onClick={() => setClosedInterviewFilter("withInterview")}
+            >
+              <MessageSquare className="h-3.5 w-3.5" />
+              Interviewed
+              <Badge variant="outline" className="rounded-full bg-background/70 px-1.5 py-0 text-[10px]">
+                {closedInterviewCount}
+              </Badge>
+            </Button>
+          </div>
+        ) : null}
+
+        <div className="relative w-full sm:max-w-sm">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder={isClosedStageGroup ? "Search company, role, notes" : "Search company, role, next action, notes"}
+            className="pl-9"
+          />
+        </div>
       </div>
     </div>
   );
@@ -409,9 +479,11 @@ export default function JobOsApplicationsPage() {
                   {selectedIds.length} application{selectedIds.length === 1 ? "" : "s"} selected.
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  <Button size="sm" variant="outline" onClick={() => void bulkFollowUp()}>
-                    Set Follow-up
-                  </Button>
+                  {!isClosedStageGroup ? (
+                    <Button size="sm" variant="outline" onClick={() => void bulkFollowUp()}>
+                      Set Follow-up
+                    </Button>
+                  ) : null}
                   <Button size="sm" variant="outline" onClick={() => void applyBulkStatus("screen")}>
                     Move to Screen
                   </Button>
@@ -450,82 +522,100 @@ export default function JobOsApplicationsPage() {
                       <TableHead>Quality</TableHead>
                       <TableHead>{renderSortHeader("Status", "status")}</TableHead>
                       <TableHead>{renderSortHeader("Date", "date")}</TableHead>
-                      <TableHead>{renderSortHeader("Next Action", "nextAction")}</TableHead>
+                      {!isClosedStageGroup ? (
+                        <TableHead>{renderSortHeader("Next Action", "nextAction")}</TableHead>
+                      ) : null}
                       <TableHead />
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {pagedApplications.map((application) => (
-                      <TableRow
-                        key={application.id}
-                        className="cursor-pointer"
-                        onClick={() => openDetails(application)}
-                      >
-                        <TableCell>
-                          <input
-                            type="checkbox"
-                            checked={selectedSet.has(application.id)}
-                            onClick={(event) => event.stopPropagation()}
-                            onChange={() => toggleSelection(application.id)}
-                          />
-                        </TableCell>
-                        <TableCell>
-                          {companiesById.get(application.companyId)?.name ?? "-"}
-                        </TableCell>
-                        <TableCell>{rolesById.get(application.roleId)?.title ?? "-"}</TableCell>
-                        <TableCell>
-                          {!["rejected", "ghosted"].includes(application.status) && (
-                            <ApplicationQualityBadge
-                              application={application}
-                              cvTailoringRuns={cvTailoringRuns}
+                    {pagedApplications.map((application) => {
+                      const reachedInterview = applicationReachedInterview(application);
+                      const isClosedApplication = APPLICATION_STAGE_GROUPS.closed.statuses.includes(application.status);
+
+                      return (
+                        <TableRow
+                          key={application.id}
+                          className="cursor-pointer"
+                          onClick={() => openDetails(application)}
+                        >
+                          <TableCell>
+                            <input
+                              type="checkbox"
+                              checked={selectedSet.has(application.id)}
+                              onClick={(event) => event.stopPropagation()}
+                              onChange={() => toggleSelection(application.id)}
                             />
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          <Select
-                            value={application.status}
-                            onValueChange={(value) =>
-                              void handleApplicationStatusChange(
-                                application.id,
-                                application.roleId,
-                                value as ApplicationStatus
+                          </TableCell>
+                          <TableCell>
+                            {companiesById.get(application.companyId)?.name ?? "-"}
+                          </TableCell>
+                          <TableCell>{rolesById.get(application.roleId)?.title ?? "-"}</TableCell>
+                          <TableCell>
+                            {isClosedApplication ? (
+                              reachedInterview ? (
+                                <Badge variant="secondary" className="gap-1 rounded-full">
+                                  <MessageSquare className="h-3.5 w-3.5" />
+                                  Interviewed
+                                </Badge>
+                              ) : (
+                                <span className="text-xs text-muted-foreground">-</span>
                               )
-                            }
-                          >
-                            <SelectTrigger className="w-36">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {STATUS_VALUES.map((status) => (
-                                <SelectItem key={status} value={status}>
-                                  {APPLICATION_STATUS_LABELS[status]}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </TableCell>
-                        <TableCell>{application.dateApplied}</TableCell>
-                        <TableCell className="max-w-[220px] truncate">
-                          {application.nextAction || "-"}
-                        </TableCell>
-                        <TableCell>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              openDetails(application);
-                            }}
-                          >
-                            Open
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    ))}
+                            ) : (
+                              <ApplicationQualityBadge
+                                application={application}
+                                cvTailoringRuns={cvTailoringRuns}
+                              />
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <Select
+                              value={application.status}
+                              onValueChange={(value) =>
+                                void handleApplicationStatusChange(
+                                  application.id,
+                                  application.roleId,
+                                  value as ApplicationStatus
+                                )
+                              }
+                            >
+                              <SelectTrigger className="w-36">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {STATUS_VALUES.map((status) => (
+                                  <SelectItem key={status} value={status}>
+                                    {APPLICATION_STATUS_LABELS[status]}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </TableCell>
+                          <TableCell>{application.dateApplied}</TableCell>
+                          {!isClosedStageGroup ? (
+                            <TableCell className="max-w-[220px] truncate">
+                              {application.nextAction || "-"}
+                            </TableCell>
+                          ) : null}
+                          <TableCell>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                openDetails(application);
+                              }}
+                            >
+                              Open
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
                     {filteredApplications.length === 0 ? (
                       <TableRow>
                         <TableCell
-                          colSpan={8}
+                          colSpan={isClosedStageGroup ? 7 : 8}
                           className="py-10 text-center text-sm text-muted-foreground"
                         >
                           <div className="mx-auto flex max-w-md flex-col items-center gap-3">
@@ -644,6 +734,18 @@ export default function JobOsApplicationsPage() {
                 ))}
               </SelectContent>
             </Select>
+            <label className="flex items-center gap-2 rounded-xl border border-border/70 px-3 py-2 text-sm text-foreground md:col-span-2">
+              <Checkbox
+                checked={draft.interviewStageReached || INTERVIEW_RELATED_APPLICATION_STATUSES.has(draft.status)}
+                onCheckedChange={(checked) =>
+                  setDraft((current) => ({
+                    ...current,
+                    interviewStageReached: checked === true,
+                  }))
+                }
+              />
+              Reached interview stage
+            </label>
             <div className="md:col-span-2">
               <Input
                 value={draft.nextAction}
@@ -691,6 +793,11 @@ export default function JobOsApplicationsPage() {
         <DialogContent className="max-w-2xl">
           {detailApplication && detailDraft ? (
             <>
+              {(() => {
+                const isClosedDetail = APPLICATION_STAGE_GROUPS.closed.statuses.includes(detailDraft.status);
+
+                return (
+                  <>
               <DialogHeader>
                 <DialogTitle>
                   {companiesById.get(detailApplication.companyId)?.name ?? "Unknown company"}
@@ -705,13 +812,31 @@ export default function JobOsApplicationsPage() {
                   <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                     Applied
                   </div>
-                  <div className="text-sm text-foreground">{detailApplication.dateApplied}</div>
+                  <Input
+                    type="date"
+                    value={detailDraft.dateApplied}
+                    onChange={(event) =>
+                      setDetailDraft((current) =>
+                        current ? { ...current, dateApplied: event.target.value } : current
+                      )
+                    }
+                    onKeyDown={handleDetailDialogKeyDown}
+                  />
                 </div>
                 <div className="space-y-1">
                   <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                     Channel
                   </div>
-                  <div className="text-sm text-foreground">{detailApplication.channel}</div>
+                  <Input
+                    value={detailDraft.channel}
+                    onChange={(event) =>
+                      setDetailDraft((current) =>
+                        current ? { ...current, channel: event.target.value } : current
+                      )
+                    }
+                    onKeyDown={handleDetailDialogKeyDown}
+                    placeholder="Application source"
+                  />
                 </div>
                 <div className="space-y-1">
                   <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -735,14 +860,32 @@ export default function JobOsApplicationsPage() {
                     </SelectContent>
                   </Select>
                 </div>
-                <div className="md:col-span-2">
-                  <Input
-                    value={detailDraft.nextAction}
-                    onChange={(event) => setDetailDraft((current) => current ? { ...current, nextAction: event.target.value } : current)}
-                    onKeyDown={handleDetailDialogKeyDown}
-                    placeholder="What should happen next?"
+                <label className="flex items-center gap-2 rounded-xl border border-border/70 px-3 py-2 text-sm text-foreground md:col-span-2">
+                  <Checkbox
+                    checked={detailDraft.interviewStageReached || INTERVIEW_RELATED_APPLICATION_STATUSES.has(detailDraft.status)}
+                    onCheckedChange={(checked) =>
+                      setDetailDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              interviewStageReached: checked === true,
+                            }
+                          : current
+                      )
+                    }
                   />
-                </div>
+                  Reached interview stage
+                </label>
+                {!isClosedDetail ? (
+                  <div className="md:col-span-2">
+                    <Input
+                      value={detailDraft.nextAction}
+                      onChange={(event) => setDetailDraft((current) => current ? { ...current, nextAction: event.target.value } : current)}
+                      onKeyDown={handleDetailDialogKeyDown}
+                      placeholder="What should happen next?"
+                    />
+                  </div>
+                ) : null}
                 <div className="md:col-span-2">
                   <Textarea
                     value={detailDraft.notes}
@@ -753,6 +896,9 @@ export default function JobOsApplicationsPage() {
                   />
                 </div>
               </div>
+                  </>
+                );
+              })()}
 
               <div className="flex flex-wrap justify-between gap-2">
                 <div className="flex gap-2">

--- a/src/app/pages/job-os/JobOsCompaniesPage.tsx
+++ b/src/app/pages/job-os/JobOsCompaniesPage.tsx
@@ -20,8 +20,11 @@ import {
   Download,
   Eye,
   Link,
+  Pencil,
+  Plus,
   Trash2,
   Upload,
+  X,
 } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
@@ -125,6 +128,10 @@ function normalizeCompanyKey(value: string): string {
     .toLowerCase();
 }
 
+function normalizeIndustryKey(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
 type CompanySortKey =
   | "name"
   | "industry"
@@ -168,6 +175,11 @@ export default function JobOsCompaniesPage() {
   const [editDraft, setEditDraft] = useState<Partial<JobOsCompany>>({});
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [pasteLinkOpen, setPasteLinkOpen] = useState(false);
+  const [customIndustries, setCustomIndustries] = useState<string[]>([]);
+  const [industryDialogOpen, setIndustryDialogOpen] = useState(false);
+  const [newIndustry, setNewIndustry] = useState("");
+  const [editingIndustry, setEditingIndustry] = useState<string | null>(null);
+  const [editingIndustryDraft, setEditingIndustryDraft] = useState("");
   const [draft, setDraft] = useState<Omit<JobOsCompany, "id" | "createdAt" | "updatedAt">>({
     name: "",
     industry: "",
@@ -227,6 +239,18 @@ export default function JobOsCompaniesPage() {
 
   const selectedCompany = companies.find((c) => c.id === selectedCompanyId) ?? null;
   const lockStorageKey = `job_os_companies_lock_${session?.userId ?? "anon"}`;
+  const industryStorageKey = `job_os_industries_${session?.userId ?? "anon"}`;
+  const industryOptions = useMemo(() => {
+    const byKey = new Map<string, string>();
+    [...companies.map((company) => company.industry), ...customIndustries].forEach((industry) => {
+      const cleaned = industry.trim().replace(/\s+/g, " ");
+      if (!cleaned) return;
+      byKey.set(normalizeIndustryKey(cleaned), cleaned);
+    });
+    return Array.from(byKey.values()).sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "base" })
+    );
+  }, [companies, customIndustries]);
 
   useEffect(() => {
     if (!session?.userId) return;
@@ -242,6 +266,22 @@ export default function JobOsCompaniesPage() {
     if (!session?.userId) return;
     localStorage.setItem(lockStorageKey, companyListLocked ? "true" : "false");
   }, [companyListLocked, lockStorageKey, session?.userId]);
+
+  useEffect(() => {
+    if (!session?.userId) return;
+    try {
+      const raw = localStorage.getItem(industryStorageKey);
+      const parsed = raw ? JSON.parse(raw) : [];
+      setCustomIndustries(Array.isArray(parsed) ? parsed.filter((value) => typeof value === "string") : []);
+    } catch {
+      setCustomIndustries([]);
+    }
+  }, [industryStorageKey, session?.userId]);
+
+  useEffect(() => {
+    if (!session?.userId) return;
+    localStorage.setItem(industryStorageKey, JSON.stringify(customIndustries));
+  }, [customIndustries, industryStorageKey, session?.userId]);
 
   useEffect(() => {
     resetCompaniesPage();
@@ -429,6 +469,62 @@ export default function JobOsCompaniesPage() {
     setDetailMode("edit");
   }
 
+  function openAddIndustryDialog(): void {
+    setNewIndustry("");
+    setEditingIndustry(null);
+    setEditingIndustryDraft("");
+    setIndustryDialogOpen(true);
+  }
+
+  function addIndustry(): void {
+    const industry = newIndustry.trim().replace(/\s+/g, " ");
+    if (!industry) return;
+    if (industryOptions.some((option) => normalizeIndustryKey(option) === normalizeIndustryKey(industry))) {
+      setNewIndustry("");
+      return;
+    }
+    setCustomIndustries((current) => [...current, industry]);
+    if (detailMode === "edit" && selectedCompany) {
+      setEditDraft((current) => ({ ...current, industry }));
+    } else {
+      setDraft((current) => ({ ...current, industry }));
+    }
+    setNewIndustry("");
+  }
+
+  async function saveIndustryEdit(originalIndustry: string): Promise<void> {
+    const nextIndustry = editingIndustryDraft.trim().replace(/\s+/g, " ");
+    if (!nextIndustry) return;
+    const originalKey = normalizeIndustryKey(originalIndustry);
+    const nextKey = normalizeIndustryKey(nextIndustry);
+
+    setCustomIndustries((current) => {
+      const withoutOriginal = current.filter((industry) => normalizeIndustryKey(industry) !== originalKey);
+      if (withoutOriginal.some((industry) => normalizeIndustryKey(industry) === nextKey)) {
+        return withoutOriginal;
+      }
+      return [...withoutOriginal, nextIndustry];
+    });
+
+    if (normalizeIndustryKey(draft.industry) === originalKey) {
+      setDraft((current) => ({ ...current, industry: nextIndustry }));
+    }
+    if (normalizeIndustryKey(editDraft.industry ?? "") === originalKey) {
+      setEditDraft((current) => ({ ...current, industry: nextIndustry }));
+    }
+
+    const companiesToUpdate = companies.filter(
+      (company) => normalizeIndustryKey(company.industry) === originalKey
+    );
+    await Promise.all(
+      companiesToUpdate.map((company) => updateCompany(company.id, { industry: nextIndustry }))
+    );
+
+    setEditingIndustry(null);
+    setEditingIndustryDraft("");
+    toast.success(`Industry updated to ${nextIndustry}`);
+  }
+
   async function handleSaveEdit(): Promise<void> {
     if (!selectedCompanyId || !editDraft.name?.trim()) return;
     setIsSavingEdit(true);
@@ -563,11 +659,45 @@ export default function JobOsCompaniesPage() {
               onChange={(e) => setDraft((p) => ({ ...p, name: e.target.value }))}
               placeholder="Company"
             />
-            <Input
-              value={draft.industry}
-              onChange={(e) => setDraft((p) => ({ ...p, industry: e.target.value }))}
-              placeholder="Industry"
-            />
+            <div className="flex gap-2">
+              <Select
+                value={draft.industry || undefined}
+                onValueChange={(value) => setDraft((p) => ({ ...p, industry: value }))}
+              >
+                <SelectTrigger className="min-w-0 flex-1">
+                  <SelectValue placeholder="Industry" />
+                </SelectTrigger>
+                <SelectContent>
+                  {industryOptions.length > 0 ? (
+                    industryOptions.map((industry) => (
+                      <SelectItem key={industry} value={industry}>
+                        {industry}
+                      </SelectItem>
+                    ))
+                  ) : (
+                    <SelectItem value="Unknown">Unknown</SelectItem>
+                  )}
+                </SelectContent>
+              </Select>
+              <Button
+                type="button"
+                variant="outline"
+                className="gap-1.5 px-3"
+                onClick={openAddIndustryDialog}
+              >
+                <Plus className="h-4 w-4" />
+                Add
+              </Button>
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                onClick={() => setIndustryDialogOpen(true)}
+                aria-label="Manage industries"
+              >
+                <Pencil className="h-4 w-4" />
+              </Button>
+            </div>
             <Input
               value={draft.size}
               onChange={(e) => setDraft((p) => ({ ...p, size: e.target.value }))}
@@ -609,9 +739,9 @@ export default function JobOsCompaniesPage() {
             <div className="md:col-span-2">
               <Button
                 className="w-full"
-                disabled={companyListLocked}
+                disabled={companyListLocked || !draft.name.trim() || !draft.industry.trim()}
                 onClick={() => {
-                  if (!draft.name) return;
+                  if (!draft.name.trim() || !draft.industry.trim()) return;
                   void addCompany(draft).then(() => toast.success("Company added"));
                   setDraft({
                     name: "",
@@ -741,16 +871,16 @@ export default function JobOsCompaniesPage() {
                     {(companiesPage - 1) * COMPANIES_PAGE_SIZE + index + 1}
                   </TableCell>
                   <TableCell className="font-medium">{company.name}</TableCell>
-                  <TableCell>{company.industry}</TableCell>
-                  <TableCell>{company.size}</TableCell>
-                  <TableCell>{company.remotePolicy}</TableCell>
-                  <TableCell>{company.priority}</TableCell>
-                  <TableCell>{company.status}</TableCell>
-                  <TableCell className="max-w-[260px] truncate">
-                    {company.notes || "-"}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex items-center justify-end gap-1">
+                    <TableCell>{company.industry}</TableCell>
+                    <TableCell>{company.size}</TableCell>
+                    <TableCell>{company.remotePolicy}</TableCell>
+                    <TableCell>{company.priority}</TableCell>
+                    <TableCell>{company.status}</TableCell>
+                    <TableCell className="max-w-[260px] truncate">
+                      {company.notes || "-"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-1">
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span className="inline-flex">
@@ -765,6 +895,25 @@ export default function JobOsCompaniesPage() {
                           </span>
                         </TooltipTrigger>
                         <TooltipContent side="top">View</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex">
+                            <Button
+                              size="icon"
+                              variant="outline"
+                              disabled={companyListLocked}
+                              onClick={() => {
+                                setSelectedCompanyId(company.id);
+                                openEditMode(company);
+                              }}
+                              aria-label="Edit company"
+                            >
+                              <Pencil className="h-4 w-4" />
+                            </Button>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">Edit</TooltipContent>
                       </Tooltip>
                       <AlertDialog>
                         <AlertDialogTrigger asChild>
@@ -813,8 +962,8 @@ export default function JobOsCompaniesPage() {
                           </AlertDialogFooter>
                         </AlertDialogContent>
                       </AlertDialog>
-                    </div>
-                  </TableCell>
+                      </div>
+                    </TableCell>
                 </TableRow>
               ))}
             </TableBody>
@@ -1016,11 +1165,48 @@ export default function JobOsCompaniesPage() {
                 </div>
                 <div className="space-y-1">
                   <label className="text-xs text-neutral-500">Industry</label>
-                  <Input
-                    value={editDraft.industry ?? ""}
-                    onChange={(e) => setEditDraft((p) => ({ ...p, industry: e.target.value }))}
-                    disabled={isSavingEdit}
-                  />
+                  <div className="flex gap-2">
+                    <Select
+                      value={editDraft.industry || undefined}
+                      onValueChange={(value) => setEditDraft((p) => ({ ...p, industry: value }))}
+                      disabled={isSavingEdit}
+                    >
+                      <SelectTrigger className="min-w-0 flex-1">
+                        <SelectValue placeholder="Industry" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {industryOptions.length > 0 ? (
+                          industryOptions.map((industry) => (
+                            <SelectItem key={industry} value={industry}>
+                              {industry}
+                            </SelectItem>
+                          ))
+                        ) : (
+                          <SelectItem value="Unknown">Unknown</SelectItem>
+                        )}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={openAddIndustryDialog}
+                      disabled={isSavingEdit}
+                      className="gap-1.5 px-3"
+                    >
+                      <Plus className="h-4 w-4" />
+                      Add
+                    </Button>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="outline"
+                      onClick={() => setIndustryDialogOpen(true)}
+                      disabled={isSavingEdit}
+                      aria-label="Manage industries"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                  </div>
                 </div>
                 <div className="space-y-1">
                   <label className="text-xs text-neutral-500">Size</label>
@@ -1117,13 +1303,124 @@ export default function JobOsCompaniesPage() {
                 <Button
                   size="sm"
                   onClick={() => void handleSaveEdit()}
-                  disabled={!editDraft.name?.trim() || isSavingEdit}
+                  disabled={!editDraft.name?.trim() || !editDraft.industry?.trim() || isSavingEdit}
                 >
                   {isSavingEdit ? "Saving…" : "Save Changes"}
                 </Button>
               </div>
             </div>
           )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={industryDialogOpen} onOpenChange={setIndustryDialogOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Manage Industries</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="flex gap-2">
+              <Input
+                value={newIndustry}
+                onChange={(event) => setNewIndustry(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    addIndustry();
+                  }
+                }}
+                placeholder="Add industry"
+              />
+              <Button type="button" onClick={addIndustry} disabled={!newIndustry.trim()}>
+                <Plus className="h-4 w-4" />
+                Add
+              </Button>
+            </div>
+
+            <div className="max-h-72 space-y-2 overflow-y-auto rounded-md border border-border p-2">
+              {industryOptions.length > 0 ? (
+                industryOptions.map((industry) => {
+                  const usageCount = companies.filter(
+                    (company) => normalizeIndustryKey(company.industry) === normalizeIndustryKey(industry)
+                  ).length;
+                  const isEditing = editingIndustry === industry;
+
+                  return (
+                    <div
+                      key={industry}
+                      className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5"
+                    >
+                      {isEditing ? (
+                        <Input
+                          value={editingIndustryDraft}
+                          onChange={(event) => setEditingIndustryDraft(event.target.value)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                              event.preventDefault();
+                              void saveIndustryEdit(industry);
+                            }
+                          }}
+                          autoFocus
+                        />
+                      ) : (
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium">{industry}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {usageCount} compan{usageCount === 1 ? "y" : "ies"}
+                          </div>
+                        </div>
+                      )}
+
+                      <div className="flex shrink-0 items-center gap-1">
+                        {isEditing ? (
+                          <>
+                            <Button
+                              type="button"
+                              size="sm"
+                              onClick={() => void saveIndustryEdit(industry)}
+                              disabled={!editingIndustryDraft.trim()}
+                            >
+                              Save
+                            </Button>
+                            <Button
+                              type="button"
+                              size="icon"
+                              variant="ghost"
+                              onClick={() => {
+                                setEditingIndustry(null);
+                                setEditingIndustryDraft("");
+                              }}
+                              aria-label="Cancel industry edit"
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </>
+                        ) : (
+                          <Button
+                            type="button"
+                            size="icon"
+                            variant="ghost"
+                            onClick={() => {
+                              setEditingIndustry(industry);
+                              setEditingIndustryDraft(industry);
+                            }}
+                            aria-label={`Edit ${industry}`}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })
+              ) : (
+                <div className="px-2 py-6 text-center text-sm text-muted-foreground">
+                  Add your first industry to use the dropdown.
+                </div>
+              )}
+            </div>
+          </div>
         </DialogContent>
       </Dialog>
 

--- a/src/app/pages/job-os/JobOsRolesPage.tsx
+++ b/src/app/pages/job-os/JobOsRolesPage.tsx
@@ -95,6 +95,8 @@ export default function JobOsRolesPage() {
   } = useJobOsContext();
 
   const [addFormOpen, setAddFormOpen] = useState(false);
+  const [companySearch, setCompanySearch] = useState("");
+  const [companyOptionsOpen, setCompanyOptionsOpen] = useState(false);
   const [editingRoleId, setEditingRoleId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState<Omit<JobOsRole, "id" | "createdAt" | "updatedAt"> | null>(null);
   const [formNotice, setFormNotice] = useState<string | null>(null);
@@ -129,6 +131,15 @@ export default function JobOsRolesPage() {
     () => new Map(companies.map((company) => [company.id, company])),
     [companies]
   );
+  const selectedDraftCompany = draft.companyId ? companiesById.get(draft.companyId) : null;
+  const filteredCompanyOptions = useMemo(() => {
+    const query = companySearch.trim().toLowerCase();
+    const matches = query
+      ? companies.filter((company) => company.name.toLowerCase().includes(query))
+      : companies;
+
+    return matches.slice(0, 50);
+  }, [companies, companySearch]);
 
   const filtered = useMemo(() => {
     const companyQuery = tableFilters.company.trim().toLowerCase();
@@ -329,6 +340,7 @@ export default function JobOsRolesPage() {
         jobDescription: "",
         jobDescriptionUpdatedAt: undefined,
       });
+      setCompanySearch("");
       setFormNotice("");
       toast.success("Role added");
     } catch (error) {
@@ -388,6 +400,7 @@ export default function JobOsRolesPage() {
   function handleToggleAddForm() {
     if (addFormOpen && !confirmAddFormDiscard()) return;
     setAddFormOpen((value) => !value);
+    setCompanyOptionsOpen(false);
   }
 
   return (
@@ -414,12 +427,55 @@ export default function JobOsRolesPage() {
         </CardHeader>
         {addFormOpen ? (
           <CardContent className="grid gap-3 pt-4 md:grid-cols-4">
-            <Select value={draft.companyId} onValueChange={(value) => setDraft((current) => ({ ...current, companyId: value }))}>
-              <SelectTrigger><SelectValue placeholder="Company" /></SelectTrigger>
-              <SelectContent>
-                {companies.map((company) => <SelectItem key={company.id} value={company.id}>{company.name}</SelectItem>)}
-              </SelectContent>
-            </Select>
+            <div className="relative">
+              <Input
+                value={companyOptionsOpen ? companySearch : selectedDraftCompany?.name ?? companySearch}
+                onChange={(event) => {
+                  setCompanySearch(event.target.value);
+                  setCompanyOptionsOpen(true);
+                  setDraft((current) => ({ ...current, companyId: "" }));
+                }}
+                onFocus={() => {
+                  setCompanySearch(selectedDraftCompany?.name ?? companySearch);
+                  setCompanyOptionsOpen(true);
+                }}
+                onBlur={() => {
+                  window.setTimeout(() => setCompanyOptionsOpen(false), 120);
+                }}
+                placeholder="Company"
+                autoComplete="off"
+              />
+              {companyOptionsOpen ? (
+                <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-64 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md">
+                  {filteredCompanyOptions.length > 0 ? (
+                    filteredCompanyOptions.map((company) => (
+                      <button
+                        key={company.id}
+                        type="button"
+                        className="flex w-full items-center gap-2 rounded-sm px-2 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={() => {
+                          setDraft((current) => ({ ...current, companyId: company.id }));
+                          setCompanySearch(company.name);
+                          setCompanyOptionsOpen(false);
+                        }}
+                      >
+                        <Check
+                          className={`h-4 w-4 ${
+                            draft.companyId === company.id ? "opacity-100" : "opacity-0"
+                          }`}
+                        />
+                        <span className="truncate">{company.name}</span>
+                      </button>
+                    ))
+                  ) : (
+                    <div className="px-2 py-3 text-sm text-muted-foreground">
+                      No company found.
+                    </div>
+                  )}
+                </div>
+              ) : null}
+            </div>
             <Input value={draft.title} onChange={(event) => setDraft((current) => ({ ...current, title: event.target.value }))} placeholder="Role title" />
             <Select value={draft.origin ?? "self_sourced"} onValueChange={(value) => setDraft((current) => ({ ...current, origin: value as RoleOrigin }))}>
               <SelectTrigger><SelectValue /></SelectTrigger>

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, type ReactNode } from "react";
 import { createBrowserRouter, Navigate } from "react-router";
 import SignIn from "./pages/SignIn";
 import { JobOsRouteProvider } from "./components/job-os/JobOsRouteProvider";
+import { PublicJobOsReportProvider } from "./components/job-os/PublicJobOsReportProvider";
 import JobOsSettingsPage from "./pages/job-os/JobOsSettingsPage";
 import NotFound from "./pages/NotFound";
 import { ProtectedRoute } from "./components/ProtectedRoute";
@@ -14,6 +15,7 @@ const JobOsAssetsPage = lazy(() => import("./pages/job-os/JobOsAssetsPage"));
 const JobOsCompaniesPage = lazy(() => import("./pages/job-os/JobOsCompaniesPage"));
 const JobOsRolesPage = lazy(() => import("./pages/job-os/JobOsRolesPage"));
 const JobOsApplicationsPage = lazy(() => import("./pages/job-os/JobOsApplicationsPage"));
+const JobOsAfaReportPage = lazy(() => import("./pages/job-os/JobOsAfaReportPage"));
 const JobOsOutreachPage = lazy(() => import("./pages/job-os/JobOsOutreachPage"));
 const CvOptimizerPage = lazy(() => import("../features/cvOptimizer/CvOptimizerPage"));
 const AfaCompliancePage = lazy(() => import("./pages/AfaCompliancePage"));
@@ -34,6 +36,15 @@ export const router = createBrowserRouter([
   {
     path: "/signin",
     element: <SignIn />,
+  },
+  {
+    Component: PublicJobOsReportProvider,
+    children: [
+      {
+        path: "/job-os/afa-report",
+        element: lazyElement(<JobOsAfaReportPage />),
+      },
+    ],
   },
   {
     Component: ProtectedRoute,

--- a/src/app/services/execution/nextActionEngine.ts
+++ b/src/app/services/execution/nextActionEngine.ts
@@ -15,6 +15,7 @@ export type NextActionType =
   | "add_role"
   | "research"
   | "optimize_cv"
+  | "add_jd"
   | "archive";
 
 export type ActionPriority = "urgent" | "high" | "medium" | "low";
@@ -536,6 +537,43 @@ export function getPipelineStats(
   };
 }
 
+// ─── Missing JD Actions ──────────────────────────────────────────────────────
+
+const ADD_JD_BASE = 45;
+const ADD_JD_ACTIVE_STATUSES = new Set(["sent", "screen", "case", "interview", "final"]);
+
+function generateAddJdActions(
+  applications: JobOsApplication[],
+  companies: JobOsCompany[]
+): NextAction[] {
+  const companyMap = new Map(companies.map((c) => [c.id, c]));
+
+  return applications
+    .filter(
+      (a) =>
+        ADD_JD_ACTIVE_STATUSES.has(a.status) &&
+        !a.latestJobDescriptionId
+    )
+    .map((app) => {
+      const company = companyMap.get(app.companyId);
+      const priorityBonus = company ? PRIORITY_WEIGHT[company.priority] : 0;
+      const score = clamp(ADD_JD_BASE + priorityBonus, 0, 100);
+
+      return {
+        id: `add-jd-${app.id}`,
+        type: "add_jd" as NextActionType,
+        priority: toPriority(score),
+        score,
+        companyId: app.companyId,
+        companyName: company?.name,
+        applicationId: app.id,
+        reason: "No job description attached — add one to enable CV tailoring",
+        actionLabel: "Add JD",
+        href: "/cv-optimizer",
+      };
+    });
+}
+
 // ─── Main Entry Point ─────────────────────────────────────────────────────────
 
 /**
@@ -553,6 +591,7 @@ export function getNextActions(
     ...generateOverdueOutreachActions(outreach, companies),
     ...generateStalledApplicationActions(applications, outreach, companies),
     ...generateFollowUpActions(applications, companies),
+    ...generateAddJdActions(applications, companies),
     ...generateLogApplicationActions(roles, companies, applications),
     ...generateApplyActions(roles, companies, applications),
     ...generateAddRoleActions(companies, roles),

--- a/src/app/services/jobOsApplications.ts
+++ b/src/app/services/jobOsApplications.ts
@@ -1,0 +1,125 @@
+import type { ApplicationStatus, JobOsApplication, JobOsCompany, JobOsRole } from "../types/jobOs";
+
+export type ApplicationSortField =
+  | "company"
+  | "role"
+  | "status"
+  | "date"
+  | "channel"
+  | "nextAction"
+  | "notes";
+export type SortDirection = "asc" | "desc";
+
+export const INTERVIEW_RELATED_APPLICATION_STATUSES = new Set<ApplicationStatus>([
+  "interview",
+  "final",
+  "offer",
+]);
+
+export const CLOSED_APPLICATION_STATUSES = new Set<ApplicationStatus>([
+  "rejected",
+  "ghosted",
+]);
+
+export const APPLICATION_STATUS_LABELS: Record<ApplicationStatus, string> = {
+  sent: "Submitted",
+  screen: "Screening",
+  case: "Case Study",
+  interview: "Interview",
+  final: "Final Round",
+  offer: "Offer",
+  rejected: "Rejected",
+  ghosted: "Ghosted",
+};
+
+const GENERIC_FOLLOW_UP_NEXT_ACTIONS = new Set([
+  "send follow-up in 5 days",
+  "follow up in 5 days",
+]);
+
+export function normalizeApplicationNextActionForStatus(
+  nextAction: string | undefined,
+  status: ApplicationStatus
+): string {
+  const value = nextAction ?? "";
+  if (
+    status === "rejected" &&
+    GENERIC_FOLLOW_UP_NEXT_ACTIONS.has(value.trim().toLowerCase())
+  ) {
+    return "";
+  }
+
+  return value;
+}
+
+export function getApplicationVisibleNextAction(application: JobOsApplication): string {
+  return normalizeApplicationNextActionForStatus(
+    application.nextAction,
+    application.status
+  );
+}
+
+export function applicationReachedInterview(application: JobOsApplication): boolean {
+  return (
+    Boolean(application.interviewStageReached) ||
+    INTERVIEW_RELATED_APPLICATION_STATUSES.has(application.status)
+  );
+}
+
+export function applicationHasActiveInterview(application: JobOsApplication): boolean {
+  return (
+    INTERVIEW_RELATED_APPLICATION_STATUSES.has(application.status) &&
+    !CLOSED_APPLICATION_STATUSES.has(application.status)
+  );
+}
+
+export function getApplicationInterviewMetrics(applications: JobOsApplication[]): {
+  interviewCount: number;
+  activeInterviewCount: number;
+} {
+  return {
+    interviewCount: applications.filter(applicationReachedInterview).length,
+    activeInterviewCount: applications.filter(applicationHasActiveInterview).length,
+  };
+}
+
+export function sortJobOsApplications(
+  applications: JobOsApplication[],
+  companiesById: Map<string, JobOsCompany>,
+  rolesById: Map<string, JobOsRole>,
+  sortField: ApplicationSortField,
+  sortDirection: SortDirection
+): JobOsApplication[] {
+  return [...applications].sort((left, right) => {
+    const leftCompany = companiesById.get(left.companyId)?.name ?? "";
+    const rightCompany = companiesById.get(right.companyId)?.name ?? "";
+    const leftRole = rolesById.get(left.roleId)?.title ?? "";
+    const rightRole = rolesById.get(right.roleId)?.title ?? "";
+
+    const comparison = (() => {
+      switch (sortField) {
+        case "company":
+          return leftCompany.localeCompare(rightCompany);
+        case "role":
+          return leftRole.localeCompare(rightRole);
+        case "status":
+          return APPLICATION_STATUS_LABELS[left.status].localeCompare(
+            APPLICATION_STATUS_LABELS[right.status]
+          );
+        case "nextAction":
+          return getApplicationVisibleNextAction(left).localeCompare(
+            getApplicationVisibleNextAction(right)
+          );
+        case "channel":
+          return (left.channel || "").localeCompare(right.channel || "");
+        case "notes":
+          return (left.notes || "").localeCompare(right.notes || "");
+        case "date":
+        default:
+          return left.dateApplied.localeCompare(right.dateApplied);
+      }
+    })();
+
+    return sortDirection === "asc" ? comparison : -comparison;
+  });
+}

--- a/src/app/types/jobOs.ts
+++ b/src/app/types/jobOs.ts
@@ -302,6 +302,7 @@ export interface JobOsApplication {
   aiEnrichment?: AiImportEnrichmentV1;
   // Execution engine metadata
   lastResponseAt?: string;
+  interviewStageReached?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/tests/e2e/command-centre.spec.ts
+++ b/tests/e2e/command-centre.spec.ts
@@ -19,8 +19,9 @@ test.describe("Command Centre", () => {
     await expect(page.getByText("Quick Actions")).toBeVisible();
   });
 
-  test("Quick Actions contains all four nav links", async ({ page }) => {
-    await expect(page.getByRole("link", { name: /Add Company/i })).toBeVisible();
+  test("Quick Actions contains the expected actions", async ({ page }) => {
+    // "Add Role" is now a modal-trigger button (not a nav link)
+    await expect(page.getByRole("button", { name: /Add Role/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /Log Application/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /Tailor CV/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /Browse Roles/i })).toBeVisible();

--- a/tests/e2e/job-os-role-application.spec.ts
+++ b/tests/e2e/job-os-role-application.spec.ts
@@ -86,7 +86,7 @@ test("logs one application from Roles, prevents duplicates, and persists after r
   await expect(page.getByRole("button", { name: "Application already logged" })).toBeVisible();
 
   await page.goto("/job-os/applications");
-  await expect(page.getByText("Apheris")).toBeVisible();
+  await expect(page.getByRole("cell", { name: "Apheris" })).toBeVisible();
   await expect(page.getByText("Technical Chief of Staff (to the CTO)")).toBeVisible();
   await expect
     .poll(() =>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import viteConfig from './vite.config'
 
 export default mergeConfig(viteConfig, defineConfig({
   test: {
-    exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**'],
+    exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**', '.worktrees/**'],
   },
 }))


### PR DESCRIPTION
## Summary
- add standalone advisor-facing AfA report at /job-os/afa-report with sortable rows, interview metrics, language toggle, PDF print action, and public route access
- add shared application status/interview helpers used by Applications, Pipeline board, and the report
- improve Job OS workflows: closed interview visibility/filtering, editable applied date/channel, searchable role-company selection, editable company details, and managed industries
- add Firestore rules/config for read-only public report access to the report owner applications, companies, and roles

## Verification
- npm run lint
- npm run build
- manual unauthenticated browser check confirmed /job-os/afa-report does not redirect to /signin

## Notes
- Live public report data requires deploying Firestore rules: firebase deploy --only firestore:rules

Closes #115
Closes #116