### PR TITLE
fix(sync): rewrite SyncStatusBadge with clear synced/pending/local/error states

### DIFF
--- a/src/app/components/SyncStatusBadge.tsx
+++ b/src/app/components/SyncStatusBadge.tsx
@@ -1,45 +1,81 @@
-import { Loader2, RefreshCcw } from "lucide-react";
-import { Button } from "./ui/button";
-import { useApp } from "../context";
+import { CheckCircle2, CloudOff, Loader2, WifiOff } from "lucide-react";
+import { useJobOsSyncSnapshot } from "../services/jobOsSync";
+
+type SyncStatus = "synced" | "pending" | "local-only" | "error";
+
+function getSyncStatus(
+  pendingWrites: number,
+  storageMode: "firebase" | "local",
+  syncNotice: string | null
+): SyncStatus {
+  if (syncNotice) return "error";
+  if (storageMode === "local") return "local-only";
+  if (pendingWrites > 0) return "pending";
+  return "synced";
+}
+
+const STATUS_CONFIG: Record<
+  SyncStatus,
+  { label: string; icon: React.ReactNode; className: string }
+> = {
+  synced: {
+    label: "Synced",
+    icon: <CheckCircle2 className="h-3.5 w-3.5" />,
+    className: "text-emerald-400 dark:text-emerald-500",
+  },
+  pending: {
+    label: "Saving…",
+    icon: <Loader2 className="h-3.5 w-3.5 animate-spin" />,
+    className: "text-amber-400 dark:text-amber-500",
+  },
+  "local-only": {
+    label: "Local only",
+    icon: <WifiOff className="h-3.5 w-3.5" />,
+    className: "text-neutral-400 dark:text-neutral-500",
+  },
+  error: {
+    label: "Sync error",
+    icon: <CloudOff className="h-3.5 w-3.5" />,
+    className: "text-red-400 dark:text-red-500",
+  },
+};
 
 export function SyncStatusBadge() {
-  const { syncState, refreshData } = useApp();
+  const { pendingWrites, storageMode, syncNotice, lastSyncedAt } =
+    useJobOsSyncSnapshot();
 
-  const lastSyncedLabel = syncState.lastSyncedAt
-    ? new Date(syncState.lastSyncedAt).toLocaleTimeString()
-    : "never";
+  const status = getSyncStatus(pendingWrites, storageMode, syncNotice);
+  const { label, icon, className } = STATUS_CONFIG[status];
+
+  const lastSyncedLabel = lastSyncedAt
+    ? new Date(lastSyncedAt).toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : null;
 
   return (
-    <div className="flex items-center gap-2">
-      <div className="hidden md:block text-xs text-neutral-500 dark:text-neutral-400">
-        <span className="font-medium uppercase mr-1">{syncState.storageMode}</span>
-        <span>Sync: {syncState.isSyncing ? "in progress" : "ok"}</span>
-        <span className="mx-1">|</span>
-        <span>Last: {lastSyncedLabel}</span>
-        {syncState.error && (
-          <>
-            <span className="mx-1">|</span>
-            <span className="text-red-600 dark:text-red-400">{syncState.error}</span>
-          </>
-        )}
-      </div>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={() => {
-          void refreshData();
-        }}
-        className="gap-2"
-      >
-        {syncState.isSyncing ? (
-          <Loader2 className="w-4 h-4 animate-spin" />
-        ) : (
-          <RefreshCcw className="w-4 h-4" />
-        )}
-        <span className="hidden sm:inline">Refresh</span>
-      </Button>
+    <div className={`flex items-center gap-1.5 text-xs font-medium ${className}`}>
+      {icon}
+      <span className="hidden sm:inline">{label}</span>
+      {status === "synced" && lastSyncedLabel && (
+        <span className="hidden lg:inline text-neutral-500 dark:text-neutral-500 font-normal">
+          · {lastSyncedLabel}
+        </span>
+      )}
+      {status === "pending" && pendingWrites > 1 && (
+        <span className="hidden lg:inline font-normal opacity-70">
+          ({pendingWrites})
+        </span>
+      )}
+      {status === "error" && syncNotice && (
+        <span
+          className="hidden lg:inline font-normal opacity-70 max-w-[160px] truncate"
+          title={syncNotice}
+        >
+          · {syncNotice}
+        </span>
+      )}
     </div>
   );
 }
-


### PR DESCRIPTION
## What

Rewrote `SyncStatusBadge` to use `useJobOsSyncSnapshot()` instead of the legacy `useApp().syncState`. Four deterministic states with distinct icons and colours:

| State | Trigger | Icon | Colour |
|---|---|---|---|
| `synced` | firebase mode, no pending writes, no notice | ✓ CheckCircle | Emerald |
| `pending` | pendingWrites > 0 | ⟳ Loader (spinning) | Amber |
| `local-only` | storageMode = "local" | wifi-off | Neutral |
| `error` | syncNotice not null | cloud-off | Red |

Additional details shown at `lg` breakpoint: last-sync time (synced), pending write count (pending), truncated notice (error).

The legacy Refresh button was removed — it was wired to the old storage `refreshData()` which no longer applies. Firestore listeners auto-recover on reconnect.

## Why

The old badge used `useApp().syncState` which was the legacy auth/storage sync system, not the Job OS data sync bus. It didn't reflect actual Firestore sync status. Issue #120 asks for clear, accurate sync state labels.

Closes #120

## How To Test

1. Load dashboard while online — badge shows green "Synced" with last-sync time.
2. Edit a record — badge briefly shows amber "Saving…" then returns to synced.
3. Block Firestore (DevTools → Network, block `firestore.googleapis.com`) — badge shows neutral "Local only".
4. Disconnect network, attempt edit — badge shows red "Sync error" with notice.

## Evidence

- Issue: #120
- Demo artifact: visual — follow test steps to see badge states in the navbar

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit b2ed8d4

## Checklist

- [x] Linked to issue #120
- [x] Scope limited to SyncStatusBadge component
- [x] Local checks pass (`npm run lint && npm run build`)
- [x] Docs updated — N/A
- [x] CHANGELOG.md updated — N/A
- [x] Demo artifact — follow test steps

Closes #120