### PR TITLE
Add public landing page before app experience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high --omit=dev
-
       - name: Lint
         run: npm run lint
 

--- a/src/app/components/AppNavbar.tsx
+++ b/src/app/components/AppNavbar.tsx
@@ -154,7 +154,6 @@ export function AppNavbar({
                     Private Access
                   </div>
                   <Link
-                    to={appPath("/compliance/afa")}
                     to="/job-os/afa-report"
                     className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-neutral-700 transition-colors hover:bg-neutral-100 dark:text-neutral-200 dark:hover:bg-neutral-900"
                   >
@@ -229,7 +228,6 @@ export function AppNavbar({
             <div className="pt-2 border-t border-neutral-200 dark:border-neutral-800 mt-2">
               <SheetClose asChild>
                 <Link
-                  to={appPath("/compliance/afa")}
                   to="/job-os/afa-report"
                   className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
                 >

--- a/src/app/components/AppNavbar.tsx
+++ b/src/app/components/AppNavbar.tsx
@@ -16,6 +16,7 @@ import { useJobOsSyncSnapshot } from "../services/jobOsSync";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 import { trackPageView } from "../services/analytics";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "./ui/dropdown-menu";
+import { appPath } from "../routing";
 import {
   Sheet,
   SheetContent,
@@ -34,31 +35,31 @@ interface AppNavbarProps {
 
 const NAV_ITEMS = [
   {
-    to: "/",
+    to: appPath(),
     label: "Action",
     icon: LayoutDashboard,
-    matches: (pathname: string) => pathname === "/" || pathname === "/analytics",
+    matches: (pathname: string) => pathname === appPath() || pathname === appPath("/analytics"),
   },
   {
-    to: "/job-os/applications",
+    to: appPath("/job-os/applications"),
     label: "Pipeline",
     icon: BriefcaseBusiness,
     matches: (pathname: string) =>
-      pathname === "/job-os" ||
-      pathname === "/job-os/applications" ||
-      pathname === "/job-os/outreach",
+      pathname === appPath("/job-os") ||
+      pathname === appPath("/job-os/applications") ||
+      pathname === appPath("/job-os/outreach"),
   },
   {
-    to: "/job-os/assets",
+    to: appPath("/job-os/assets"),
     label: "System",
     icon: FolderOpen,
     matches: (pathname: string) =>
-      pathname === "/job-os/assets" ||
-      pathname === "/job-os/companies" ||
-      pathname === "/job-os/roles" ||
-      pathname === "/job-os/settings" ||
-      pathname === "/cv-optimizer" ||
-      pathname === "/compliance/afa",
+      pathname === appPath("/job-os/assets") ||
+      pathname === appPath("/job-os/companies") ||
+      pathname === appPath("/job-os/roles") ||
+      pathname === appPath("/job-os/settings") ||
+      pathname === appPath("/cv-optimizer") ||
+      pathname === appPath("/compliance/afa"),
   },
 ];
 
@@ -153,7 +154,7 @@ export function AppNavbar({
                     Private Access
                   </div>
                   <Link
-                    to="/compliance/afa"
+                    to={appPath("/compliance/afa")}
                     className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-neutral-700 transition-colors hover:bg-neutral-100 dark:text-neutral-200 dark:hover:bg-neutral-900"
                   >
                     <Lock className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
@@ -227,7 +228,7 @@ export function AppNavbar({
             <div className="pt-2 border-t border-neutral-200 dark:border-neutral-800 mt-2">
               <SheetClose asChild>
                 <Link
-                  to="/compliance/afa"
+                  to={appPath("/compliance/afa")}
                   className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
                 >
                   <Lock className="w-4 h-4 shrink-0 text-neutral-500" />

--- a/src/app/components/dashboard/FirstRunScreen.tsx
+++ b/src/app/components/dashboard/FirstRunScreen.tsx
@@ -24,6 +24,7 @@ import type {
   JobOsCompany,
   JobOsRole,
 } from "../../types/jobOs";
+import { appPath } from "../../routing";
 
 type Step = "input" | "analyzing" | "reviewing" | "next_action" | "saving" | "done";
 
@@ -314,7 +315,7 @@ export function FirstRunScreen({
                 asChild
                 className="text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
               >
-                <Link to="/job-os/companies" onClick={onDismiss}>
+                <Link to={appPath("/job-os/companies")} onClick={onDismiss}>
                   Enter manually
                 </Link>
               </Button>

--- a/src/app/components/dashboard/QuickActions.tsx
+++ b/src/app/components/dashboard/QuickActions.tsx
@@ -1,40 +1,11 @@
 import { Link } from "react-router";
-import { PlusCircle, FileText, Building2, ClipboardList } from "lucide-react";
-import { appPath } from "../../routing";
 import { PlusCircle, FileText, ClipboardList, Rocket } from "lucide-react";
+import { appPath } from "../../routing";
 
 interface QuickActionsProps {
   onAddRole?: () => void;
 }
 
-const QUICK_ACTIONS: QuickAction[] = [
-  {
-    label: "Add Company",
-    description: "Track a new target",
-    href: appPath("/job-os/companies"),
-    icon: <Building2 className="h-4 w-4" />,
-  },
-  {
-    label: "Log Application",
-    description: "Record a submission",
-    href: appPath("/job-os/applications"),
-    icon: <ClipboardList className="h-4 w-4" />,
-  },
-  {
-    label: "Tailor CV",
-    description: "Optimise for a role",
-    href: appPath("/cv-optimizer"),
-    icon: <FileText className="h-4 w-4" />,
-  },
-  {
-    label: "Browse Roles",
-    description: "Review your pipeline",
-    href: appPath("/job-os/roles"),
-    icon: <PlusCircle className="h-4 w-4" />,
-  },
-];
-
-export function QuickActions() {
 export function QuickActions({ onAddRole }: QuickActionsProps) {
   return (
     <section className="space-y-3">
@@ -59,7 +30,7 @@ export function QuickActions({ onAddRole }: QuickActionsProps) {
         </button>
 
         <Link
-          to="/job-os/applications"
+          to={appPath("/job-os/applications")}
           className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
         >
           <span className="text-neutral-500 dark:text-neutral-400">
@@ -74,7 +45,7 @@ export function QuickActions({ onAddRole }: QuickActionsProps) {
         </Link>
 
         <Link
-          to="/cv-optimizer"
+          to={appPath("/cv-optimizer")}
           className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
         >
           <span className="text-neutral-500 dark:text-neutral-400">
@@ -89,7 +60,7 @@ export function QuickActions({ onAddRole }: QuickActionsProps) {
         </Link>
 
         <Link
-          to="/job-os/roles"
+          to={appPath("/job-os/roles")}
           className="flex flex-col items-center gap-1.5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 text-center shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
         >
           <span className="text-neutral-500 dark:text-neutral-400">

--- a/src/app/components/dashboard/QuickActions.tsx
+++ b/src/app/components/dashboard/QuickActions.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
 import { PlusCircle, FileText, Building2, ClipboardList } from "lucide-react";
+import { appPath } from "../../routing";
 
 interface QuickAction {
   label: string;
@@ -12,25 +13,25 @@ const QUICK_ACTIONS: QuickAction[] = [
   {
     label: "Add Company",
     description: "Track a new target",
-    href: "/job-os/companies",
+    href: appPath("/job-os/companies"),
     icon: <Building2 className="h-4 w-4" />,
   },
   {
     label: "Log Application",
     description: "Record a submission",
-    href: "/job-os/applications",
+    href: appPath("/job-os/applications"),
     icon: <ClipboardList className="h-4 w-4" />,
   },
   {
     label: "Tailor CV",
     description: "Optimise for a role",
-    href: "/cv-optimizer",
+    href: appPath("/cv-optimizer"),
     icon: <FileText className="h-4 w-4" />,
   },
   {
     label: "Browse Roles",
     description: "Review your pipeline",
-    href: "/job-os/roles",
+    href: appPath("/job-os/roles"),
     icon: <PlusCircle className="h-4 w-4" />,
   },
 ];

--- a/src/app/components/job-os/JobOsLayout.tsx
+++ b/src/app/components/job-os/JobOsLayout.tsx
@@ -12,17 +12,18 @@ import {
 import { AppNavbar } from "../AppNavbar";
 import { useApp } from "../../context";
 import { useJobOsSyncSnapshot } from "../../services/jobOsSync";
+import { appPath } from "../../routing";
 
 const PIPELINE_NAV_ITEMS = [
-  { to: "/job-os/applications", label: "Applications", icon: FileSpreadsheet },
-  { to: "/job-os/outreach", label: "Outreach", icon: Megaphone },
+  { to: appPath("/job-os/applications"), label: "Applications", icon: FileSpreadsheet },
+  { to: appPath("/job-os/outreach"), label: "Outreach", icon: Megaphone },
 ];
 
 const SYSTEM_NAV_ITEMS = [
-  { to: "/job-os/assets", label: "Assets", icon: FolderOpen },
-  { to: "/job-os/companies", label: "Companies", icon: Building2 },
-  { to: "/job-os/roles", label: "Roles", icon: FileText },
-  { to: "/job-os/settings", label: "Settings", icon: Settings },
+  { to: appPath("/job-os/assets"), label: "Assets", icon: FolderOpen },
+  { to: appPath("/job-os/companies"), label: "Companies", icon: Building2 },
+  { to: appPath("/job-os/roles"), label: "Roles", icon: FileText },
+  { to: appPath("/job-os/settings"), label: "Settings", icon: Settings },
 ];
 
 export function JobOsLayout({
@@ -47,9 +48,9 @@ export function JobOsLayout({
     ? new Date(jobOsSync.lastSyncedAt).toLocaleString()
     : "not yet synced";
   const inPipelineContext =
-    location.pathname === "/job-os" ||
-    location.pathname.startsWith("/job-os/applications") ||
-    location.pathname.startsWith("/job-os/outreach");
+    location.pathname === appPath("/job-os") ||
+    location.pathname.startsWith(appPath("/job-os/applications")) ||
+    location.pathname.startsWith(appPath("/job-os/outreach"));
   const navItems = inPipelineContext ? PIPELINE_NAV_ITEMS : SYSTEM_NAV_ITEMS;
 
   const settingsContent = session ? (
@@ -103,7 +104,7 @@ export function JobOsLayout({
           </nav>
           {!inPipelineContext ? (
             <NavLink
-              to="/cv-optimizer"
+              to={appPath("/cv-optimizer")}
               className="inline-flex items-center gap-1.5 text-xs font-medium text-neutral-500 transition-colors hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
             >
               <WandSparkles className="h-3.5 w-3.5" />

--- a/src/app/pages/Analytics.tsx
+++ b/src/app/pages/Analytics.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
+import { Link } from "react-router";
 import { BarChart2 } from "lucide-react";
 import { useApp } from "../context";
 import { useJobOs } from "../hooks/useJobOs";
 import { AppNavbar } from "../components/AppNavbar";
+import { appPath } from "../routing";
 import {
   BarChart,
   Bar,
@@ -92,12 +94,12 @@ function EmptyAnalytics() {
         Add applications to your Job OS pipeline to start seeing conversion
         analytics and funnel benchmarks.
       </p>
-      <a
-        href="/job-os/applications"
+      <Link
+        to={appPath("/job-os/applications")}
         className="text-xs text-blue-500 hover:underline mt-1"
       >
         Go to Applications →
-      </a>
+      </Link>
     </div>
   );
 }

--- a/src/app/pages/NotFound.tsx
+++ b/src/app/pages/NotFound.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router";
 import { Button } from "../components/ui/button";
 import { Home } from "lucide-react";
+import { appPath } from "../routing";
 
 export default function NotFound() {
   return (
@@ -12,7 +13,7 @@ export default function NotFound() {
         <p className="text-neutral-600 dark:text-neutral-400 mb-8">
           Page not found
         </p>
-        <Link to="/">
+        <Link to={appPath()}>
           <Button className="gap-2">
             <Home className="w-4 h-4" />
             Back to Dashboard

--- a/src/app/pages/SignIn.tsx
+++ b/src/app/pages/SignIn.tsx
@@ -4,6 +4,7 @@ import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
 import { useApp } from "../context";
+import { appPath } from "../routing";
 
 export default function SignIn() {
   const { session, signIn, signInWithGoogle, supportsGoogleSignIn, authLoading, resetPassword } = useApp();
@@ -18,7 +19,7 @@ export default function SignIn() {
   const [resetError, setResetError] = useState("");
 
   if (session) {
-    return <Navigate to="/" replace />;
+    return <Navigate to={appPath()} replace />;
   }
 
   const handleSubmit = async (event: React.FormEvent) => {

--- a/src/app/pages/dashboard/DashboardPage.tsx
+++ b/src/app/pages/dashboard/DashboardPage.tsx
@@ -24,6 +24,7 @@ import { FirstRunScreen } from "../../components/dashboard/FirstRunScreen";
 import { AppPageShell } from "../../components/layout/AppPageShell";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../../components/ui/collapsible";
 import { WeeklyExecutionPanel } from "../../components/WeeklyExecutionPanel";
+import { appPath } from "../../routing";
 
 export function DashboardPage() {
   const { session } = useApp();
@@ -130,7 +131,7 @@ export function DashboardPage() {
             addApplication={addApplication}
             onDismiss={() => {
               updateOnboardingStatus("dismissed");
-              void navigate("/job-os/companies");
+              void navigate(appPath("/job-os/companies"));
             }}
             onComplete={() => updateOnboardingStatus("completed")}
           />

--- a/src/app/pages/job-os/JobOsApplicationsPage.tsx
+++ b/src/app/pages/job-os/JobOsApplicationsPage.tsx
@@ -36,6 +36,7 @@ import {
 } from "../../components/job-os/JobOsPipelineBoard";
 import { getApplicationCvLabel, getDefaultCvAsset } from "../../services/cvAssets";
 import { ApplicationQualityBadge } from "../../components/job-os/ApplicationQualityBadge";
+import { appPath } from "../../routing";
 import type { ApplicationStatus, JobOsApplication, JobOsCompany, JobOsRole } from "../../types/jobOs";
 
 const STATUS_VALUES: ApplicationStatus[] = [
@@ -757,7 +758,7 @@ export default function JobOsApplicationsPage() {
               <div className="flex flex-wrap justify-between gap-2">
                 <div className="flex gap-2">
                   <Button asChild variant="outline">
-                    <Link to={`/cv-optimizer?applicationId=${detailApplication.id}`}>Tailor CV</Link>
+                    <Link to={`${appPath("/cv-optimizer")}?applicationId=${detailApplication.id}`}>Tailor CV</Link>
                   </Button>
                   <AlertDialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
                     <Button

--- a/src/app/pages/job-os/JobOsAssetsPage.tsx
+++ b/src/app/pages/job-os/JobOsAssetsPage.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { useJobOsContext } from "../../context/JobOsContext";
 import { JobOsTransferControls } from "../../components/job-os/JobOsTransferControls";
 import { JobOsLayout } from "../../components/job-os/JobOsLayout";
+import { appPath } from "../../routing";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -597,7 +598,7 @@ export default function JobOsAssetsPage() {
                               return (
                                 <Link
                                   key={application.id}
-                                  to={`/cv-optimizer?applicationId=${application.id}`}
+                                  to={`${appPath("/cv-optimizer")}?applicationId=${application.id}`}
                                   className="rounded-full border border-border px-3 py-1.5 text-xs transition-colors hover:border-brand-blue/40 hover:bg-brand-blue/5"
                                 >
                                   {companyName} - {roleTitle} - {getApplicationCvLabel(application, assets.cvs)}

--- a/src/app/pages/job-os/JobOsRolesPage.tsx
+++ b/src/app/pages/job-os/JobOsRolesPage.tsx
@@ -41,6 +41,7 @@ import { usePagination } from "../../hooks/usePagination";
 import { PaginationControls } from "../../components/ui/PaginationControls";
 import { JobOsLayout } from "../../components/job-os/JobOsLayout";
 import { JobOsTransferControls } from "../../components/job-os/JobOsTransferControls";
+import { appPath } from "../../routing";
 import { getRecommendedCvForTrack } from "../../services/cvAssets";
 import type { JobOsRole, JobTrack, RoleStatus } from "../../types/jobOs";
 
@@ -855,7 +856,7 @@ export default function JobOsRolesPage() {
                       <TooltipTrigger asChild>
                         <span className="inline-flex">
                           <Button asChild size="icon" variant="secondary" aria-label="Tailor CV">
-                            <Link to={`/cv-optimizer?roleId=${role.id}`}>
+                            <Link to={`${appPath("/cv-optimizer")}?roleId=${role.id}`}>
                               <WandSparkles className="h-4 w-4" />
                             </Link>
                           </Button>

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,10 +1,12 @@
 import { lazy, Suspense, type ReactNode } from "react";
 import { createBrowserRouter, Navigate } from "react-router";
+import LandingPage from "../marketing/LandingPage";
 import SignIn from "./pages/SignIn";
 import { JobOsRouteProvider } from "./components/job-os/JobOsRouteProvider";
 import JobOsSettingsPage from "./pages/job-os/JobOsSettingsPage";
 import NotFound from "./pages/NotFound";
 import { ProtectedRoute } from "./components/ProtectedRoute";
+import { appPath } from "./routing";
 
 const DashboardPage = lazy(() =>
   import("./pages/dashboard/DashboardPage").then((module) => ({ default: module.DashboardPage }))
@@ -32,66 +34,115 @@ function lazyElement(element: ReactNode) {
 
 export const router = createBrowserRouter([
   {
+    path: "/",
+    element: <LandingPage />,
+  },
+  {
     path: "/signin",
     element: <SignIn />,
   },
   {
+    path: "/app",
     Component: ProtectedRoute,
     children: [
       {
-        path: "/",
+        index: true,
         element: lazyElement(<DashboardPage />),
       },
       {
-        path: "/overview",
-        element: <Navigate to="/" replace />,
+        path: "overview",
+        element: <Navigate to="/app" replace />,
       },
       {
-        path: "/analytics",
+        path: "analytics",
         element: lazyElement(<Analytics />),
       },
       {
-        path: "/compliance/afa",
+        path: "compliance/afa",
         element: lazyElement(<AfaCompliancePage />),
       },
       {
         Component: JobOsRouteProvider,
         children: [
           {
-            path: "/job-os",
+            path: "job-os",
             element: lazyElement(<JobOsApplicationsPage />),
           },
           {
-            path: "/job-os/assets",
+            path: "job-os/assets",
             element: lazyElement(<JobOsAssetsPage />),
           },
           {
-            path: "/job-os/companies",
+            path: "job-os/companies",
             element: lazyElement(<JobOsCompaniesPage />),
           },
           {
-            path: "/job-os/roles",
+            path: "job-os/roles",
             element: lazyElement(<JobOsRolesPage />),
           },
           {
-            path: "/job-os/applications",
+            path: "job-os/applications",
             element: lazyElement(<JobOsApplicationsPage />),
           },
           {
-            path: "/job-os/outreach",
+            path: "job-os/outreach",
             element: lazyElement(<JobOsOutreachPage />),
           },
           {
-            path: "/job-os/settings",
+            path: "job-os/settings",
             element: lazyElement(<JobOsSettingsPage />),
           },
         ],
       },
       {
-        path: "/cv-optimizer",
+        path: "cv-optimizer",
         element: lazyElement(<CvOptimizerPage />),
       },
     ],
+  },
+  {
+    path: "/overview",
+    element: <Navigate to="/app" replace />,
+  },
+  {
+    path: "/analytics",
+    element: <Navigate to={appPath("/analytics")} replace />,
+  },
+  {
+    path: "/compliance/afa",
+    element: <Navigate to={appPath("/compliance/afa")} replace />,
+  },
+  {
+    path: "/cv-optimizer",
+    element: <Navigate to={appPath("/cv-optimizer")} replace />,
+  },
+  {
+    path: "/job-os",
+    element: <Navigate to={appPath("/job-os")} replace />,
+  },
+  {
+    path: "/job-os/assets",
+    element: <Navigate to={appPath("/job-os/assets")} replace />,
+  },
+  {
+    path: "/job-os/companies",
+    element: <Navigate to={appPath("/job-os/companies")} replace />,
+  },
+  {
+    path: "/job-os/roles",
+    element: <Navigate to={appPath("/job-os/roles")} replace />,
+  },
+  {
+    path: "/job-os/applications",
+    element: <Navigate to={appPath("/job-os/applications")} replace />,
+  },
+  {
+    path: "/job-os/outreach",
+    element: <Navigate to={appPath("/job-os/outreach")} replace />,
+  },
+  {
+    path: "/job-os/settings",
+    element: <Navigate to={appPath("/job-os/settings")} replace />,
   },
   {
     path: "*",

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -1,0 +1,9 @@
+export const APP_BASE_PATH = "/app";
+
+export function appPath(path = "") {
+  if (!path || path === "/") {
+    return APP_BASE_PATH;
+  }
+
+  return `${APP_BASE_PATH}${path.startsWith("/") ? path : `/${path}`}`;
+}

--- a/src/app/services/execution/nextActionEngine.ts
+++ b/src/app/services/execution/nextActionEngine.ts
@@ -5,6 +5,7 @@ import type {
   JobOsApplication,
   CompanyPriority,
 } from "../../types/jobOs";
+import { appPath } from "../../routing";
 
 // ─── Public Types ─────────────────────────────────────────────────────────────
 
@@ -109,7 +110,7 @@ function generateApplyActions(
         roleTitle: role.title,
         reason: `Fit score ${role.fitScore}/5${company ? ` · ${company.priority}-priority target` : ""}`,
         actionLabel: "Apply Now",
-        href: "/job-os/roles",
+        href: appPath("/job-os/roles"),
       };
     });
 }
@@ -143,7 +144,7 @@ function generateFollowUpActions(
         applicationId: app.id,
         reason: `Applied ${days} day${days !== 1 ? "s" : ""} ago — no response yet`,
         actionLabel: "Follow Up",
-        href: "/job-os/applications",
+        href: appPath("/job-os/applications"),
       };
     });
 }
@@ -180,7 +181,7 @@ function generateLogApplicationActions(
         roleTitle: role.title,
         reason: `Role is marked ${role.status} but no application record exists yet`,
         actionLabel: "Log Application",
-        href: "/job-os/roles",
+        href: appPath("/job-os/roles"),
       };
     });
 }
@@ -212,7 +213,7 @@ function generateOptimizeCvActions(
         applicationId: app.id,
         reason: "Interview stage — tailor your CV to maximise impact",
         actionLabel: "Tailor CV",
-        href: "/cv-optimizer",
+        href: appPath("/cv-optimizer"),
       };
     });
 }
@@ -242,7 +243,7 @@ function generateAddRoleActions(
         companyName: company.name,
         reason: `${company.status} company — no roles tracked yet`,
         actionLabel: "Add Role",
-        href: "/job-os/companies",
+        href: appPath("/job-os/companies"),
       };
     });
 }
@@ -269,7 +270,7 @@ function generateResearchActions(
       companyName: company.name,
       reason: "A-priority target in research — find open roles",
       actionLabel: "Research",
-      href: "/job-os/companies",
+      href: appPath("/job-os/companies"),
     }));
 }
 
@@ -298,7 +299,7 @@ function generateArchiveActions(
         applicationId: app.id,
         reason: "Keep your pipeline clean — close stale applications",
         actionLabel: "Archive",
-        href: "/job-os/applications",
+        href: appPath("/job-os/applications"),
       };
     });
 }
@@ -354,7 +355,7 @@ function generateStalledApplicationActions(
           applicationId: app.id,
           reason: `Re-engage — last message was ${days} days ago`,
           actionLabel: "Re-engage",
-          href: "/job-os/outreach",
+          href: appPath("/job-os/outreach"),
         });
       } else {
         actions.push({
@@ -367,7 +368,7 @@ function generateStalledApplicationActions(
           applicationId: app.id,
           reason: `Applied ${days} days ago — no outreach logged`,
           actionLabel: "Log Outreach",
-          href: "/job-os/outreach",
+          href: appPath("/job-os/outreach"),
         });
       }
     }
@@ -384,7 +385,7 @@ function generateStalledApplicationActions(
         applicationId: app.id,
         reason: `Screener stage for ${days} days — check status`,
         actionLabel: "Check Status",
-        href: "/job-os/applications",
+        href: appPath("/job-os/applications"),
       });
     }
   }
@@ -425,7 +426,7 @@ function generateOverdueOutreachActions(
         companyName: company?.name,
         reason: `Follow-up with ${o.contactName || "contact"} at ${company?.name ?? "company"} is overdue`,
         actionLabel: "Follow Up",
-        href: "/job-os/outreach",
+        href: appPath("/job-os/outreach"),
       };
     });
 }
@@ -472,7 +473,7 @@ export function getHotOpportunities(
         fitScore: role.fitScore,
         score,
         reason: reasons.join(" · ") || `Fit score ${role.fitScore}/5`,
-        href: "/job-os/roles",
+        href: appPath("/job-os/roles"),
       };
     })
     .sort((a, b) => b.score - a.score)

--- a/src/marketing/LandingPage.tsx
+++ b/src/marketing/LandingPage.tsx
@@ -1,0 +1,203 @@
+import { Link } from "react-router";
+import {
+  ArrowRight,
+  BriefcaseBusiness,
+  CheckCircle2,
+  LineChart,
+  Sparkles,
+  Workflow,
+} from "lucide-react";
+import { Button } from "../app/components/ui/button";
+
+const PROOF_POINTS = [
+  {
+    title: "Clear job-search operating system",
+    description:
+      "JobSprint turns scattered links, applications, outreach, and CV variants into one execution layer with a visible next move.",
+    icon: Workflow,
+  },
+  {
+    title: "Built for measurable progress",
+    description:
+      "The product connects pipeline hygiene, prioritisation, analytics, and follow-up momentum so effort compounds instead of fragmenting.",
+    icon: LineChart,
+  },
+  {
+    title: "Demonstrates systems thinking",
+    description:
+      "This is not just a dashboard. It is a product case study in routing, workflow design, state modeling, and recruiter-facing UX narrative.",
+    icon: Sparkles,
+  },
+];
+
+const FEATURE_STRIPS = [
+  "Command Centre surfaces the strongest next action first.",
+  "Job OS tracks companies, roles, applications, outreach, and assets together.",
+  "CV Optimizer links tailoring workflows to live opportunities.",
+];
+
+export default function LandingPage() {
+  return (
+    <div className="min-h-screen bg-[linear-gradient(180deg,#f8fbff_0%,#eef4ff_42%,#f7f7f2_100%)] text-slate-950">
+      <div className="absolute inset-x-0 top-0 -z-10 h-[34rem] bg-[radial-gradient(circle_at_top_left,rgba(18,75,230,0.18),transparent_34%),radial-gradient(circle_at_top_right,rgba(230,170,18,0.18),transparent_28%)]" />
+
+      <header className="border-b border-slate-200/70 bg-white/70 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">
+              JobSprint
+            </div>
+            <div className="text-sm text-slate-600">
+              Product execution layer for modern job search workflows
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <Link
+              to="/signin"
+              className="text-sm font-medium text-slate-600 transition-colors hover:text-slate-900"
+            >
+              Sign in
+            </Link>
+            <Button asChild className="rounded-full px-5">
+              <Link to="/app">
+                Open demo
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <main>
+        <section className="mx-auto grid max-w-7xl gap-12 px-6 py-20 lg:grid-cols-[1.15fr_0.85fr] lg:items-center">
+          <div className="max-w-3xl">
+            <div className="inline-flex items-center gap-2 rounded-full border border-blue-200 bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-blue-700 shadow-sm">
+              <BriefcaseBusiness className="h-3.5 w-3.5" />
+              See the system. Enter the workflow.
+            </div>
+            <h1 className="mt-7 max-w-4xl text-5xl font-semibold tracking-[-0.04em] text-slate-950 sm:text-6xl">
+              A job search product that behaves like an execution system, not a static tracker.
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg leading-8 text-slate-600">
+              JobSprint helps candidates act on the right next move, keep their pipeline clean,
+              and connect opportunity data to real workflow decisions. It also proves product,
+              frontend, and systems-thinking depth in one experience.
+            </p>
+
+            <div className="mt-10 flex flex-col gap-4 sm:flex-row">
+              <Button asChild size="lg" className="h-12 rounded-full px-6 text-sm font-semibold">
+                <Link to="/app">
+                  Explore the product
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                variant="outline"
+                className="h-12 rounded-full px-6 text-sm font-semibold"
+              >
+                <Link to="/signin">Go to sign in</Link>
+              </Button>
+            </div>
+
+            <div className="mt-10 grid gap-3 text-sm text-slate-600 sm:grid-cols-3">
+              {FEATURE_STRIPS.map((item) => (
+                <div
+                  key={item}
+                  className="rounded-2xl border border-white/80 bg-white/80 p-4 shadow-[0_18px_50px_-34px_rgba(15,23,42,0.45)] backdrop-blur"
+                >
+                  {item}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-[2rem] border border-slate-200 bg-slate-950 p-6 text-white shadow-[0_30px_90px_-45px_rgba(15,23,42,0.72)]">
+            <div className="rounded-[1.5rem] border border-white/10 bg-[linear-gradient(180deg,rgba(18,75,230,0.35),rgba(15,23,42,0.98))] p-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-xs uppercase tracking-[0.24em] text-blue-200">
+                    What It Proves
+                  </div>
+                  <div className="mt-2 text-2xl font-semibold">Product + systems thinking</div>
+                </div>
+                <div className="rounded-2xl bg-white/10 px-3 py-2 text-xs text-white/80">
+                  Recruiter-ready
+                </div>
+              </div>
+
+              <div className="mt-8 space-y-4">
+                {[
+                  "Intentional information architecture from entry page to authenticated workspace",
+                  "Execution-first UX that prioritises decisions instead of passive reporting",
+                  "Scalable SPA structure with protected routing, modular pages, and reusable UI",
+                ].map((item) => (
+                  <div
+                    key={item}
+                    className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4"
+                  >
+                    <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-amber-300" />
+                    <p className="text-sm leading-6 text-white/84">{item}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-6 pb-12">
+          <div className="grid gap-5 lg:grid-cols-3">
+            {PROOF_POINTS.map((point) => {
+              const Icon = point.icon;
+              return (
+                <article
+                  key={point.title}
+                  className="rounded-[1.75rem] border border-slate-200 bg-white/85 p-6 shadow-[0_22px_70px_-48px_rgba(15,23,42,0.4)] backdrop-blur"
+                >
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-blue-50 text-blue-700">
+                    <Icon className="h-5 w-5" />
+                  </div>
+                  <h2 className="mt-5 text-xl font-semibold tracking-tight text-slate-950">
+                    {point.title}
+                  </h2>
+                  <p className="mt-3 text-sm leading-6 text-slate-600">{point.description}</p>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-6 pb-20">
+          <div className="rounded-[2rem] border border-slate-200 bg-white px-8 py-10 shadow-[0_28px_80px_-55px_rgba(15,23,42,0.42)] sm:px-10">
+            <div className="grid gap-8 lg:grid-cols-[1fr_auto] lg:items-center">
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  Why it matters
+                </div>
+                <h2 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  Most job searches lose momentum because the workflow is fragmented.
+                </h2>
+                <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">
+                  Roles live in one place, CVs in another, outreach in another, and decisions
+                  depend on memory. JobSprint unifies that process into a single system so users
+                  can act with more focus, more consistency, and better signal.
+                </p>
+                <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">
+                  The result is a job search that is easier to manage, easier to improve, and far
+                  more intentional from first outreach to final interview.
+                </p>
+              </div>
+              <Button asChild size="lg" className="h-12 rounded-full px-6 text-sm font-semibold">
+                <Link to="/app">
+                  Launch JobSprint
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -14,12 +14,11 @@ test.describe("Authentication", () => {
     await page.locator("#email").fill("e2e@example.com");
     await page.locator("#password").fill("password123");
     await page.locator('button[type="submit"]').click();
-    await expect(page).toHaveURL("/");
+    await expect(page).toHaveURL("/app");
   });
 
   test("protected route redirects unauthenticated users to sign-in", async ({ page }) => {
-    // Visit a protected page without signing in first
-    await page.goto("/");
+    await page.goto("/app");
     await expect(page).toHaveURL("/signin");
   });
 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -57,5 +57,5 @@ export async function signIn(page: Page, email = "e2e@example.com"): Promise<voi
   await page.locator("#email").fill(email);
   await page.locator("#password").fill("password123");
   await page.locator('button[type="submit"]').click();
-  await expect(page).toHaveURL("/");
+  await expect(page).toHaveURL("/app");
 }


### PR DESCRIPTION
## Summary
- add a public landing page at / with product-focused messaging and demo CTA
- move the authenticated JobSprint experience under /app and keep old app URLs redirecting safely
- update internal navigation and deep links so dashboard, Job OS, analytics, compliance, and CV optimizer resolve under the new app base path

## Testing
- npm run build