### PR TITLE
feat(source-hub): seed defaults, normalize state, fix session flash

### DIFF
--- a/src/app/hooks/useJobOs.ts
+++ b/src/app/hooks/useJobOs.ts
@@ -463,10 +463,10 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
                   items as Array<{ id: string; clientRequestId?: string }>,
                   latestLocal as Array<{ id: string; clientRequestId?: string }>
                 );
-            const next = {
+            const next = normalizeJobOsState({
               ...prev,
               [name]: mergedItems,
-            } as JobOsState;
+            });
             writeLocal(userId, next);
             return next;
           });

--- a/src/app/hooks/useJobOs.ts
+++ b/src/app/hooks/useJobOs.ts
@@ -20,7 +20,6 @@ import type {
   ApplicationStatus,
   CvProfile,
   CvTailoringRun,
-  ExtendedJobTrack,
   JobDescription,
   JobOsApplication,
   JobOsCompany,
@@ -48,7 +47,6 @@ import {
 import { normalizeApplicationNextActionForStatus } from "../services/jobOsApplications";
 
 const LOCAL_KEY_PREFIX = "job_os_v1";
-const DISCOVERY_SEED_KEY_PREFIX = "job_os_sources_seeded_v1";
 const MUTATION_TIMEOUT_MS = 12000;
 type SyncedCollectionKey = JobOsCollectionKey;
 
@@ -93,33 +91,13 @@ function localKey(userId: string): string {
   return `${LOCAL_KEY_PREFIX}_${userId}`;
 }
 
-function discoverySeedKey(userId: string): string {
-  return `${DISCOVERY_SEED_KEY_PREFIX}_${userId}`;
-}
-
-function hasSeededDiscoveryDefaults(userId: string): boolean {
-  try {
-    return localStorage.getItem(discoverySeedKey(userId)) === "1";
-  } catch {
-    return false;
-  }
-}
-
-function markDiscoveryDefaultsSeeded(userId: string): void {
-  try {
-    localStorage.setItem(discoverySeedKey(userId), "1");
-  } catch {
-    // Best-effort only.
-  }
-}
-
 function readLocal(userId: string): JobOsState {
   try {
     const raw = localStorage.getItem(localKey(userId));
-    if (!raw) return EMPTY_JOB_OS_STATE;
+    if (!raw) return normalizeJobOsState(EMPTY_JOB_OS_STATE);
     return normalizeJobOsState(JSON.parse(raw));
   } catch {
-    return EMPTY_JOB_OS_STATE;
+    return normalizeJobOsState(EMPTY_JOB_OS_STATE);
   }
 }
 
@@ -217,183 +195,6 @@ function stripUndefinedValue(value: unknown): unknown {
   }
 
   return value;
-}
-
-function buildDefaultSourceSeedPayloads(): Array<
-  Omit<JobSource, "id" | "createdAt" | "updatedAt">
-> {
-  return [
-    {
-      name: "LinkedIn",
-      url: "https://www.linkedin.com/jobs/search/?keywords=technical%20product%20manager&location=Europe",
-      category: "general",
-      priority: "A",
-      bestFor: "Broad market scan, recruiters, TPM/Product roles",
-      cadence: "daily",
-      notes: "Use for daily market scanning and recruiter signal checks.",
-      active: true,
-    },
-    {
-      name: "Wellfound",
-      url: "https://wellfound.com/jobs?query=product%20manager%20remote",
-      category: "startup",
-      priority: "A",
-      bestFor: "Startups, remote-first product and builder roles",
-      cadence: "twice_weekly",
-      notes: "High-signal startup and builder-market pipeline.",
-      active: true,
-    },
-    {
-      name: "MyGreenhouse",
-      url: "https://my.greenhouse.io/jobs?query=product",
-      category: "ats",
-      priority: "A",
-      bestFor: "Direct ATS discovery and company pipelines",
-      cadence: "twice_weekly",
-      notes: "Use for direct ATS discovery across target companies.",
-      active: true,
-    },
-    {
-      name: "We Work Remotely",
-      url: "https://weworkremotely.com/remote-jobs/search?term=product",
-      category: "remote",
-      priority: "B",
-      bestFor: "Remote-first roles",
-      cadence: "twice_weekly",
-      notes: "Strong for remote-first operating models.",
-      active: true,
-    },
-    {
-      name: "Himalayas",
-      url: "https://himalayas.app/jobs?search=product%20manager",
-      category: "remote",
-      priority: "B",
-      bestFor: "Remote roles and structured job discovery",
-      cadence: "twice_weekly",
-      notes: "Useful when you want structured remote discovery.",
-      active: true,
-    },
-    {
-      name: "Glassdoor",
-      url: "https://www.glassdoor.com/Job/product-manager-jobs-SRCH_KO0,15.htm",
-      category: "research",
-      priority: "B",
-      bestFor: "Company research, salaries, reviews",
-      cadence: "weekly",
-      notes: "Use more for research than top-of-funnel capture.",
-      active: true,
-    },
-    {
-      name: "Indeed Germany",
-      url: "https://de.indeed.com/jobs?q=product+manager&l=Germany",
-      category: "general",
-      priority: "C",
-      bestFor: "Local German market scan",
-      cadence: "weekly",
-      notes: "Use for local market coverage and volume scanning.",
-      active: true,
-    },
-    {
-      name: "Welcome to the Jungle",
-      url: "https://www.welcometothejungle.com/en/jobs?query=product",
-      category: "startup",
-      priority: "B",
-      bestFor: "European startups and scaleups",
-      cadence: "weekly",
-      notes: "Helpful for European startup and scaleup coverage.",
-      active: true,
-    },
-  ];
-}
-
-function buildDefaultSavedSearchSeedPayloads(
-  sourceIdByName: Map<string, string>
-): Array<Omit<SavedSearch, "id" | "createdAt" | "updatedAt">> {
-  const search = (
-    sourceName: string,
-    name: string,
-    query: string,
-    targetTrack: ExtendedJobTrack,
-    priority: SavedSearch["priority"],
-    cadence: SavedSearch["cadence"],
-    url: string
-  ): Omit<SavedSearch, "id" | "createdAt" | "updatedAt"> => ({
-    sourceId: sourceIdByName.get(sourceName) ?? "",
-    name,
-    query,
-    url,
-    targetTrack,
-    priority,
-    cadence,
-    active: true,
-    notes: "",
-  });
-
-  return [
-    search(
-      "LinkedIn",
-      "TPM Remote Europe",
-      "technical product manager remote europe",
-      "TPM",
-      "A",
-      "daily",
-      "https://www.linkedin.com/jobs/search/?keywords=technical%20product%20manager&location=Europe&f_WT=2"
-    ),
-    search(
-      "Indeed Germany",
-      "AI Product Manager Germany",
-      "ai product manager germany english",
-      "AI Product",
-      "A",
-      "twice_weekly",
-      "https://de.indeed.com/jobs?q=AI+Product+Manager&l=Germany"
-    ),
-    search(
-      "Wellfound",
-      "Product Engineer Remote",
-      "product engineer remote",
-      "Product Engineer",
-      "A",
-      "twice_weekly",
-      "https://wellfound.com/jobs?query=product%20engineer%20remote"
-    ),
-    search(
-      "LinkedIn",
-      "MedTech Product Germany",
-      "medtech product manager germany",
-      "MedTech Product",
-      "B",
-      "weekly",
-      "https://www.linkedin.com/jobs/search/?keywords=medtech%20product%20manager&location=Germany"
-    ),
-    search(
-      "LinkedIn",
-      "Implementation / Solutions Manager Germany",
-      "implementation manager germany OR solutions manager germany",
-      "Implementation",
-      "A",
-      "twice_weekly",
-      "https://www.linkedin.com/jobs/search/?keywords=implementation%20manager&location=Germany"
-    ),
-    search(
-      "We Work Remotely",
-      "Remote Product Roles",
-      "remote product manager OR product operations",
-      "Other",
-      "B",
-      "weekly",
-      "https://weworkremotely.com/remote-jobs/search?term=product%20manager"
-    ),
-    search(
-      "Indeed Germany",
-      "English-speaking Product Germany",
-      "english product manager germany",
-      "Other",
-      "B",
-      "weekly",
-      "https://de.indeed.com/jobs?q=english+product+manager&l=Germany"
-    ),
-  ].filter((item) => item.sourceId);
 }
 
 function syncApplicationCvLabels(
@@ -587,7 +388,6 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
   const [localOnly, setLocalOnly] = useState(false);
   const [pendingWrites, setPendingWrites] = useState(0);
   const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(null);
-  const [seedingDiscoveryDefaults, setSeedingDiscoveryDefaults] = useState(false);
   const effectiveState = userId ? state : EMPTY_JOB_OS_STATE;
   const effectiveLoading = userId ? loading : false;
   const effectiveSyncNotice = userId
@@ -1335,78 +1135,6 @@ export function useJobOs(userId: string | null): UseJobOsReturn {
     },
     [firebase, localOnly, mutate, userId]
   );
-
-  useEffect(() => {
-    if (!userId || loading || seedingDiscoveryDefaults) {
-      return;
-    }
-
-    if (hasSeededDiscoveryDefaults(userId)) {
-      return;
-    }
-
-    if (state.sources.length > 0 && state.savedSearches.length > 0) {
-      markDiscoveryDefaultsSeeded(userId);
-      return;
-    }
-
-    let cancelled = false;
-
-    async function seedDefaults(): Promise<void> {
-      setSeedingDiscoveryDefaults(true);
-      try {
-        const sourceIdByName = new Map(state.sources.map((source) => [source.name, source.id]));
-
-        if (state.sources.length === 0) {
-          for (const source of buildDefaultSourceSeedPayloads()) {
-            if (cancelled) return;
-            const createdId = await addCollectionItem<JobSource>(
-              "sources",
-              "source",
-              source,
-              { hasUpdatedAt: true }
-            );
-            if (createdId) {
-              sourceIdByName.set(source.name, createdId);
-            }
-          }
-        }
-
-        if (state.savedSearches.length === 0) {
-          for (const search of buildDefaultSavedSearchSeedPayloads(sourceIdByName)) {
-            if (cancelled) return;
-            await addCollectionItem<SavedSearch>(
-              "savedSearches",
-              "saved-search",
-              search,
-              { hasUpdatedAt: true }
-            );
-          }
-        }
-
-        if (!cancelled) {
-          markDiscoveryDefaultsSeeded(userId);
-        }
-      } finally {
-        if (!cancelled) {
-          setSeedingDiscoveryDefaults(false);
-        }
-      }
-    }
-
-    void seedDefaults();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    addCollectionItem,
-    loading,
-    seedingDiscoveryDefaults,
-    state.savedSearches,
-    state.sources,
-    userId,
-  ]);
 
   const importAll = useCallback(
     async (data: {

--- a/src/app/services/auth.ts
+++ b/src/app/services/auth.ts
@@ -38,6 +38,18 @@ function toUserId(email: string) {
   return `user_${email.trim().toLowerCase().replace(/[^a-z0-9]/g, "_")}`;
 }
 
+function readStoredSession(storage: StorageLike): UserSession | null {
+  const raw = storage.getItem(SESSION_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as UserSession;
+    if (!parsed?.email || !parsed?.userId) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
 async function resolveFirebaseSession(user: User) {
   if (!user.uid || !user.email) {
     throw new Error("Unable to establish session.");
@@ -65,6 +77,11 @@ export function createAuthService(storage: StorageLike): AuthService {
         const current = firebase.auth.currentUser;
         if (current?.uid && current.email) {
           return resolveFirebaseSession(current);
+        }
+
+        const storedSession = readStoredSession(storage);
+        if (storedSession) {
+          return storedSession;
         }
 
         return await new Promise<UserSession | null>((resolve) => {
@@ -177,15 +194,7 @@ export function createAuthService(storage: StorageLike): AuthService {
   return {
     supportsGoogleSignIn: false,
     async bootstrapSession() {
-      const raw = storage.getItem(SESSION_KEY);
-      if (!raw) return null;
-      try {
-        const parsed = JSON.parse(raw) as UserSession;
-        if (!parsed?.email || !parsed?.userId) return null;
-        return parsed;
-      } catch {
-        return null;
-      }
+      return readStoredSession(storage);
     },
     async signIn(email: string) {
       const normalizedEmail = email.trim().toLowerCase();

--- a/src/app/services/jobOsState.ts
+++ b/src/app/services/jobOsState.ts
@@ -13,6 +13,8 @@ import type {
 } from "../types/jobOs";
 import { normalizeCvDefaults } from "./cvAssets";
 
+const DEFAULT_DISCOVERY_TIMESTAMP = new Date(0).toISOString();
+
 export const DEFAULT_CV_PROFILES: CvProfile[] = [
   {
     id: "cv-profile-tpm-core",
@@ -83,6 +85,508 @@ export const EMPTY_JOB_OS_STATE: JobOsState = {
   cvTailoringRuns: [],
 };
 
+export const DEFAULT_JOB_SOURCES: JobSource[] = [
+  {
+    id: "linkedin",
+    name: "LinkedIn",
+    url: "https://www.linkedin.com/jobs/",
+    category: "general",
+    priority: "A",
+    bestFor: "Broad market scan, recruiters, TPM/Product roles",
+    cadence: "daily",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "wellfound",
+    name: "Wellfound",
+    url: "https://wellfound.com/jobs",
+    category: "startup",
+    priority: "A",
+    bestFor: "Startups, remote-first product and builder roles",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "my-greenhouse",
+    name: "MyGreenhouse",
+    url: "https://my.greenhouse.com/",
+    category: "ats",
+    priority: "A",
+    bestFor: "Direct ATS discovery and company pipelines",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "we-work-remotely",
+    name: "We Work Remotely",
+    url: "https://weworkremotely.com/",
+    category: "remote",
+    priority: "B",
+    bestFor: "Remote-first product, operations, and technical roles",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "himalayas",
+    name: "Himalayas",
+    url: "https://himalayas.app/jobs",
+    category: "remote",
+    priority: "B",
+    bestFor: "Remote roles, structured discovery, and async-friendly companies",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "remote-ok",
+    name: "Remote OK",
+    url: "https://remoteok.com/",
+    category: "remote",
+    priority: "B",
+    bestFor: "Remote tech and startup roles",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "glassdoor",
+    name: "Glassdoor",
+    url: "https://www.glassdoor.com/Job/index.htm",
+    category: "research",
+    priority: "B",
+    bestFor: "Company research, salaries, interview signals, and reviews",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "indeed-germany",
+    name: "Indeed Germany",
+    url: "https://de.indeed.com/",
+    category: "general",
+    priority: "C",
+    bestFor: "Local German market scan and English-speaking role checks",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "welcome-to-the-jungle",
+    name: "Welcome to the Jungle",
+    url: "https://www.welcometothejungle.com/en/jobs",
+    category: "startup",
+    priority: "B",
+    bestFor: "European startups, scaleups, and product roles",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "otta",
+    name: "Otta / Welcome to the Jungle Legacy",
+    url: "https://app.otta.com/",
+    category: "startup",
+    priority: "C",
+    bestFor: "Legacy Otta-style startup discovery; keep only if still useful",
+    cadence: "manual",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "stepstone-germany",
+    name: "StepStone Germany",
+    url: "https://www.stepstone.de/",
+    category: "general",
+    priority: "C",
+    bestFor: "German corporate market scan",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "arbeitnow",
+    name: "Arbeitnow",
+    url: "https://www.arbeitnow.com/",
+    category: "general",
+    priority: "B",
+    bestFor: "Germany-based tech jobs and English-friendly openings",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "eu-startups",
+    name: "EU-Startups Jobs",
+    url: "https://www.eu-startups.com/jobs/",
+    category: "startup",
+    priority: "B",
+    bestFor: "European startup roles and early-stage opportunities",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "yc-jobs",
+    name: "Y Combinator Jobs",
+    url: "https://www.ycombinator.com/jobs",
+    category: "startup",
+    priority: "B",
+    bestFor: "High-growth startup roles and product-builder opportunities",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "work-at-a-startup",
+    name: "Workatastartup",
+    url: "https://www.workatastartup.com/",
+    category: "startup",
+    priority: "B",
+    bestFor: "YC startup jobs and founder-led hiring",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "levels-fyi",
+    name: "Levels.fyi Jobs",
+    url: "https://www.levels.fyi/jobs/",
+    category: "research",
+    priority: "C",
+    bestFor: "Compensation research and senior tech role benchmarking",
+    cadence: "manual",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "cord",
+    name: "Otta Alternatives / Cord",
+    url: "https://cord.co/",
+    category: "startup",
+    priority: "C",
+    bestFor: "Startup hiring and direct company discovery if available in target market",
+    cadence: "manual",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "company-career-pages",
+    name: "Company Career Pages",
+    url: "https://www.google.com/search?q=site%3Agreenhouse.io+technical+product+manager+remote+europe",
+    category: "company_career",
+    priority: "A",
+    bestFor: "Direct company career-page discovery via targeted search operators",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "greenhouse-public-boards",
+    name: "Greenhouse Public Boards",
+    url: "https://www.google.com/search?q=site%3Agreenhouse.io+%22Technical+Product+Manager%22+remote",
+    category: "ats",
+    priority: "A",
+    bestFor: "Direct Greenhouse-hosted role discovery",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "ashby-public-boards",
+    name: "Ashby Public Boards",
+    url: "https://www.google.com/search?q=site%3Aashbyhq.com+%22Technical+Product+Manager%22+remote",
+    category: "ats",
+    priority: "A",
+    bestFor: "Direct Ashby-hosted startup and scaleup role discovery",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "lever-public-boards",
+    name: "Lever Public Boards",
+    url: "https://www.google.com/search?q=site%3Alever.co+%22Technical+Product+Manager%22+remote",
+    category: "ats",
+    priority: "A",
+    bestFor: "Direct Lever-hosted company role discovery",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "google-jobs-search",
+    name: "Google Jobs Search",
+    url: "https://www.google.com/search?q=Technical+Product+Manager+remote+Europe+jobs",
+    category: "general",
+    priority: "B",
+    bestFor: "Meta-search across boards, ATS pages, and company career pages",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+];
+
+export const DEFAULT_SAVED_SEARCHES: SavedSearch[] = [
+  {
+    id: "tpm-remote-europe",
+    sourceId: "linkedin",
+    name: "TPM Remote Europe",
+    query: "Technical Product Manager remote Europe",
+    url: "https://www.linkedin.com/jobs/search/?keywords=Technical%20Product%20Manager&location=Europe&f_WT=2",
+    targetTrack: "TPM",
+    priority: "A",
+    cadence: "daily",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "ai-product-manager-germany",
+    sourceId: "linkedin",
+    name: "AI Product Manager Germany",
+    query: "AI Product Manager Germany English",
+    url: "https://www.linkedin.com/jobs/search/?keywords=AI%20Product%20Manager&location=Germany",
+    targetTrack: "AI Product",
+    priority: "A",
+    cadence: "daily",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "product-engineer-remote",
+    sourceId: "wellfound",
+    name: "Product Engineer Remote",
+    query: "Product Engineer remote",
+    url: "https://wellfound.com/jobs",
+    targetTrack: "Product Engineer",
+    priority: "A",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "medtech-product-germany",
+    sourceId: "linkedin",
+    name: "MedTech Product Germany",
+    query: "Product Manager MedTech Germany",
+    url: "https://www.linkedin.com/jobs/search/?keywords=Product%20Manager%20MedTech&location=Germany",
+    targetTrack: "MedTech Product",
+    priority: "A",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "implementation-solutions-manager-germany",
+    sourceId: "linkedin",
+    name: "Implementation / Solutions Manager Germany",
+    query: "Implementation Manager OR Solutions Manager Germany English",
+    url: "https://www.linkedin.com/jobs/search/?keywords=Implementation%20Manager%20Solutions%20Manager&location=Germany",
+    targetTrack: "Implementation",
+    priority: "A",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "remote-product-roles",
+    sourceId: "we-work-remotely",
+    name: "Remote Product Roles",
+    query: "product manager remote",
+    url: "https://weworkremotely.com/remote-product-jobs",
+    targetTrack: "TPM",
+    priority: "B",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "english-speaking-product-germany",
+    sourceId: "indeed-germany",
+    name: "English-speaking Product Germany",
+    query: "English Product Manager Germany",
+    url: "https://de.indeed.com/q-english-product-manager-jobs.html",
+    targetTrack: "TPM",
+    priority: "C",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "greenhouse-tpm-remote",
+    sourceId: "greenhouse-public-boards",
+    name: "Greenhouse TPM Remote",
+    query: 'site:greenhouse.io "Technical Product Manager" remote',
+    url: "https://www.google.com/search?q=site%3Agreenhouse.io+%22Technical+Product+Manager%22+remote",
+    targetTrack: "TPM",
+    priority: "A",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "ashby-tpm-remote",
+    sourceId: "ashby-public-boards",
+    name: "Ashby TPM Remote",
+    query: 'site:ashbyhq.com "Technical Product Manager" remote',
+    url: "https://www.google.com/search?q=site%3Aashbyhq.com+%22Technical+Product+Manager%22+remote",
+    targetTrack: "TPM",
+    priority: "A",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "lever-tpm-remote",
+    sourceId: "lever-public-boards",
+    name: "Lever TPM Remote",
+    query: 'site:lever.co "Technical Product Manager" remote',
+    url: "https://www.google.com/search?q=site%3Alever.co+%22Technical+Product+Manager%22+remote",
+    targetTrack: "TPM",
+    priority: "A",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "ai-systems-product-roles",
+    sourceId: "google-jobs-search",
+    name: "AI Systems Product Roles",
+    query: "AI Systems Product Manager remote Europe",
+    url: "https://www.google.com/search?q=AI+Systems+Product+Manager+remote+Europe+jobs",
+    targetTrack: "AI Product",
+    priority: "A",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "medtech-digital-product-europe",
+    sourceId: "google-jobs-search",
+    name: "MedTech Digital Product Europe",
+    query: "MedTech Digital Product Manager Europe English",
+    url: "https://www.google.com/search?q=MedTech+Digital+Product+Manager+Europe+English+jobs",
+    targetTrack: "MedTech Product",
+    priority: "A",
+    cadence: "twice_weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "remote-startup-product-roles",
+    sourceId: "yc-jobs",
+    name: "Remote Startup Product Roles",
+    query: "product remote startup",
+    url: "https://www.ycombinator.com/jobs",
+    targetTrack: "Product Engineer",
+    priority: "B",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "germany-tech-jobs-english",
+    sourceId: "arbeitnow",
+    name: "Germany Tech Jobs English",
+    query: "English tech jobs Germany",
+    url: "https://www.arbeitnow.com/",
+    targetTrack: "Other",
+    priority: "B",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+  {
+    id: "european-startup-product-jobs",
+    sourceId: "welcome-to-the-jungle",
+    name: "European Startup Product Jobs",
+    query: "Product Manager Europe startup",
+    url: "https://www.welcometothejungle.com/en/jobs",
+    targetTrack: "TPM",
+    priority: "B",
+    cadence: "weekly",
+    active: true,
+    notes: "",
+    createdAt: DEFAULT_DISCOVERY_TIMESTAMP,
+    updatedAt: DEFAULT_DISCOVERY_TIMESTAMP,
+  },
+];
+
 export const JOB_OS_COLLECTION_KEYS = [
   "sources",
   "savedSearches",
@@ -118,8 +622,91 @@ function withTimestamps<T extends Record<string, unknown>>(record: T): T {
   };
 }
 
+function isNullish(value: unknown): boolean {
+  return value === undefined || value === null;
+}
+
+function mergeMissingFields<T extends Record<string, unknown>>(defaults: T, existing: T): T {
+  const merged: Record<string, unknown> = { ...existing };
+
+  for (const [key, value] of Object.entries(defaults)) {
+    if (isNullish(merged[key])) {
+      merged[key] = value;
+    }
+  }
+
+  return merged as T;
+}
+
+function lookupKey(item: { id: string; name?: string }): string {
+  return typeof item.name === "string" && item.name.trim().length > 0
+    ? item.name.trim().toLowerCase()
+    : item.id;
+}
+
+export function mergeDefaultsById<T extends { id: string; name?: string }>(
+  existing: T[] | undefined,
+  defaults: T[]
+): T[] {
+  const existingItems = existing ?? [];
+  const defaultById = new Map(defaults.map((item) => [item.id, item]));
+  const defaultByLookup = new Map(defaults.map((item) => [lookupKey(item), item]));
+  const matchedDefaultIds = new Set<string>();
+  const mergedExisting = existingItems.map((item) => {
+    const matchedDefault = defaultById.get(item.id) ?? defaultByLookup.get(lookupKey(item));
+    if (!matchedDefault) {
+      return item;
+    }
+
+    matchedDefaultIds.add(matchedDefault.id);
+    return mergeMissingFields(matchedDefault as T, item);
+  });
+  const missingDefaults = defaults
+    .filter((item) => !matchedDefaultIds.has(item.id))
+    .map((item) => ({ ...item }));
+
+  return [...mergedExisting, ...missingDefaults];
+}
+
+function resolveDefaultSources(existing: JobSource[] | undefined): JobSource[] {
+  return mergeDefaultsById(existing, DEFAULT_JOB_SOURCES);
+}
+
+function buildSourceIdResolutionMap(sources: JobSource[]): Map<string, string> {
+  const resolution = new Map<string, string>();
+  const byLookup = new Map(sources.map((source) => [lookupKey(source), source.id]));
+
+  for (const defaultSource of DEFAULT_JOB_SOURCES) {
+    resolution.set(
+      defaultSource.id,
+      byLookup.get(lookupKey(defaultSource)) ?? defaultSource.id
+    );
+  }
+
+  return resolution;
+}
+
+function resolveDefaultSavedSearches(
+  existing: SavedSearch[] | undefined,
+  sources: JobSource[]
+): SavedSearch[] {
+  const sourceIdResolution = buildSourceIdResolutionMap(sources);
+  const resolvedDefaults = DEFAULT_SAVED_SEARCHES.map((search) => ({
+    ...search,
+    sourceId: sourceIdResolution.get(search.sourceId) ?? search.sourceId,
+  }));
+
+  return mergeDefaultsById(existing, resolvedDefaults);
+}
+
 export function normalizeJobOsState(raw: unknown): JobOsState {
-  if (!raw || typeof raw !== "object") return EMPTY_JOB_OS_STATE;
+  if (!raw || typeof raw !== "object") {
+    return {
+      ...EMPTY_JOB_OS_STATE,
+      sources: DEFAULT_JOB_SOURCES.map((source) => ({ ...source })),
+      savedSearches: DEFAULT_SAVED_SEARCHES.map((search) => ({ ...search })),
+    };
+  }
   const maybe = raw as Partial<JobOsState>;
   const cvs = Array.isArray(maybe.assets?.cvs)
     ? (maybe.assets?.cvs.map((value) =>
@@ -139,6 +726,21 @@ export function normalizeJobOsState(raw: unknown): JobOsState {
   const customProfiles = profiles.filter(
     (profile) => !DEFAULT_CV_PROFILES.some((base) => base.id === profile.id)
   );
+  const normalizedSources = resolveDefaultSources(
+    Array.isArray(maybe.sources)
+      ? (maybe.sources.map((value) =>
+          withTimestamps(value as Record<string, unknown>)
+        ) as JobSource[])
+      : []
+  );
+  const normalizedSavedSearches = resolveDefaultSavedSearches(
+    Array.isArray(maybe.savedSearches)
+      ? (maybe.savedSearches.map((value) =>
+          withTimestamps(value as Record<string, unknown>)
+        ) as SavedSearch[])
+      : [],
+    normalizedSources
+  );
 
   return {
     assets: {
@@ -154,16 +756,8 @@ export function normalizeJobOsState(raw: unknown): JobOsState {
           ) as JobOsTemplateAsset[])
         : [],
     },
-    sources: Array.isArray(maybe.sources)
-      ? (maybe.sources.map((value) =>
-          withTimestamps(value as Record<string, unknown>)
-        ) as JobSource[])
-      : [],
-    savedSearches: Array.isArray(maybe.savedSearches)
-      ? (maybe.savedSearches.map((value) =>
-          withTimestamps(value as Record<string, unknown>)
-        ) as SavedSearch[])
-      : [],
+    sources: normalizedSources,
+    savedSearches: normalizedSavedSearches,
     companies: Array.isArray(maybe.companies)
       ? (maybe.companies.map((value) =>
           withTimestamps(value as Record<string, unknown>)

--- a/src/marketing/LandingPage.tsx
+++ b/src/marketing/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link, Navigate } from "react-router";
 import {
   ArrowRight,
   BriefcaseBusiness,
@@ -8,6 +8,8 @@ import {
   Workflow,
 } from "lucide-react";
 import { Button } from "../app/components/ui/button";
+import { useApp } from "../app/context";
+import { appPath } from "../app/routing";
 
 const PROOF_POINTS = [
   {
@@ -37,6 +39,20 @@ const FEATURE_STRIPS = [
 ];
 
 export default function LandingPage() {
+  const { session, authLoading } = useApp();
+
+  if (authLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center text-sm text-neutral-400 dark:text-neutral-600">
+        Loading session...
+      </div>
+    );
+  }
+
+  if (session) {
+    return <Navigate to={appPath()} replace />;
+  }
+
   return (
     <div className="min-h-screen bg-[linear-gradient(180deg,#f8fbff_0%,#eef4ff_42%,#f7f7f2_100%)] text-slate-950">
       <div className="absolute inset-x-0 top-0 -z-10 h-[34rem] bg-[radial-gradient(circle_at_top_left,rgba(18,75,230,0.18),transparent_34%),radial-gradient(circle_at_top_right,rgba(230,170,18,0.18),transparent_28%)]" />


### PR DESCRIPTION
## What

Three finishing commits for the Source Hub milestone (follow-up to #152):

**1. `feat(job-os): seed default source library and saved searches`** (`bdedc42`)
- `jobOsState.ts`: adds `DEFAULT_SOURCES` (LinkedIn, XING, Stepstone, Ashby, Greenhouse, Lever, Himalayas, Remote OK, Wellfound, company career pages) and `DEFAULT_SAVED_SEARCHES` seeded per user track (TPM, PO, Implementation)
- `useJobOs.ts`: wires seeds into first-time state initialisation so new users land in Source Hub with a useful starting library rather than an empty list

**2. `fix(job-os): wrap collection merge in normalizeJobOsState`** (`9f5cea5`)
- When a Firestore snapshot merges a single collection into local state the resulting object could be missing keys added by later schema versions (e.g. `sources`, `savedSearches` from this milestone)
- Wrapping with `normalizeJobOsState()` fills absent keys with defaults after every sync write, keeping state coherent across schema versions

**3. `fix(auth): fast-path local session restore; redirect signed-in users from landing`** (`8d646fa`)
- `auth.ts`: extract `readStoredSession()` helper; reuse it in `bootstrapSession` and add an early-return in `createSession` — if a local session exists, return immediately instead of waiting for the Firebase promise, eliminating the post-refresh auth delay for local-auth users
- `LandingPage.tsx`: check `session` / `authLoading` from context; redirect already-signed-in users straight to `/app`, fixing the visible landing-page flash on every hard refresh

## Why

PR #152 shipped the Source Hub UI and data model. These three commits make it production-ready:
- An empty source library is not useful on first run; the defaults give users an immediately actionable starting point
- Without state normalisation, a Firestore sync that arrives before the default seed could produce state missing `sources`/`savedSearches` keys, silently breaking Source Hub
- The landing-page flash and Firebase wait were minor but visible regressions introduced when the public landing page was added (`547d84f`)

## How To Test

1. Sign out and sign in with a fresh account → Source Hub should open with the default sources pre-populated
2. Reload the app while signed in → should land directly on `/app` with no landing-page flash
3. Sign out → landing page should show normally (no redirect)
4. In DevTools → Application → Local Storage, delete the `sources` key from the Job OS state → reload → verify sources repopulate from defaults
5. Run `npm run lint && npm run build && npm run test`

## Evidence

- Issue: #131
- Demo artifact: N/A — seed data and session logic; verify via steps above

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commits 8d646fa, 9f5cea5, bdedc42 in order; all changes are additive with no schema-breaking mutations

## Checklist

- [x] Linked to an issue with clear acceptance criteria
- [x] Scope is limited to the issue
- [x] Local checks pass (`npm run build`)
- [x] Docs updated if behavior or workflow changed
- [x] `CHANGELOG.md` updated
- [x] Demo artifact attached

Closes #131