### PR TITLE
fix(e2e): update dashboard route from / to /app in role-application test

### DIFF
--- a/tests/e2e/job-os-role-application.spec.ts
+++ b/tests/e2e/job-os-role-application.spec.ts
@@ -135,7 +135,7 @@ test("syncs role status changes into Applications and dashboard metrics", async 
       .getByRole("combobox")
   ).toContainText("Interview");
 
-  await page.goto("/");
+  await page.goto("/app");
   await expect(page.getByText("Pipeline Snapshot")).toBeVisible();
   await expect(
     page


### PR DESCRIPTION
## What

One-line fix in `tests/e2e/job-os-role-application.spec.ts` line 138:

```diff
- await page.goto("/");
+ await page.goto("/app");
```

## Why

Commit `547d84f` added a public marketing landing page at `/`, moving the authenticated app entry point to `/app`. The E2E test `syncs role status changes into Applications and dashboard metrics` still navigated to `"/"` and expected to see the dashboard's `"Pipeline Snapshot"` component, which no longer lives there.

This caused CI to fail with:
```
Error: expect(locator).toBeVisible() failed
Locator: getByText('Pipeline Snapshot')
Expected: visible
Timeout: 10000ms
```

## How To Test

1. Run `npm run test:e2e` locally (requires `npm run preview` or `npm run build` first)
2. Verify all 16 Playwright tests pass including `syncs role status changes into Applications and dashboard metrics`
3. Check CI passes on this PR

## Evidence

- Issue: #154
- Demo artifact: N/A — one-line test route fix

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit 477cd7e

## Checklist

- [x] Linked to an issue with clear acceptance criteria
- [x] Scope is limited to the issue
- [x] Local checks pass (`npm run build`)
- [x] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated — N/A, CI fix only
- [x] Demo artifact attached

Closes #154