### PR TITLE
fix(safety): show dependency warning before deleting companies or roles

### DIFF
--- a/src/app/pages/job-os/JobOsCompaniesPage.tsx
+++ b/src/app/pages/job-os/JobOsCompaniesPage.tsx
@@ -783,8 +783,23 @@ export default function JobOsCompaniesPage() {
                         <AlertDialogContent>
                           <AlertDialogHeader>
                             <AlertDialogTitle>Delete {company.name}?</AlertDialogTitle>
-                            <AlertDialogDescription>
-                              This company and all its linked data will be permanently removed.
+                            <AlertDialogDescription asChild>
+                              <div>
+                                <span>This will permanently remove the company record.</span>
+                                {(() => {
+                                  const linkedRoles = roles.filter((r) => r.companyId === company.id).length;
+                                  const linkedApps = applications.filter((a) => a.companyId === company.id).length;
+                                  if (linkedRoles === 0 && linkedApps === 0) return null;
+                                  return (
+                                    <span className="mt-2 block rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
+                                      Warning: {linkedRoles > 0 && `${linkedRoles} role${linkedRoles !== 1 ? "s" : ""}`}
+                                      {linkedRoles > 0 && linkedApps > 0 && " and "}
+                                      {linkedApps > 0 && `${linkedApps} application${linkedApps !== 1 ? "s" : ""}`}
+                                      {" "}linked to this company will also be deleted.
+                                    </span>
+                                  );
+                                })()}
+                              </div>
                             </AlertDialogDescription>
                           </AlertDialogHeader>
                           <AlertDialogFooter>

--- a/src/app/pages/job-os/JobOsRolesPage.tsx
+++ b/src/app/pages/job-os/JobOsRolesPage.tsx
@@ -900,8 +900,19 @@ export default function JobOsRolesPage() {
                       <AlertDialogContent>
                         <AlertDialogHeader>
                           <AlertDialogTitle>Delete this role?</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            {role.title} will be permanently removed along with any linked data.
+                          <AlertDialogDescription asChild>
+                            <div>
+                              <span>{role.title} will be permanently removed.</span>
+                              {(() => {
+                                const linkedApps = applications.filter((a) => a.roleId === role.id).length;
+                                if (linkedApps === 0) return null;
+                                return (
+                                  <span className="mt-2 block rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
+                                    Warning: {linkedApps} application{linkedApps !== 1 ? "s" : ""} linked to this role will also be deleted.
+                                  </span>
+                                );
+                              })()}
+                            </div>
                           </AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>


### PR DESCRIPTION
## What

Delete confirmation dialogs on the Companies and Roles pages now compute linked entity counts inline and display an amber warning banner when dependents exist:

- **Company delete** (`JobOsCompaniesPage.tsx`): warns with counts of linked roles and/or applications.
- **Role delete** (`JobOsRolesPage.tsx`): warns with count of linked applications.

The warning is informational — the user can still confirm deletion. Both pages already had `roles` and `applications` in scope from `useJobOsContext()`.

## Why

Deleting a company or role with downstream data produces orphaned application and outreach records that silently break the pipeline view. Issue #118 calls for surfacing dependency warnings before destructive deletes.

Closes #118

## How To Test

1. Create a company, add a role, log an application.
2. Companies page → delete company → dialog shows amber warning listing linked role and application counts.
3. Roles page → delete role → dialog warns about linked application.
4. For an entity with no dependents → no warning banner appears.
5. Deletion proceeds normally after confirmation.

## Evidence

- Issue: #118
- Demo artifact: visual — follow test steps to see warning banner in the delete dialog

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit 1773648

## Checklist

- [x] Linked to issue #118
- [x] Scope limited to delete dialogs in Companies and Roles pages
- [x] Local checks pass (`npm run lint && npm run build`)
- [x] Docs updated — N/A
- [x] `CHANGELOG.md` updated — N/A
- [x] Demo artifact — follow test steps

Closes #118