### PR TITLE
fix(sync): replace magic snapshot counter with deterministic set-based loading

### DIFF
--- a/src/app/hooks/useJobOs.ts
+++ b/src/app/hooks/useJobOs.ts
@@ -395,10 +395,20 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
     }
 
     const unsubscribers: Array<() => void> = [];
-    let snapshotCount = 0;
-    const markLoaded = () => {
-      snapshotCount += 1;
-      if (snapshotCount >= 8) {
+    const SUBSCRIPTION_KEYS = [
+      "assets",
+      "companies",
+      "roles",
+      "applications",
+      "outreach",
+      "cvProfiles",
+      "jobDescriptions",
+      "cvTailoringRuns",
+    ] as const;
+    const loadedKeys = new Set<string>();
+    const markLoaded = (key: string) => {
+      loadedKeys.add(key);
+      if (loadedKeys.size >= SUBSCRIPTION_KEYS.length) {
         setLoading(false);
       }
     };
@@ -449,12 +459,12 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
           setSyncNotice(null);
           setLocalOnly(false);
           setLastSyncedAt(new Date().toISOString());
-          markLoaded();
+          markLoaded(name);
         },
         () => {
           setSyncNotice("Cloud sync unavailable. Working in local mode.");
           setLocalOnly(true);
-          markLoaded();
+          markLoaded(name);
         }
       );
       unsubscribers.push(unsubscribe);
@@ -483,12 +493,12 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
         });
         setSyncNotice(null);
         setLocalOnly(false);
-        markLoaded();
+        markLoaded("assets");
       },
       () => {
         setSyncNotice("Cloud sync unavailable. Working in local mode.");
         setLocalOnly(true);
-        markLoaded();
+        markLoaded("assets");
       }
     );
     unsubscribers.push(assetsUnsub);


### PR DESCRIPTION
## What

Replace the `snapshotCount >= 8` magic number in `useJobOs.ts` with a `Set<string>` (`loadedKeys`) tracking which named subscription keys have reported their first snapshot. Loading clears when every entry in `SUBSCRIPTION_KEYS` has a corresponding entry in the set. `markLoaded()` now takes a `key: string` argument.

## Why

The counter-to-8 approach is brittle: adding a new collection subscription requires remembering to bump the constant, and miscounting causes either an infinite loading state or premature readiness. Issue #121 calls for deterministic readiness per collection.

Closes #121

## How To Test

1. Load the dashboard with a valid user — data appears normally without a stuck loading spinner.
2. Block Firestore in DevTools → Network, reload — falls through to local mode without hanging.
3. Data loads correctly whether the user has data in all collections or just some.

## Evidence

- Issue: #121
- Demo artifact: N/A — non-visual infra change

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit 9c60fb4

## Checklist

- [x] Linked to issue #121
- [x] Scope limited to loading gate in `useJobOs.ts`
- [x] Local checks pass (`npm run lint && npm run build`)
- [x] Docs updated — N/A
- [x] `CHANGELOG.md` updated — N/A
- [x] Demo artifact — N/A

Closes #121