### PR TITLE
fix(issue-131): Patch dependency vulnerabilities and enforce audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit dependencies
+        run: npm audit --audit-level=high --omit=dev
+
       - name: Lint
         run: npm run lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3972,6 +3972,66 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.4.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.0.4",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.4.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "0.2.12",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.3",
+                "@emnapi/runtime": "^1.4.3",
+                "@tybys/wasm-util": "^0.10.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+            "version": "0.10.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+            "version": "2.8.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.1.12",
             "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.12.tgz",
@@ -4598,9 +4658,9 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.8.11",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-            "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+            "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -6331,9 +6391,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,10 @@
         "vite": "6.3.5",
         "vitest": "^4.0.18"
     },
+    "overrides": {
+        "@xmldom/xmldom": "0.8.12",
+        "lodash": "4.18.1"
+    },
     "pnpm": {
         "overrides": {
             "vite": "6.3.5"


### PR DESCRIPTION
## Summary
- patch the vulnerable runtime transitive dependencies called out in #131 using npm overrides
- refresh the lockfile so npm installs fixed lodash and @xmldom/xmldom versions
- add a CI audit gate that fails on high-severity production vulnerabilities

## Files changed
- package.json
- package-lock.json
- .github/workflows/ci.yml

## Verification
- npm ci
- npm run lint
- npm run test
- npm run build
- npm audit --audit-level=high --omit=dev

## Risks / notes
- lodash is now pinned to 4.18.1 via npm overrides because there is no published 4.17.24 release
- the CI audit gate is scoped to production dependencies to match the runtime vulnerability fix in this issue

Closes #131