### PR TITLE
chore(repo): full audit — docs, architecture, backlog, session start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format follows Keep a Changelog principles and this project uses date-based 
 
 ## [Unreleased]
 
+### Added (2026-04-29 — Repo Audit)
+
+- `docs/ARCHITECTURE.md`: full rewrite documenting current data model, navigation structure, persistence modes, and known structure issues (migration backlog).
+- `docs/SPRINT_BACKLOG.md`: replaced outdated Month-3 backlog with current P0/P1/P2/P3 priorities.
+- `docs/NEXT_SESSION_START.md`: updated with post-audit state, uncommitted work summary, and recommended next issues.
+- `docs/ROADMAP.md`: updated completion snapshot and next 3-month focus.
+- `README.md`: rewritten to reflect all current product modules (Source Hub, Assets Vault, AfA Compliance, CV Optimizer).
+- `CLAUDE.md`: added Product Workflow section anchoring Source Hub as top-of-funnel.
+
+### Changed (2026-04-29 — Repo Audit)
+
+- `origin/dev` remote branch deleted (fully merged into main, no unique work).
+- `origin/feat/131-source-hub-workflow` remote branch deleted (PR #152 merged, no unique remote work).
+- 11 local merged branches deleted.
+- 3 stale git worktrees pruned (`.worktrees/issue-131`, `JobSprint-jobos`, `pr-137-fix`).
+
 ### Added
 
 - Wave 2 UX feedback loops: empty states, loading skeletons, unsaved-changes guard.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,28 @@ Rules:
 
 ---
 
+## Product Workflow (for context)
+
+The canonical user journey through JobSprint:
+
+```
+Source Hub (sources + saved searches)
+  → Quick Capture (paste-link import dialog)
+  → Qualification Queue (DiscoveryStatus: discovered → qualified → to_apply)
+  → Companies (company engine)
+  → Roles (roles pipeline)
+  → Applications (applications log, with CV linked)
+  → CV Optimizer (tailoring from Assets Vault or inline)
+  → Outreach (recruiter / direct messages)
+  → AfA Compliance (German job-seekers)
+  → Dashboard (Command Centre: next-action engine, pipeline stats)
+  → Analytics (funnel conversion, offer probability)
+```
+
+Source Hub is **top of funnel**. All new features should reinforce this flow.
+
+---
+
 ## Stack Constraints (frozen)
 
 | Concern | Approved choice |

--- a/README.md
+++ b/README.md
@@ -1,87 +1,128 @@
 
 # JobSprint
 
-JobSprint is a job-search execution dashboard for solo operators: track applications, monitor funnel conversion, and focus weekly effort on actions that improve your odds of getting an offer.
+JobSprint is a job-search execution OS for solo operators. It replaces the
+spreadsheet/browser-tabs/email-thread patchwork with a software-grade production system that
+lets you run your search like a measurable pipeline.
 
-## 30-Second Pitch
+## What It Does
 
-Most job searches fail from inconsistent execution, not lack of talent. JobSprint gives you a visible pipeline, weekly execution targets, and analytics so you can run your search like a measurable production system.
+| Module | What you do there |
+|---|---|
+| **Source Hub** | Track job boards and company career pages; manage saved searches |
+| **Companies** | Build your target company list; import via CSV |
+| **Roles** | Manage open role opportunities linked to companies |
+| **Applications** | Log applications with status, CV used, and next action |
+| **Outreach** | Track recruiter and direct outreach messages |
+| **CV Assets Vault** | Store CV text snapshots, scripts, and templates; link to applications |
+| **CV Optimizer** | Tailor your CV to a specific role using AI (optional OpenAI key) |
+| **Command Centre** | Daily view: most urgent next actions, pipeline snapshot, probability engine |
+| **Analytics** | Funnel conversion, application rate, and offer probability trends |
+| **AfA Compliance** | Track Arbeitsförderungsgesetz application obligations (German job-seekers) |
+
+## Who It Is For
+
+A single job-search operator — typically a product manager, TPM, or implementation specialist —
+who wants to run a structured search with visible pipeline metrics and daily execution focus.
+
+## Current Status
+
+- Stage: MVP+ (Firebase auth + Firestore persistence enabled)
+- Production URL: **https://job-sprint-ten.vercel.app/**
+- Canonical branch: `main`
+
+## Tech Stack
+
+| Concern | Choice |
+|---|---|
+| Bundler | Vite |
+| UI | React 18 + TypeScript |
+| Styling | Tailwind CSS v4 + Radix UI |
+| Routing | React Router v7 |
+| Persistence | Firebase Firestore (primary) / localStorage (fallback) |
+| Auth | Firebase email/password (primary) / local email session (fallback) |
+| Testing | Vitest (unit) + Playwright (E2E) |
+| CI | GitHub Actions |
+| Hosting | Vercel |
+
+## Setup
+
+```bash
+npm install
+npm run dev       # start dev server on http://localhost:5173
+npm run lint      # must exit 0 before any commit
+npm run build     # must pass before any commit
+npm run test      # Vitest unit tests
+npm run test:e2e  # Playwright E2E (requires a running build: npm run preview)
+```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+```bash
+VITE_FIREBASE_API_KEY=...
+VITE_FIREBASE_AUTH_DOMAIN=...
+VITE_FIREBASE_PROJECT_ID=...
+VITE_FIREBASE_STORAGE_BUCKET=...
+VITE_FIREBASE_MESSAGING_SENDER_ID=...
+VITE_FIREBASE_APP_ID=...
+```
+
+Without Firebase vars the app runs in local-session mode (localStorage only, no cross-device sync).
+
+## Live CV Tailoring (optional)
+
+To enable AI-powered CV rewriting:
+
+```bash
+cp .env.server.example .env.server
+# set OPENAI_API_KEY in .env.server
+
+npm run dev:api          # starts Express server on port 8787
+```
+
+Then in `.env`:
+```bash
+VITE_JSPRINT_REMOTE_API_URL=http://localhost:8787
+```
+
+See [docs/CV_TAILORING_API.md](./docs/CV_TAILORING_API.md) for the full API contract.
+
+## Branch Policy
+
+- `main` is the canonical production branch
+- Feature branches: `feat/{issue-number}-short-slug`
+- Fix branches: `fix/{issue-number}-short-slug`
+- One issue = one branch = one PR
+- All PRs require `npm run lint && npm run build` to pass
+- Direct pushes to `main` are not allowed
+
+See [CLAUDE.md](./CLAUDE.md) and [CONTRIBUTING.md](./CONTRIBUTING.md) for full governance rules.
 
 ## Case Study
 
-**Problem**
+**Problem:** Running a serious job search is a full-time operational problem. Most candidates track
+across a mix of spreadsheets, LinkedIn saved jobs, browser tabs, and email threads. There is no
+single place to see which companies are in-flight, what the next action is, what the interview
+conversion rate looks like, or whether the current pace will produce an offer.
 
-Running a serious job search is a full-time operational problem. Most candidates track across a mix of spreadsheets, LinkedIn saved jobs, browser tabs, and email threads. There is no single place to see: which companies are in-flight, what the next action is, what the interview conversion rate looks like, or whether the current pace will realistically produce an offer.
-
-**Solution**
-
-JobSprint replaces that patchwork with a software-grade production system. It has a Command Centre that surfaces the three most urgent actions every day, a probability engine that models offer likelihood from actual funnel data, a Job OS (company engine, roles pipeline, applications log, outreach tracker), a CV tailoring workflow backed by an OpenAI API, and an AfA compliance module for German job-seekers.
-
-**Key Decisions**
-
-| Decision | Rationale |
-|---|---|
-| Vite + React 18 + TypeScript | Fast feedback loop; type safety across a growing codebase |
-| Tailwind CSS v4 + Radix UI | No duplicate styling systems; accessible primitives out of the box |
-| Firebase Auth + Firestore | Zero-ops persistence with real-time sync; local-storage fallback for offline |
-| Next-action engine (pure TS) | Deterministic, testable scoring without a backend round-trip |
-| Recruiter-origin flag on roles | Lets the probability engine separate inbound vs. outbound funnel rates |
-| Command Centre as primary surface | Forces daily review of the most important actions, not just passive tracking |
+**Solution:** JobSprint replaces that patchwork with a software-grade execution system: a Source Hub
+that anchors the top of the funnel, a Command Centre that surfaces the three most urgent actions
+every day, a probability engine that models offer likelihood from actual funnel data, a CV tailoring
+workflow, and an AfA compliance module for German job-seekers.
 
 **Live demo:** https://job-sprint-ten.vercel.app/
 
 **Walkthrough:** _(Loom walkthrough coming soon)_
 
-## Current Status
-
-- Stage: MVP+ (Firebase auth + Firestore persistence enabled)
-- Scope: dashboard, pipeline tracking, analytics, weekly execution panel, sync status, safe delete undo, Job OS role/application guardrails
-- Adoption: AI Production OS v1 process active since March 2, 2026
-- Milestone checkpoint: Month 2 foundation completed on March 3, 2026
-
-## Tech Stack
-
-- Vite + React + TypeScript
-- React Router
-- Tailwind CSS
-- Recharts
-- Radix UI primitives
-
-## Setup
-
-```bash
-npm install   # install dependencies
-npm run dev   # start dev server
-npm run build # production build
-npm run test  # run smoke tests
-```
-
-## Live CV Tailoring
-
-To enable live CV tailoring with OpenAI:
-
-```bash
-cp .env.server.example .env.server
-# set OPENAI_API_KEY and optional OPENAI_MODEL
-npm run dev:api
-```
-
-Then point the frontend at the API in `.env`:
-
-```bash
-VITE_JSPRINT_REMOTE_API_URL=http://localhost:8787
-```
-
-The frontend will call `POST /cv-tailor` for live full-CV rewriting. See `docs/CV_TAILORING_API.md`.
-
-App access requires sign-in. If the `VITE_FIREBASE_*` env vars are configured, auth uses Firebase email/password + Google sign-in.
-
-## Deploy
-
-- Current production URL: https://job-sprint-ten.vercel.app/
-- Hosting: Vercel
-- Optional remote persistence can be configured with `VITE_JSPRINT_REMOTE_API_URL`.
-- Firebase mode (Auth + Firestore) is enabled automatically when `VITE_FIREBASE_*` variables are set.
+| Decision | Rationale |
+|---|---|
+| Vite + React 18 + TypeScript | Fast feedback; type safety across a growing codebase |
+| Tailwind v4 + Radix UI | No duplicate styling systems; accessible primitives |
+| Firebase Auth + Firestore | Zero-ops persistence; localStorage fallback for offline |
+| Pure-TS next-action engine | Deterministic, testable scoring without a backend round-trip |
+| Source Hub as top-of-funnel | Anchors the search to a manageable set of vetted sources |
 
 ## Screenshots
 
@@ -91,22 +132,16 @@ App access requires sign-in. If the `VITE_FIREBASE_*` env vars are configured, a
 ### Analytics
 ![JobSprint Analytics](./docs/assets/analytics.png)
 
-## Demo Artifact
-
-- [Assets Vault Case Study](./docs/CASE_STUDY_ASSETS_VAULT.md)
-
-This is the clearest current proof-of-work artifact for JobSprint's product direction: turning a job-search tracker into an execution system with stable CV assets, reusable scripts, and linked application context.
-
 ## Documentation
 
-- [PRD](./docs/PRD.md)
 - [Architecture](./docs/ARCHITECTURE.md)
 - [Roadmap](./docs/ROADMAP.md)
-- [Decisions Log](./docs/DECISIONS_LOG.md)
-- [Workflow Automation Playbook](./docs/WORKFLOW_AUTOMATION_PLAYBOOK.md)
-- [Cross-Device Sync Checklist](./docs/CROSS_DEVICE_SYNC_CHECKLIST.md)
+- [Sprint Backlog](./docs/SPRINT_BACKLOG.md)
 - [Next Session Start](./docs/NEXT_SESSION_START.md)
+- [PRD](./docs/PRD.md)
+- [Decisions Log](./docs/DECISIONS_LOG.md)
+- [CV Tailoring API](./docs/CV_TAILORING_API.md)
+- [AI Import Schema](./docs/AI_IMPORT_SCHEMA_V1.md)
+- [Case Study — Assets Vault](./docs/CASE_STUDY_ASSETS_VAULT.md)
 - [Contributing Guide](./CONTRIBUTING.md)
-- [Developer Workflow](./docs/DEV_WORKFLOW.md)
 - [Changelog](./CHANGELOG.md)
-

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,69 +1,229 @@
 # Architecture
 
-## High-Level Overview
+Last updated: 2026-04-29
 
-JobSprint is a client-side single-page application built with Vite + React + TypeScript. It uses React Router for page navigation, a sign-in gate, and a global context provider for application state. Persistence is handled behind a repository boundary with local fallback and optional remote API mode.
+## Overview
 
-## Key Components
+JobSprint is a client-side single-page application (SPA) built with Vite + React 18 + TypeScript. It
+targets a solo job-search operator and provides a full execution OS: source management, qualification
+queue, pipeline tracking, outreach, CV tailoring, AfA compliance, and analytics.
 
-- `src/app/context.tsx`
-  - Central state container for auth session, applications, weekly goals, theme mode, sync state, and delete-undo queue.
-- `src/app/services/storage.ts`
-  - Repository interface and adapters (local + optional remote API).
-  - Includes legacy local-data migration helper.
-- `src/app/services/auth.ts`
-  - Session bootstrap and local email-based sign-in/sign-out.
-- `src/app/pages/Dashboard.tsx`
-  - Main execution page containing KPI strip, pipeline board, and weekly/probability panels.
-- `src/app/pages/Analytics.tsx`
-  - Trend charts and conversion funnel visualizations.
-- `src/app/components/*`
-  - Domain components for application cards, modals, and panels.
-- `src/app/utils.ts`
-  - Metric and probability calculations.
+Persistence is Firebase Firestore (primary) with a `localStorage` fallback for offline or unauthenticated
+sessions. Auth is Firebase email/password with a local email-session fallback.
+
+---
+
+## Source Layout
+
+```
+src/
+  main.tsx                   # app entry, mounts router
+  app/
+    App.tsx                  # provider tree (theme, context)
+    context.tsx              # useApp() — auth session, theme, sync
+    context/
+      JobOsContext.tsx        # JobOs state and CRUD actions
+    routes.tsx               # createBrowserRouter, lazy-loaded pages
+    routing.ts               # appPath() helper for /app/* prefix
+    components/
+      AppNavbar.tsx           # top nav — Action / Pipeline / System tabs
+      AppErrorBoundary.tsx    # React error boundary with auto-reload
+      ProtectedRoute.tsx      # auth guard
+      SyncStatusBadge.tsx     # Firestore write-pending badge
+      WeeklyExecutionPanel.tsx
+      compliance/             # AfA modal, dashboard, report, table
+      dashboard/              # Dashboard sub-components (NextAction, Pipeline, etc.)
+      figma/                  # ImageWithFallback helper (rename candidate → ui/)
+      job-os/                 # Core Job OS: layout, command center, import dialogs
+      layout/                 # AppPageShell (page wrapper)
+      ui/                     # Radix-based design system components (shadcn pattern)
+    hooks/
+      useAfaCompliance.ts     # AfA compliance derived state
+      useJobOs.ts             # Full Job OS state hook (thin wrapper over JobOsContext)
+      usePagination.ts        # Generic pagination
+      useUnsavedChanges.ts    # Warn on unsaved edits
+    pages/
+      SignIn.tsx
+      NotFound.tsx
+      Analytics.tsx
+      AfaCompliancePage.tsx
+      dashboard/
+        DashboardPage.tsx     # Command Centre: next-action engine, pipeline snapshot
+      job-os/
+        JobOsSourcesPage.tsx  # Source Hub (top-of-funnel)
+        JobOsCompaniesPage.tsx
+        JobOsRolesPage.tsx
+        JobOsApplicationsPage.tsx
+        JobOsOutreachPage.tsx
+        JobOsAssetsPage.tsx   # CV Assets Vault
+        JobOsSettingsPage.tsx # Import/export, data management
+        JobOsAfaReportPage.tsx # Public-accessible AfA report
+    services/
+      auth.ts                 # Firebase + local session bootstrap
+      firebase.ts             # Firebase app init
+      storage.ts              # localStorage adapter
+      jobOsState.ts           # Default state seeds, normalisation helpers
+      jobOsSync.ts            # Firestore read/write sync layer
+      jobOsApplications.ts    # Application status logic and sorting
+      jobOsExport.ts          # JSON round-trip export/import
+      jobOsTransfer.ts        # CSV company import
+      jobOsExport.test.ts     # Unit tests — MIGRATION CANDIDATE → tests/unit/
+      cvAssets.ts             # CV asset normalisation
+      dashboardOnboarding.ts  # Getting Started checklist state
+      analytics.ts            # Page view tracking
+      execution/
+        nextActionEngine.ts   # Pure TS next-action scoring
+      ingestion/
+        jobImportEnrichmentGateway.ts
+        companyIngestionService.ts
+        preprocessImportText.ts
+        sourceAdapters/       # LinkedIn, Greenhouse, Ashby, Lever, Himalayas, Generic
+        types.ts
+        utils.ts
+    types/
+      jobOs.ts                # All Job OS entity types
+      afa.ts                  # AfA compliance types
+    types.ts                  # LEGACY — shared auth/session types; migration candidate → types/
+    utils/
+      afaDeadlineEngine.ts
+      afaRiskEngine.ts
+    utils.ts                  # LEGACY — metric/probability calculations; migration candidate → utils/
+  features/
+    cvOptimizer/              # CV Optimizer feature module (all self-contained)
+      CvOptimizerPage.tsx
+      CvProfileSelector.tsx
+      FitAnalysisPanel.tsx
+      JobDescriptionInput.tsx
+      PortfolioSuggestions.tsx
+      TailoredOutputPanel.tsx
+      TailoringHistoryList.tsx
+  marketing/
+    LandingPage.tsx           # Public landing — redirects to /app if already signed in
+  services/                   # CV tailoring services — SPLIT from src/app/services/
+    cvFileImportService.ts    # mammoth + pdfjs file parsing
+    cvOptimizerService.ts
+    cvTailoringGateway.ts     # OpenAI API gateway
+  styles/
+    index.css
+    tailwind.css
+    theme.css
+    fonts.css
+```
+
+---
 
 ## Data Model
 
-Primary entity:
+Primary state container: `JobOsState` (defined in `src/app/types/jobOs.ts`).
 
-- `Application` (company, role, date, status, priority, notes, etc.)
+| Entity | Key fields | Purpose |
+|---|---|---|
+| `JobSource` | id, name, url, category, priority, cadence | Source Hub — where to find jobs |
+| `SavedSearch` | id, name, url, sourceId, track | Saved search URLs per source |
+| `JobOsCompany` | id, name, sector, size, notes | Company engine |
+| `JobOsRole` | id, companyId, title, track, status, nextAction | Roles pipeline |
+| `JobOsApplication` | id, roleId, companyId, status, cvAssetId, interviews | Applications log |
+| `JobOsScriptAsset` | id, name, body | Reusable outreach scripts |
+| `JobOsTemplateAsset` | id, name, body | Reusable email templates |
+| `JobOsCvAsset` | id, name, text, isDefault | CV text snapshots |
+| `CvProfile` | id, targetTrack, headline, summary, skills | CV tailoring profiles |
+| `CvTailoringRun` | id, cvProfileId, jobDescriptionId, output | Tailoring history |
 
-Supporting entities:
+Auth/session types are in `src/app/types.ts` (legacy root file, migration candidate).
 
-- `WeeklyGoals`
-- `WeeklyChecklistItem`
+---
 
-All data types are declared in `src/app/types.ts`.
+## Navigation Structure
+
+```
+/ (public landing)
+  → redirects to /app if session exists
+
+/signin
+
+/app (ProtectedRoute)
+  /app                          Dashboard (Command Centre)
+  /app/analytics                Analytics
+  /app/compliance/afa           AfA Compliance
+  /app/cv-optimizer             CV Optimizer
+  /app/job-os/sources           Source Hub        ← top of funnel
+  /app/job-os/companies         Companies
+  /app/job-os/roles             Roles
+  /app/job-os/applications      Applications
+  /app/job-os/outreach          Outreach
+  /app/job-os/assets            Assets Vault
+  /app/job-os/settings          Settings
+
+/app/job-os/afa-report          Public AfA report (no auth required)
+```
+
+Top nav groups: **Action** (dashboard + analytics) | **Pipeline** (applications + outreach) | **System** (assets, companies, roles, cv-optimizer, compliance, settings)
+
+---
 
 ## Data Flow
 
-1. User triggers UI action (create/edit/delete/move application).
-2. Component calls context action from `useApp()`.
-3. Context updates in-memory React state.
-4. Derived metrics are recalculated in utility functions.
-5. Updated state is persisted via repository adapter (`local` or `remote`).
-6. UI rerenders with updated KPI/pipeline/chart values.
+1. User triggers UI action.
+2. Component calls action from `useJobOs()` or `useApp()`.
+3. Hook optimistically updates React state.
+4. State is written to `localStorage` via `storage.ts`.
+5. If Firebase is configured, `jobOsSync.ts` mirrors the change to Firestore.
+6. `SyncStatusBadge` reflects pending/synced/error state.
 
-## Storage and Auth Choices
+---
 
-- Storage: repository adapter
-  - Local mode: user-scoped `localStorage` keys.
-  - Remote mode: API calls to `VITE_JSPRINT_REMOTE_API_URL`.
-- Firebase mode: Firestore state + Firebase email/password auth when `VITE_FIREBASE_*` env vars are present.
-- Authentication: local email session bootstrap fallback if Firebase is not configured.
+## Persistence Modes
 
-## Key Tradeoffs
+| Mode | Trigger | Scope |
+|---|---|---|
+| Local only | No `VITE_FIREBASE_*` env vars | All data in `localStorage` per user key |
+| Firebase | `VITE_FIREBASE_*` env vars present | Auth: Firebase email/password; data: Firestore per-user |
+| CV tailoring API | `VITE_JSPRINT_REMOTE_API_URL` set | `POST /cv-tailor` to local Express server (`server/`) |
 
-- Chosen: local-first simplicity and speed
-  - Pros: fast iteration, no backend complexity
-  - Cons: no cross-device sync, weak durability
-- Chosen: context-based state
-  - Pros: low ceremony for MVP
-  - Cons: less scalable for complex async flows
+---
 
-## Future Scaling Notes
+## Key Technical Decisions
 
-- Introduce a persistence boundary (repository/service layer) before adding backend.
-- Add schema validation at input boundaries.
-- Add API-backed persistence and auth once test and CI baseline is stable.
-- Add instrumentation for funnel events to improve metric trust.
+| Decision | Rationale |
+|---|---|
+| Vite + React 18 + TypeScript | Fast feedback; full type safety across the growing codebase |
+| Tailwind CSS v4 + Radix UI | No duplicate styling systems; accessible primitives |
+| Firebase Auth + Firestore | Zero-ops persistence with real-time sync; localStorage fallback for offline |
+| React Router v7 lazy routes | Code-split by page; avoids loading all feature code upfront |
+| Pure-TS next-action engine | Deterministic, unit-testable scoring without a backend round-trip |
+| Local-first + Firestore mirror | Fast UI, eventual sync; works offline |
+| `appPath()` prefix helper | Keeps all app routes under `/app/*`, allowing `/*` for public pages |
+
+---
+
+## Known Structure Issues (migration backlog)
+
+| Issue | Location | Risk | Fix |
+|---|---|---|---|
+| Parallel root types file | `src/app/types.ts` alongside `src/app/types/` | Confusion about which file to add to | Merge `types.ts` into `types/session.ts` or `types/index.ts` |
+| Parallel root utils file | `src/app/utils.ts` alongside `src/app/utils/` | Same confusion | Move helpers to `utils/metrics.ts` |
+| Parallel root context file | `src/app/context.tsx` alongside `src/app/context/` | Two context patterns | Consolidate; `context.tsx` can re-export from `context/` |
+| CV services outside app/ | `src/services/` vs `src/app/services/` | Mental model split | Move to `src/app/services/cv/` or `src/features/cvOptimizer/services/` |
+| Test file in services/ | `src/app/services/jobOsExport.test.ts` | Breaks colocation convention | Move to `tests/unit/jobOsExport.test.ts` |
+| `figma/` component folder | `src/app/components/figma/ImageWithFallback.tsx` | Misleading name | Rename folder to `ui/` or move file to `components/ui/` |
+| Source Hub not in features/ | `src/app/pages/job-os/JobOsSourcesPage.tsx` | Mixed feature/app concerns | Create `src/features/source-hub/` as issues mature |
+
+Do not perform a mass file migration without a dedicated issue. Document the target and migrate incrementally.
+
+---
+
+## Target Directory Structure (next 3-6 months)
+
+```
+src/
+  app/                  # routing, shell, shared components, shared state
+  features/
+    cv-optimizer/       # already exists
+    source-hub/         # Sources + SavedSearches (extract from job-os pages)
+    afa-compliance/     # AfA module (extract from compliance pages/components)
+  services/             # MERGE into src/app/services/ or src/features/*/services/
+  styles/
+tests/
+  unit/
+  e2e/
+```

--- a/docs/NEXT_SESSION_START.md
+++ b/docs/NEXT_SESSION_START.md
@@ -1,110 +1,115 @@
 # Next Session Start
 
-Last updated: 2026-03-20
+Last updated: 2026-04-29
 
-## Where We Are
+---
 
-All Month 3 sprint issues are closed:
-- #37 Playwright E2E baseline ?
-- #38 JSON export/import ?
-- #39 Case Study README ?
+## Current State
 
-Firebase auth + Firestore persistence operational.
-Current production URL: https://job-sprint-ten.vercel.app/
+**Production URL:** https://job-sprint-ten.vercel.app/
 
-## What Shipped This Session (2026-03-20)
-- All planned Week 1-4 and Month 2 issues are closed.
-- Firebase auth + Firestore persistence are integrated.
-- Current production URL: https://job-sprint-ten.vercel.app/
-- Dashboard right rail is more compact: Quick Actions stay accessible, and Probability Engine is collapsed by default.
-- Today's Actions now surfaces missing `Log Application` tasks when a role has progressed without a linked application record.
-- Roles page now starts with `Add Role` collapsed and blocks duplicate application creation for the same role with explicit feedback.
-- Job OS import/export is available from the shared settings panel on all major Job OS surfaces.
-- Assets Vault now works like a CV constructor: up to 5 managed CV variants, one default CV, linked application visibility, inline script/template editing, and stable `cvAssetId` links behind application records.
-- Playwright now covers role-to-application logging, the Assets Vault CV constructor, CV file import, reusable asset delete confirmations, and Job OS import/export.
-- Route-level lazy loading and focused manual chunk splitting are in place, including lazy-loaded CV import tooling on the Assets page; the initial entry bundle is smaller even though the heaviest shared vendor chunks still need attention.
-- Outward-facing artifact drafted: `docs/CASE_STUDY_ASSETS_VAULT.md`.
-- The case study is now linked from the README as the main proof-of-work artifact.
+**Canonical branch:** `main`
+Remote branches: only `origin/main` (dev and feat/131 were merged and deleted 2026-04-29)
+
+**Checks (as of 2026-04-29):**
+- `npm run lint` — PASS (0 warnings)
+- `npm run build` — PASS (warnings on chunk size > 500 kB — mammoth, pdfjs, vendor)
+- `npm run test` — PASS (16/16 Vitest unit tests)
+- `npm run test:e2e` — Not re-run in this session; last known state: passing on CI
+
+---
+
+## What Shipped Since Last Session
+
+**PR #152 — feat/131 Source Hub Workflow (merged to main)**
+- Source Hub page (`/app/job-os/sources`) is live
+- Saved Searches management included
+- Qualification Queue integration: `DiscoveryStatus` flow from `discovered` → `to_apply`
+- Default source library and saved searches seeded in `jobOsState.ts`
+
+**Repo audit (2026-04-29):**
+- `origin/dev` and `origin/feat/131-source-hub-workflow` remote branches deleted (merged)
+- 11 local branches deleted (fully merged to main)
+- 3 stale git worktrees pruned
+- `docs/ARCHITECTURE.md` rewritten to reflect current data model and structure
+- `docs/SPRINT_BACKLOG.md` replaced with current backlog
+- `docs/NEXT_SESSION_START.md` updated (this file)
+- `docs/ROADMAP.md` updated
+
+---
+
+## Uncommitted Work on Local `feat/131-source-hub-workflow`
+
+There are **3 modified files + 1 unpushed commit** on the local branch that are NOT yet in `main`:
+
+1. **Unpushed commit** (`bdedc42`): `feat(job-os): seed default source library and saved searches`
+   - Changes `useJobOs.ts` and `jobOsState.ts`
+2. **`src/app/hooks/useJobOs.ts`** — wrap state merge in `normalizeJobOsState()` (fixes edge-case state corruption)
+3. **`src/app/services/auth.ts`** — extract `readStoredSession()` helper (clean refactor, no behaviour change)
+4. **`src/marketing/LandingPage.tsx`** — redirect already-signed-in users directly to `/app` instead of showing the landing page
+
+**Action required:** Create `fix/153-session-redirect-and-auth-cleanup` (or similar), commit these three files, open a PR. This is small and low-risk but improves UX (no landing flash for signed-in users) and correctness (state normalisation).
+
+---
 
 ## Start Here (first 30 minutes)
 
-1. Pull latest `main` and run checks:
-   - `npm install`
-   - `npm run test`
-   - `npm run test:e2e`
-   - `npm run build`
-2. Verify Firebase env vars in local `.env` and Vercel environment settings.
-3. Reproduce quick smoke in browser:
-   - Sign in (email/password or Google)
-   - Create one application
-   - Refresh page and confirm persistence
-4. Reproduce the latest Job OS UX guardrails in browser:
-   - Add a role and confirm `Add Role` stays collapsed by default
-   - Create one application from Roles and confirm success notice appears
-   - Try to create the same application again and confirm duplicate prevention
-5. Reproduce the latest Assets Vault behavior in browser:
-   - Upload a CV text file and confirm snapshot import feedback appears
-   - Create, duplicate, rename, and delete a CV variant
-   - Delete a script/template via modal and confirm toast feedback appears
-   - Export then import Job OS state from settings and confirm reusable assets reappear
-6. Open or confirm Month 3 issues for:
-   - screenshot-backed or hosted demo packaging for the case study
-   - deeper dependency-level bundle reduction
-   - CI/reporting polish for the growing Playwright suite
+```bash
+git checkout main
+git pull origin main
+npm install
+npm run lint
+npm run test
+npm run build
+```
 
-**Command Centre & UX**
-- Command Centre replaces legacy Dashboard as primary surface: next-action engine,
-  pipeline snapshot, probability engine (collapsible, closed by default), hot opportunities.
-- Quick Actions pinned to top of right column for always-accessible navigation.
-- Recruiter-origin flag on roles: picker in Add/Edit form, violet badge in table.
-- Probability engine extended with `responseRate`, `interviewRate`, `offerRate`.
+Then verify in browser:
+1. Sign in → confirm redirect to `/app` works
+2. Sign out → confirm landing page is shown to unauthenticated users
+3. Source Hub → confirm default sources are seeded
+4. Add a company → role → application → check Dashboard shows next action
 
-**#37 � Playwright E2E baseline**
-- `playwright.config.ts`: Chromium only, uses `vite preview` (port 4173), retries=2 in CI.
-- `e2e/helpers.ts`: `signIn()` helper uses local-session auth (no Firebase required).
-- `e2e/auth.spec.ts`: sign-in renders, local sign-in redirects to /, unauthenticated > /signin.
-- `e2e/command-centre.spec.ts`: Today's Actions, Pipeline Snapshot, Quick Actions, all four
-  nav links, Probability Engine toggle.
-- `e2e/job-os-navigation.spec.ts`: Companies / Roles / Applications pages, AppNavbar links.
-- `ci.yml`: `e2e` job (needs: build) installs chromium, builds, runs `test:e2e`, uploads
-  report artifact on failure.
-- `vite.config.ts`: excludes `e2e/**` from Vitest runner.
+---
 
-**#38 � JSON export/import**
-- `src/app/services/jobOsExport.ts`: serialize / parse / download utilities, schema v1.
-- `src/app/services/jobOsExport.test.ts`: 9 Vitest unit tests (all passing).
-- `useJobOs.importAll()`: optimistic local state + Firestore setDoc merge.
-- `src/app/pages/job-os/JobOsSettingsPage.tsx`: Export + Import at `/job-os/settings`.
-- `JobOsLayout`: Settings nav link added; existing CSV company import untouched.
+## Recommended Next Issues
 
-**#39 � Case Study README**
-- Problem / solution / key-decisions table / live link / Loom placeholder added.
-- CHANGELOG updated.
+**Immediate (create PR):**
+1. Ship the 3 uncommitted files from local `feat/131` as `fix/153-session-redirect-and-auth-cleanup`
 
-## Open TODOs (require human action before merging PR)
+**Next sprint (P1):**
+2. **#117** — First-class Next Action model (branch `feat/117-structured-next-action` has initial work)
+3. **#122** — Onboarding first workflow (branch `feat/122-first-workflow-onboarding` has initial work; may overlap with #117)
+4. **#124** — Normalize filters and views (no branch yet)
 
-1. Record Loom walkthrough > replace `<!-- TODO: replace with Loom URL -->` in README.
-2. Screenshot Command Centre > save as `docs/assets/command-centre.png`.
-3. Verify E2E job passes in GitHub Actions CI (needs live PR + GitHub Actions run).
+**Deferred:**
+5. **#123** Command palette — polish, not blocking
+6. **#125** Board/list toggle — polish
+7. **#126** Activity timeline — polish
 
-## Icebox (not in current sprint)
-
-- Offline/connection UX polish for Firebase sync errors
-- Release KPI snapshots page
-- First multi-user collaboration spike
-
-## Start Here (next session)
-
-1. `git pull origin main && npm install && npm run lint && npm run build && npm run test`
-2. Check GitHub Actions CI is green for the PR (especially the new `e2e` job).
-3. Check the icebox � pick the next roadmap-aligned issue or ask the owner for a new sprint brief.
+---
 
 ## Risks To Watch
 
-- Playwright E2E job has never run in real CI � monitor first PR run for any
-  `webServer` timing or browser install issues.
-- `docs/assets/command-centre.png` is referenced in README but not yet committed.
-- Bundle size is high � do not add new heavy dependencies without checking impact.
-- Firestore rules must stay aligned with user-scoped document paths.
-- Browser privacy blockers (especially Brave Shields) can break Firebase connectivity.
-- CV labels are now safer because application rows carry `cvAssetId`, but older records may still rely on name fallback until more users touch or re-save them.
+- **Vendor chunk (821 kB)**: mammoth + pdfjs are the heaviest. Issue #130 tracks this. Do not add new heavy libraries without checking bundle impact.
+- **State normalisation edge cases**: The `normaliseJobOsState()` change in the uncommitted work is important — without it, partial merges of Job OS state can produce inconsistent entities. Ship it promptly.
+- **E2E stability**: Playwright suite covers sign-in, pipeline, and Job OS navigation but does NOT yet cover the Sources flow. Add a Sources smoke test when shipping #117.
+- **Local branches with open work**: See `docs/SPRINT_BACKLOG.md` for branches needing review before deletion.
+- **AfA Compliance discoverability**: AfA is under "System" in the top nav but not in the Job OS sidebar. German job-seekers may not find it. Consider adding a link from the Applications page.
+
+---
+
+## Product Module Status
+
+| Module | Route | Status |
+|---|---|---|
+| Dashboard / Command Centre | `/app` | Stable |
+| Analytics | `/app/analytics` | Stable |
+| Source Hub | `/app/job-os/sources` | Shipped PR #152 |
+| Companies | `/app/job-os/companies` | Stable |
+| Roles | `/app/job-os/roles` | Stable |
+| Applications | `/app/job-os/applications` | Stable |
+| Outreach | `/app/job-os/outreach` | Stable |
+| Assets Vault | `/app/job-os/assets` | Stable |
+| CV Optimizer | `/app/cv-optimizer` | Stable (needs discoverability fix) |
+| AfA Compliance | `/app/compliance/afa` | Stable (needs discoverability fix) |
+| Settings / Export | `/app/job-os/settings` | Stable |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,139 +1,80 @@
 # Roadmap
 
-## Completion Snapshot (as of 2026-03-19)
+Last updated: 2026-04-29
 
-- Week 1 complete: baseline docs and repo clarity.
-- Week 2 complete: workflow governance and release discipline.
-- Week 3 complete: 7-day activity signal + app-level error boundary.
-- Week 4 complete: form hardening, safe delete with undo, smoke tests.
-- Month 2 complete: persistence boundary, migration helper, auth/session, sync status, Firebase integration.
-- Post-Month 2 UX hardening in progress: dashboard compression, clearer next actions, safer Role-to-Application handoff, and a stronger Assets Vault workflow.
-- E2E suite stabilised: Probability Engine toggle test fixed to assert the correct empty-pipeline state message (all 15 Playwright tests now pass).
+---
 
-## Next 4 Weeks
+## Completion Snapshot (as of 2026-04-29)
 
-## Week 1: Stabilize Baseline
+All foundational infrastructure and core Job OS modules are shipped:
 
-### Outcome
+| Area | Status |
+|---|---|
+| Firebase Auth + Firestore persistence | Done |
+| Local-first with localStorage fallback | Done |
+| Dashboard / Command Centre (next-action engine, probability engine) | Done |
+| Analytics (funnel, conversion charts) | Done |
+| Job OS: Companies, Roles, Applications, Outreach | Done |
+| Assets Vault (CV snapshots, scripts, templates) | Done |
+| Source Hub + Saved Searches | Done (PR #152) |
+| CV Optimizer (profiles, tailoring, history) | Done |
+| AfA Compliance module + public report | Done |
+| JSON import/export | Done |
+| Public landing page with auth redirect | Done |
+| CI: lint, build, unit tests | Done |
+| E2E: Playwright baseline (auth, pipeline, Job OS navigation) | Done |
+| Branch policy + commit policy in CLAUDE.md | Done |
 
-Repository is clear, scoped, and reviewable in under 10 minutes.
+---
 
-### Issues
+## Current Focus (April 2026)
 
-- Rewrite README with product framing and setup.
-- Add PRD, architecture, roadmap, and decisions log.
-- Add contribution workflow and release format.
-- Add `.env.example` baseline.
+Harden the execution loop from Source Hub through Application for a solo operator running a focused job search.
 
-### Definition of Done
+**In progress / next up:**
 
-- Documentation is complete and internally consistent.
-- New contributor can run app locally from README instructions.
+1. **Ship uncommitted local work** — session redirect (LandingPage) + state normalisation fix + auth refactor
+2. **#117 First-class Next Action model** — add `nextActionDueDate` to roles and applications; surface in next-action engine
+3. **#122 Onboarding first workflow** — guide user through: Source Hub → Company → Role → Application → Next Action
+4. **#124 Normalize filters and views** — consistent filter/sort/view state across Sources, Roles, Applications
 
-### Demo Artifact
-
-- Screenshot of README + docs index in repository.
-
-## Week 2: Ship One Visible Improvement
-
-### Outcome
-
-Project has deploy and release discipline visible to external reviewers.
-
-### Issues
-
-- Add CI workflow for build checks.
-- Add issue templates and PR template.
-- Ensure Vercel deployment is active and documented in README.
-- Add changelog with first adoption entry.
-
-### Definition of Done
-
-- CI runs on pushes and pull requests.
-- Vercel deployment URL is live and documented.
-- Changelog updated with dated entry.
-
-### Demo Artifact
-
-- Screenshot or Loom of successful CI run and live Vercel deploy.
-
-## Week 3: Add One Signal Feature
-
-### Outcome
-
-Users can see an additional quality/usage signal beyond existing KPIs.
-
-### Issues
-
-- Add a 7-day activity signal card.
-- Add error boundary fallback for runtime failures.
-- Improve metric explanation copy for probability output.
-
-### Definition of Done
-
-- Signal feature appears in dashboard/analytics.
-- Error fallback path is testable manually.
-
-### Demo Artifact
-
-- Screenshot of new signal card and fallback state.
-
-## Week 4: Data Trust and UX Hardening
-
-### Outcome
-
-Data entry errors decrease and destructive actions are safer.
-
-### Issues
-
-- Add stricter form validation and user feedback.
-- Add undo path or delayed confirmation for delete.
-- Add smoke tests for CRUD and stage movement.
-
-### Definition of Done
-
-- Invalid data entry paths are blocked.
-- Manual smoke test checklist passes.
-
-### Demo Artifact
-
-- Loom showing validation and safe delete flow.
+---
 
 ## Next 3 Months
 
-## Month 2: Expand Capability
+### P1 — JobSprint Execution Quality
 
-- Introduce backend persistence boundary.
-- Add authentication for single-user account continuity.
-- Support data sync across devices.
+| Issue | Outcome |
+|---|---|
+| #117 Next Action model | Structured due-date tracking, scored in next-action engine |
+| #122 Onboarding | User can complete first loop without friction |
+| #124 Normalize filters | Saved views for A-fit / remote / English-first / MedTech / AI Product |
+| CV Optimizer discoverability | Direct link from Applications row to CV Optimizer for the linked role |
+| AfA Compliance discoverability | Link from Applications page so German job-seekers find it naturally |
 
-## Month 3: Proof-of-Work Expansion
+### P2 — Reliability
 
-- Publish structured demo narrative and case-study assets.
-- Add import/export path for portability.
-- Add release KPI snapshots for visible progress trend.
-- Add first E2E suite for auth + CRUD + pipeline + refresh persistence.
-- Add offline/connection UX polish for Firebase sync errors.
+| Issue | Outcome |
+|---|---|
+| #128 Unit tests | State, sync, next-action logic covered by Vitest |
+| #127 E2E — full flow | Sources → Company → Role → Application → Dashboard next-action |
+| #130 Bundle size | Lazy-load mammoth + pdfjs; target vendor chunk < 400 kB gzipped |
 
-## Current Focus (March 2026)
+### P3 — Polish (after P1+P2 stable)
 
-- Improve dashboard density so the primary cards fit within a single desktop viewport more often.
-- Make Today's Actions resilient to data gaps, especially when a role is marked progressed but no application row exists yet.
-- Reduce accidental duplicate records by tightening Job OS handoff flows and surfacing explicit success/error feedback.
-- Turn Assets Vault into a compact CV constructor with stable CV-to-application linking, import/export support, reusable script/template editing, and explicit file-import feedback.
-- Publish proof-of-work artifacts and keep trimming initial bundle cost as richer Job OS surfaces are added.
+| Issue | Outcome |
+|---|---|
+| #123 Command palette | Quick-add + search from anywhere |
+| #125 Board/list toggle | Kanban view for roles and applications |
+| #126 Activity timeline | Per-entity history of status changes and outreach |
 
-## Next Session Starting Point
-
-The E2E suite is fully green (15/15 Playwright tests pass as of 2026-03-20).
-
-1. **Paste-link import engine** - continue implementation on `claude/paste-link-import-engine-Gmr65`; the branch exists and is pushed. Check the linked issue for remaining acceptance criteria.
-2. Continue bundle-size reduction: focus on the remaining shared `vendor` chunk and heavy always-on dependencies.
-3. Revisit Firebase/analytics loading boundaries to see whether more of the shared runtime can move off the default path.
+---
 
 ## Freeze List
 
 - No framework migration.
-- No large-scale component library refactor.
+- No MUI, Emotion, Bootstrap, or styled-components (Tailwind + Radix is the approved stack).
 - No multi-user collaboration features.
-- No ATS integrations before persistence/auth baseline.
+- No ATS integrations before core execution loop is stable.
+- No force pushes to `main`.
+- No large-scale component migrations without a dedicated issue approved by the human owner.

--- a/docs/SPRINT_BACKLOG.md
+++ b/docs/SPRINT_BACKLOG.md
@@ -1,72 +1,89 @@
 # Sprint Backlog
 
-Current sprint: **Month 3 — Proof-of-Work Expansion** (2026-03-04 →)
+Last updated: 2026-04-29
+Current canonical branch: `main`
+Production: https://job-sprint-ten.vercel.app/
 
 ---
 
-## Active Issues
+## P0 — Repo Health (do first)
 
-### Issue #37 — E2E baseline: Playwright + CI integration
+| # | Issue | Status | Notes |
+|---|---|---|---|
+| — | Make `main` canonical | DONE (2026-04-29) | Remote dev and feat/131 deleted; main is the only remote branch |
+| — | Prune stale worktrees | DONE (2026-04-29) | 3 stale worktrees pruned |
+| — | Validate build/lint/test | DONE (2026-04-29) | All 16 tests pass; lint clean; build clean |
+| — | Update ARCHITECTURE.md | DONE (2026-04-29) | Full rewrite reflecting current data model and structure |
+| — | Update SPRINT_BACKLOG.md | DONE (2026-04-29) | This file |
+| — | Update NEXT_SESSION_START.md | DONE (2026-04-29) | See docs/NEXT_SESSION_START.md |
+| — | Ship local feat/131 work as PR | PENDING | 1 unpushed commit + 3 modified files on local feat/131-source-hub-workflow; create `feat/153-source-hub-seed-and-session` and PR |
 
-**Goal:** Add Playwright and a happy-path E2E suite that runs in CI.
+### In-progress work on local feat/131-source-hub-workflow (NOT YET IN MAIN)
 
-**Acceptance criteria:**
+Three files have uncommitted changes that should go into their own PR:
 
-- [ ] Playwright installed and configured in `vite.config.ts` / separate config
-- [ ] At least one happy-path flow covered: sign-in → create application → move stage → delete with undo
-- [ ] E2E job added to `.github/workflows/ci.yml` after unit tests
-- [ ] E2E suite passes on `main` branch (green CI badge)
+- `src/app/hooks/useJobOs.ts` — wrap state merge in `normalizeJobOsState()` (correctness fix)
+- `src/app/services/auth.ts` — extract `readStoredSession()` helper (code quality)
+- `src/marketing/LandingPage.tsx` — redirect already-signed-in users to `/app` (UX fix)
 
-**Branch:** `feat/37-e2e-playwright-baseline`
-**Label:** feature
-
----
-
-### Issue #38 — Import / export: JSON round-trip for application data
-
-**Goal:** Users can export all application data as JSON and re-import it.
-
-**Acceptance criteria:**
-
-- [ ] Export button in Settings or Dashboard that downloads `jobsprint-export.json`
-- [ ] Import button that parses the file and merges/replaces current data
-- [ ] Schema validation on import (invalid files show a clear error, do not corrupt state)
-- [ ] Export/import is covered by a Vitest unit test for the serialisation logic
-- [ ] Changelog updated
-
-**Branch:** `feat/38-import-export-json`
-**Label:** feature
+**Recommended action:** Create branch `fix/153-session-redirect-and-auth-cleanup`, commit these changes, open PR referencing a new issue or `Closes #153`.
 
 ---
 
-### Issue #39 — Case-study section in README with Loom link
+## P1 — JobSprint Effectiveness
 
-**Goal:** Add a portfolio-facing case-study narrative to README.
-
-**Acceptance criteria:**
-
-- [ ] "Case Study" section added to README above the "Setup" section
-- [ ] Section includes: problem, solution, key decisions, live link, and Loom link placeholder
-- [ ] Loom placeholder replaced with actual Loom URL before PR is merged
-- [ ] Screenshot of the section committed to `docs/assets/` and embedded
-
-**Branch:** `docs/39-case-study-readme`
-**Label:** docs
+| Priority | Issue | Label | Action |
+|---|---|---|---|
+| 1.1 | #117 — Add first-class Next Action model | P1 / data / feature | Keep; branch `feat/117` has real feature work (nextActionDueDate). Create PR. |
+| 1.2 | #122 — Add onboarding for first workflow | P1 / onboarding / ux | Keep; branch `feat/122` has Getting Started checklist work. Create PR. |
+| 1.3 | #124 — Normalize filters and views | P1 / consistency / ux | Keep; no branch yet. Next actionable issue after #117/#122. |
+| 1.4 | Source Hub defaults | — | Harden default sources and saved searches seeded by `jobOsState.ts` |
+| 1.5 | CV Optimizer discoverability | — | CV Optimizer is hidden under System nav; add link from Applications and Assets pages |
+| 1.6 | AfA Compliance placement | — | AfA feels detached; add link from Applications page for German job-seekers |
 
 ---
 
-## Icebox (not in current sprint)
+## P2 — Reliability
 
-- Offline/connection UX polish for Firebase sync errors
-- Release KPI snapshots page
-- First multi-user collaboration spike
+| Priority | Issue | Label | Action |
+|---|---|---|---|
+| 2.1 | #128 — Expand unit tests for state/sync | P2 / quality / testing | Keep; good next step after P1 features |
+| 2.2 | #127 — Playwright E2E for core flow | P2 / quality / testing | Keep; update scope — existing e2e tests need to cover Sources → Application full flow |
+| 2.3 | #130 — Reduce bundle size | P2 / performance | Keep; vendor chunk 821 kB is real concern; mammoth + pdfjs are the main offenders |
+| 2.4 | #129 — Runtime monitoring | P2 / infra | Defer; add only after core flow is stable |
+
+---
+
+## P3 — Polish
+
+| Priority | Issue | Label | Action |
+|---|---|---|---|
+| 3.1 | #123 — Command palette | P1 / ux / feature | Defer to P3; nice-to-have after flow is solid |
+| 3.2 | #125 — Board/list toggle + batch | P1 / ux / feature | Defer to P3 |
+| 3.3 | #126 — Activity timeline | P1 / ux / feature | Defer to P3 |
+
+---
+
+## Local Branches Requiring Manual Review
+
+These local branches have unique commits vs `main` and have not been deleted. Each needs a decision:
+
+| Branch | Unique work | Recommended action |
+|---|---|---|
+| `feat/117-structured-next-action` | nextActionDueDate field + Getting Started checklist | Create PR for issue #117 |
+| `feat/122-first-workflow-onboarding` | Getting Started checklist (same commit as #117 branch) | Investigate if #117 PR covers this; may close #122 as duplicate scope |
+| `claude/paste-link-import-engine-Gmr65` | 5 commits — Dashboard command center, unified add modal, entity model | Verify if content is already in `main` via other PRs; likely safe to delete but needs human review |
+| `feat/115-116-unified-add-modal-dashboard-engine` | AfA label swap commit | Check if swap is in `main`; if yes, delete branch |
+| `feat/119-auto-link-entities` | 1 e2e test fix | Likely superseded; check tests/e2e and delete if covered |
+| `feat/47-navbar-jobos-standardization` | Row index in companies table | Check if in main; if yes, delete |
+| `feat/88-ai-job-ingestion` | Probability smoothing | Check if in main; if yes, delete |
 
 ---
 
 ## Definition of Done (all issues)
 
-- Acceptance criteria checkboxes all ticked
-- `npm run lint && npm run build` pass
-- PR references `Closes #N`
-- `CHANGELOG.md` updated (for feature/chore/bug labels)
-- Demo artifact attached to PR (screenshot or Loom)
+- Acceptance criteria checkboxes ticked
+- `npm run lint && npm run build && npm run test` pass
+- PR references `Closes #N` in both commit body and PR body
+- `CHANGELOG.md` updated
+- Demo artifact or N/A declared in PR


### PR DESCRIPTION
## What

Full repository documentation audit (2026-04-29). Documentation-only commit — no source code changes.

Files changed:
- `docs/ARCHITECTURE.md`: complete rewrite reflecting current data model, navigation structure, persistence modes, and a migration backlog table for 7 known structure issues
- `docs/SPRINT_BACKLOG.md`: replaced Month-3 backlog with current P0/P1/P2/P3 priorities; documents uncommitted local work on `feat/131` branch
- `docs/NEXT_SESSION_START.md`: updated with post-audit state, open work summary, product module status table, and recommended next issues
- `docs/ROADMAP.md`: updated completion snapshot and 3-month focus
- `README.md`: rewritten to cover all current modules (Source Hub, Assets Vault, AfA Compliance, CV Optimizer); updated tech stack table, setup commands, branch policy
- `CLAUDE.md`: added Product Workflow section anchoring Source Hub as top-of-funnel
- `CHANGELOG.md`: added 2026-04-29 repo audit entry

Remote branch cleanup (executed directly, not in this PR commit):
- `origin/dev` deleted (fully merged, 0 unique commits vs main)
- `origin/feat/131-source-hub-workflow` deleted (PR #152 merged)
- 11 local merged branches deleted
- 3 stale git worktrees pruned

## Why

Docs were 6+ weeks behind the actual product state. `ARCHITECTURE.md` still described `Application` as the primary entity and referenced a non-existent `src/app/pages/Dashboard.tsx`. The sprint backlog listed Month-3 issues already closed in March. Any new session starting from these docs would be working from incorrect context.

## How To Test

1. Read `docs/ARCHITECTURE.md` — verify it matches the actual `src/` tree
2. Read `docs/NEXT_SESSION_START.md` — verify it describes current state (Source Hub shipped, main is canonical)
3. Run `npm run lint && npm run build && npm run test` — all should pass
4. Check `git log --oneline --decorate` — only `origin/main` exists remotely (plus this PR branch)

## Evidence

- Issue: #156
- Demo artifact: N/A — non-UI change

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit d54fa04 (docs only, no functional impact)

## Checklist

- [x] Linked to an issue with clear acceptance criteria
- [x] Scope is limited to the issue
- [x] Local checks pass (`npm run build`)
- [x] Docs updated if behavior or workflow changed
- [x] `CHANGELOG.md` updated
- [x] Demo artifact attached

Closes #156
Closes #150