### PR TITLE
feat(sync): auto-link role state when application is added or removed

### DIFF
--- a/src/app/hooks/useJobOs.ts
+++ b/src/app/hooks/useJobOs.ts
@@ -1296,7 +1296,36 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
             throw new Error("An application for this role already exists.");
           }
 
-          return addCollectionItem<JobOsApplication>("applications", "app", payload, { hasUpdatedAt: true });
+          const appId = await addCollectionItem<JobOsApplication>("applications", "app", payload, { hasUpdatedAt: true });
+
+          // Propagate: mark the linked role as having an application and sync its status.
+          if (roleId) {
+            const syncedRoleStatus = mapApplicationStatusToRoleStatus(payload.status);
+            const roleUpdates: Partial<JobOsRole> = {
+              hasApplication: true,
+              ...(syncedRoleStatus != null ? { status: syncedRoleStatus } : {}),
+            };
+            await mutate(
+              "Sync role on addApplication",
+              (prev) => ({
+                ...prev,
+                roles: prev.roles.map((r) =>
+                  r.id === roleId ? { ...r, ...roleUpdates, updatedAt: new Date().toISOString() } : r
+                ),
+              }),
+              firebase && userId && !localOnly
+                ? async () => {
+                    await setDoc(
+                      doc(firebase.db, "users", userId, "roles", roleId),
+                      { ...roleUpdates, updatedAt: serverTimestamp() },
+                      { merge: true }
+                    );
+                  }
+                : null
+            );
+          }
+
+          return appId;
         },
         updateApplication: async (id: string, updates: Partial<JobOsApplication>) => {
           const now = new Date().toISOString();
@@ -1371,7 +1400,34 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
           updateCollectionItem<CvTailoringRun>("cvTailoringRuns", id, updates),
         removeCompany: (id: string) => removeCollectionItem("companies", id),
         removeRole: (id: string) => removeCollectionItem("roles", id),
-        removeApplication: (id: string) => removeCollectionItem("applications", id),
+        removeApplication: async (id: string) => {
+          // Find the linked role before removing so we can reset its state.
+          const application = state.applications.find((a) => a.id === id);
+          const roleId = application?.roleId;
+          await removeCollectionItem("applications", id);
+          // Propagate: unmark the linked role's hasApplication and reset status to to_apply.
+          if (roleId) {
+            const roleUpdates: Partial<JobOsRole> = { hasApplication: false, status: "to_apply" };
+            await mutate(
+              "Sync role on removeApplication",
+              (prev) => ({
+                ...prev,
+                roles: prev.roles.map((r) =>
+                  r.id === roleId ? { ...r, ...roleUpdates, updatedAt: new Date().toISOString() } : r
+                ),
+              }),
+              firebase && userId && !localOnly
+                ? async () => {
+                    await setDoc(
+                      doc(firebase.db, "users", userId, "roles", roleId),
+                      { ...roleUpdates, updatedAt: serverTimestamp() },
+                      { merge: true }
+                    );
+                  }
+                : null
+            );
+          }
+        },
         removeOutreach: (id: string) => removeCollectionItem("outreach", id),
         removeCvProfile: (id: string) => removeCollectionItem("cvProfiles", id),
         removeJobDescription: (id: string) => removeCollectionItem("jobDescriptions", id),


### PR DESCRIPTION
## What

Extended `useJobOs.ts` with bidirectional role propagation for application lifecycle events:

- **`addApplication`**: after creating the application, updates the linked role's `hasApplication: true` and syncs its `status` via `mapApplicationStatusToRoleStatus` (the same mapping already used by `updateApplication`).
- **`removeApplication`**: after deleting the application, resets the linked role's `hasApplication: false` and `status: "to_apply"`.

Both propagations apply optimistic local state updates and write to Firestore when online, following the existing `mutate` + async write pattern.

## Why

Previously, `addApplication` and `removeApplication` operated on the `applications` collection in isolation. Roles retained stale status and a false `hasApplication` value, causing the execution engine to misclassify roles (e.g. showing "Apply" actions for roles that already had a pending application). Issue #119 calls for deterministic entity propagation rules.

Closes #119

## How To Test

1. Add a role (status: "to_apply", hasApplication: false).
2. Log an application against that role with status "sent".
3. Navigate to Roles — role status should now be "applied", hasApplication = true.
4. Delete the application.
5. Navigate to Roles — role status should reset to "to_apply", hasApplication = false.
6. Repeat with application status "interview" — role status should sync to "interview".

## Evidence

- Issue: #119
- Demo artifact: follow test steps above

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit 15ed637

## Checklist

- [x] Linked to issue #119
- [x] Scope limited to addApplication and removeApplication propagation
- [x] Local checks pass (`npm run lint && npm run build`)
- [x] Docs updated — N/A
- [x] CHANGELOG.md updated — N/A
- [x] Demo artifact — follow test steps

Closes #119