### PR TITLE
docs(claude): align branch naming and PR body rules with policy-check CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,16 +39,18 @@ If either gate fails, fix the failure before committing. Do not use
 
 ## Branch Naming
 
-All branches must match one of:
+All branches must match the pattern enforced by `policy-check.yml`:
 
 ```
-feature/issue-{N}-short-slug
-fix/issue-{N}-short-slug
-chore/issue-{N}-short-slug
-docs/issue-{N}-short-slug
-refactor/issue-{N}-short-slug
+feat/{N}-short-slug
+fix/{N}-short-slug
+chore/{N}-short-slug
+docs/{N}-short-slug
+refactor/{N}-short-slug
 claude/*    (automation branches created by Claude Code)
 ```
+
+Where `{N}` is the GitHub issue number. The `issue-` prefix is **not** allowed — the CI policy regex is `^(feat|fix|docs|chore|refactor)\/\d+-[a-z0-9-]+$`.
 
 ---
 
@@ -139,7 +141,7 @@ Rules:
 - `## Evidence — Issue:` must contain the real issue number, e.g. `#42`.
 - `## Risk and Rollback — Risk level:` must be exactly one of `low`, `medium`, or `high`.
 - Checklist items must be checked `[x]` or explicitly unchecked `[ ]` with a reason noted inline.
-- The `Closes #N` link belongs in the **commit body**, not the PR body (already enforced by policy-check CI).
+- `Closes #N` must appear **both** in the commit body **and** in the PR body. The CI `policy-check.yml` enforces it in the PR body via regex `/(closes|fixes|resolves)\s+#\d+/i`.
 
 ---
 


### PR DESCRIPTION
## What

Updated `CLAUDE.md` to match the actual CI policy enforced by `policy-check.yml`:

1. **Branch naming**: removed the incorrect `issue-` prefix from all branch patterns. Correct format is `feat/N-slug` not `feat/issue-N-slug`. Added the exact regex from `policy-check.yml` for clarity.
2. **PR body**: clarified that `Closes #N` is required in **both** the commit body and the PR body — the CI checks the PR body via regex.

## Why

The previous CLAUDE.md branch naming convention (`feat/issue-{N}-slug`) contradicted the actual `policy-check.yml` regex (`^(feat|fix|docs|chore|refactor)\/\d+-[a-z0-9-]+$`), causing CI failures on PRs created following the documented convention. This fixes the documentation to match the enforcer.

Closes #1

## How To Test

1. Create a branch named `fix/999-test-slug` — policy check should pass.
2. Create a branch named `fix/issue-999-test-slug` — policy check should fail.

## Evidence

- Issue: #1
- Demo artifact: N/A — documentation only

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit 294326f

## Checklist

- [x] Linked to issue #1
- [x] Scope limited to CLAUDE.md documentation
- [x] Local checks pass (`npm run lint && npm run build`)
- [x] Docs updated — this IS the docs update
- [x] `CHANGELOG.md` updated — N/A
- [x] Demo artifact — N/A

Closes #1