### PR TITLE
refactor(nav): stabilize Job OS shell navigation

### DIFF
--- a/src/app/components/AppNavbar.tsx
+++ b/src/app/components/AppNavbar.tsx
@@ -26,7 +26,7 @@ import {
 } from "./ui/sheet";
 
 interface AppNavbarProps {
-  title: string;
+  title?: string;
   subtitle?: string;
   rightActions?: React.ReactNode;
   showSync?: boolean;
@@ -38,34 +38,35 @@ const NAV_ITEMS = [
     to: appPath(),
     label: "Action",
     icon: LayoutDashboard,
-    matches: (pathname: string) => pathname === appPath() || pathname === appPath("/analytics"),
+    matches: (pathname: string) =>
+      pathname === appPath() ||
+      pathname === appPath("/analytics") ||
+      pathname.startsWith(appPath("/job-os/sources")),
   },
   {
-    to: appPath("/job-os/applications"),
+    to: appPath("/job-os/roles"),
     label: "Pipeline",
     icon: BriefcaseBusiness,
     matches: (pathname: string) =>
       pathname === appPath("/job-os") ||
-      pathname === appPath("/job-os/applications") ||
-      pathname === appPath("/job-os/outreach"),
+      pathname.startsWith(appPath("/job-os/roles")) ||
+      pathname.startsWith(appPath("/job-os/applications")) ||
+      pathname.startsWith(appPath("/job-os/outreach")),
   },
   {
-    to: appPath("/job-os/assets"),
+    to: appPath("/job-os/companies"),
     label: "System",
     icon: FolderOpen,
     matches: (pathname: string) =>
-      pathname === appPath("/job-os/assets") ||
-      pathname === appPath("/job-os/companies") ||
-      pathname === appPath("/job-os/roles") ||
-      pathname === appPath("/job-os/settings") ||
-      pathname === appPath("/cv-optimizer") ||
-      pathname === appPath("/compliance/afa"),
+      pathname.startsWith(appPath("/job-os/companies")) ||
+      pathname.startsWith(appPath("/job-os/assets")) ||
+      pathname.startsWith(appPath("/job-os/settings")) ||
+      pathname.startsWith(appPath("/cv-optimizer")) ||
+      pathname.startsWith(appPath("/compliance/afa")),
   },
 ];
 
 export function AppNavbar({
-  title,
-  subtitle,
   rightActions,
   showSync = false,
   settingsContent,
@@ -77,7 +78,6 @@ export function AppNavbar({
   const hasSettingsMenu = Boolean(settingsContent);
   const [mobileOpen, setMobileOpen] = useState(false);
 
-  // Close drawer on navigation
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setMobileOpen(false); }, [location.pathname]);
 
@@ -104,7 +104,7 @@ export function AppNavbar({
             </button>
 
             <span className="text-base font-bold text-white tracking-tight">
-              {title}
+              JobSprint OS
             </span>
 
             {/* Desktop nav */}
@@ -187,12 +187,6 @@ export function AppNavbar({
             </button>
           </div>
         </div>
-
-        {subtitle && (
-          <div className="pb-1.5 -mt-1 text-xs text-white/45 truncate">
-            {subtitle}
-          </div>
-        )}
       </div>
 
       {/* Mobile nav drawer */}
@@ -200,7 +194,7 @@ export function AppNavbar({
         <SheetContent side="left" className="w-72 p-0 flex flex-col">
           <SheetHeader className="px-5 py-4 border-b border-neutral-200 dark:border-neutral-800">
             <SheetTitle className="text-base font-bold tracking-tight">
-              JobSprint
+              JobSprint OS
             </SheetTitle>
           </SheetHeader>
 

--- a/src/app/components/job-os/JobOsLayout.tsx
+++ b/src/app/components/job-os/JobOsLayout.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "react-router";
+import { NavLink, useLocation } from "react-router";
 import { CommandCenter } from "./CommandCenter";
 import {
   Building2,
@@ -8,6 +8,7 @@ import {
   FolderOpen,
   Megaphone,
   Settings,
+  ShieldCheck,
   WandSparkles,
 } from "lucide-react";
 import { AppNavbar } from "../AppNavbar";
@@ -15,18 +16,47 @@ import { useApp } from "../../context";
 import { useJobOsSyncSnapshot } from "../../services/jobOsSync";
 import { appPath } from "../../routing";
 
-const JOB_OS_NAV_ITEMS = [
-  { to: appPath("/job-os/sources"), label: "Sources", icon: Compass },
-  { to: appPath("/job-os/companies"), label: "Companies", icon: Building2 },
-  { to: appPath("/job-os/roles"), label: "Roles", icon: FileText },
-  { to: appPath("/job-os/applications"), label: "Applications", icon: FileSpreadsheet },
-  { to: appPath("/job-os/outreach"), label: "Outreach", icon: Megaphone },
-  { to: appPath("/job-os/assets"), label: "Assets", icon: FolderOpen },
-];
+function getActiveSection(pathname: string): "action" | "pipeline" | "system" {
+  if (
+    pathname === appPath("/job-os") ||
+    pathname.startsWith(appPath("/job-os/roles")) ||
+    pathname.startsWith(appPath("/job-os/applications")) ||
+    pathname.startsWith(appPath("/job-os/outreach"))
+  ) return "pipeline";
+  if (
+    pathname.startsWith(appPath("/job-os/companies")) ||
+    pathname.startsWith(appPath("/job-os/assets")) ||
+    pathname.startsWith(appPath("/job-os/settings")) ||
+    pathname.startsWith(appPath("/cv-optimizer")) ||
+    pathname.startsWith(appPath("/compliance/afa"))
+  ) return "system";
+  return "action";
+}
 
-const SETTINGS_NAV_ITEMS = [
-  { to: appPath("/job-os/settings"), label: "Settings", icon: Settings },
-];
+const SECTION_NAV = {
+  action: [
+    { to: appPath("/job-os/sources"), label: "Sources", icon: Compass },
+  ],
+  pipeline: [
+    { to: appPath("/job-os/roles"), label: "Roles", icon: FileText },
+    { to: appPath("/job-os/applications"), label: "Applications", icon: FileSpreadsheet },
+    { to: appPath("/job-os/outreach"), label: "Outreach", icon: Megaphone },
+  ],
+  system: [
+    { to: appPath("/job-os/companies"), label: "Target Companies", icon: Building2 },
+    { to: appPath("/job-os/assets"), label: "Assets", icon: FolderOpen },
+    { to: appPath("/cv-optimizer"), label: "CV Optimizer", icon: WandSparkles },
+    { to: appPath("/compliance/afa"), label: "AfA Compliance", icon: ShieldCheck },
+    { to: appPath("/job-os/settings"), label: "Settings", icon: Settings },
+  ],
+} as const;
+
+const NAV_LINK_CLASS = ({ isActive }: { isActive: boolean }) =>
+  `text-xs px-3 py-1.5 rounded-md border transition-colors inline-flex items-center gap-1.5 ${
+    isActive
+      ? "bg-neutral-900 text-white border-neutral-900 dark:bg-neutral-100 dark:text-black dark:border-neutral-100"
+      : "bg-white text-neutral-600 border-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:border-neutral-700 dark:hover:bg-neutral-800"
+  }`;
 
 export function JobOsLayout({
   title,
@@ -36,7 +66,7 @@ export function JobOsLayout({
   actions,
   settingsFooter,
 }: {
-  title: string;
+  title?: string;
   subtitle?: string;
   notice?: string | null;
   children: React.ReactNode;
@@ -45,10 +75,13 @@ export function JobOsLayout({
 }) {
   const { session } = useApp();
   const jobOsSync = useJobOsSyncSnapshot();
+  const location = useLocation();
+  const activeSection = getActiveSection(location.pathname);
+  const navItems = SECTION_NAV[activeSection];
+
   const lastSyncedLabel = jobOsSync.lastSyncedAt
     ? new Date(jobOsSync.lastSyncedAt).toLocaleString()
     : "not yet synced";
-  const navItems = JOB_OS_NAV_ITEMS;
 
   const settingsContent = session ? (
     <div className="rounded-md bg-white p-4 text-sm dark:bg-neutral-950">
@@ -71,13 +104,11 @@ export function JobOsLayout({
   return (
     <div className="min-h-screen bg-neutral-50 dark:bg-black">
       <AppNavbar
-        title={title}
-        subtitle={subtitle}
         rightActions={actions}
         settingsContent={settingsContent}
       />
       <div className="border-b border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
-        <div className="max-w-[1800px] mx-auto flex flex-wrap items-center justify-between gap-3 px-6 py-3">
+        <div className="max-w-[1800px] mx-auto px-6 py-3">
           <nav className="flex flex-wrap gap-2">
             {navItems.map((item) => {
               const Icon = item.icon;
@@ -85,13 +116,7 @@ export function JobOsLayout({
                 <NavLink
                   key={item.to}
                   to={item.to}
-                  className={({ isActive }) =>
-                    `text-xs px-3 py-1.5 rounded-md border transition-colors inline-flex items-center gap-1.5 ${
-                      isActive
-                        ? "bg-neutral-900 text-white border-neutral-900 dark:bg-neutral-100 dark:text-black dark:border-neutral-100"
-                        : "bg-white text-neutral-600 border-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:border-neutral-700 dark:hover:bg-neutral-800"
-                    }`
-                  }
+                  className={NAV_LINK_CLASS}
                 >
                   <Icon className="w-3.5 h-3.5" />
                   {item.label}
@@ -99,34 +124,6 @@ export function JobOsLayout({
               );
             })}
           </nav>
-          <div className="flex flex-wrap items-center gap-3">
-            {SETTINGS_NAV_ITEMS.map((item) => {
-              const Icon = item.icon;
-              return (
-                <NavLink
-                  key={item.to}
-                  to={item.to}
-                  className={({ isActive }) =>
-                    `text-xs px-3 py-1.5 rounded-md border transition-colors inline-flex items-center gap-1.5 ${
-                      isActive
-                        ? "bg-neutral-900 text-white border-neutral-900 dark:bg-neutral-100 dark:text-black dark:border-neutral-100"
-                        : "bg-white text-neutral-600 border-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:border-neutral-700 dark:hover:bg-neutral-800"
-                    }`
-                  }
-                >
-                  <Icon className="w-3.5 h-3.5" />
-                  {item.label}
-                </NavLink>
-              );
-            })}
-            <NavLink
-              to={appPath("/cv-optimizer")}
-              className="inline-flex items-center gap-1.5 text-xs font-medium text-neutral-500 transition-colors hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
-            >
-              <WandSparkles className="h-3.5 w-3.5" />
-              CV Optimizer
-            </NavLink>
-          </div>
         </div>
       </div>
       <CommandCenter />
@@ -134,6 +131,12 @@ export function JobOsLayout({
         {notice && (
           <div className="rounded-lg border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/20 px-4 py-3 text-sm text-amber-800 dark:text-amber-300">
             {notice}
+          </div>
+        )}
+        {(title || subtitle) && (
+          <div className="space-y-1">
+            {title && <h1 className="text-xl font-bold text-neutral-900 dark:text-white">{title}</h1>}
+            {subtitle && <p className="text-sm text-neutral-500 dark:text-neutral-400">{subtitle}</p>}
           </div>
         )}
         {children}

--- a/src/app/pages/job-os/JobOsApplicationsPage.tsx
+++ b/src/app/pages/job-os/JobOsApplicationsPage.tsx
@@ -459,8 +459,6 @@ export default function JobOsApplicationsPage() {
 
   return (
     <JobOsLayout
-      title="Applications"
-      subtitle="Pipeline control surface for submitted applications"
       notice={syncNotice}
       settingsFooter={
         <JobOsTransferControls getExportState={exportState} onImportState={replaceState} />

--- a/src/app/pages/job-os/JobOsSourcesPage.tsx
+++ b/src/app/pages/job-os/JobOsSourcesPage.tsx
@@ -560,8 +560,6 @@ export default function JobOsSourcesPage() {
 
   return (
     <JobOsLayout
-      title="Source Hub"
-      subtitle="Search less randomly. Scan high-signal sources, capture roles, and qualify only the roles worth applying to."
       notice={syncNotice}
       settingsFooter={
         <JobOsTransferControls getExportState={exportState} onImportState={replaceState} />


### PR DESCRIPTION
## What

- `AppNavbar.tsx`: header title hardcoded to "JobSprint OS"; per-page title and subtitle removed from global header; NAV_ITEMS updated — Sources matches Action, Roles matches Pipeline, Companies matches System; section matching switched to `startsWith` for sub-routes; mobile drawer title updated to "JobSprint OS"
- `JobOsLayout.tsx`: replaced flat all-items secondary nav with section-aware nav derived from active route; page `title`/`subtitle` now rendered inside `<main>` instead of passed to the header; Settings/CV Optimizer/AfA Compliance moved into System section nav as `NavLink`s
- `JobOsSourcesPage.tsx`, `JobOsApplicationsPage.tsx`: removed `title`/`subtitle` from `<JobOsLayout>` call since both pages already render their own headings via `<AppPageShell>` internally

## Why

The global header was changing its label on every navigation event, and the secondary nav bar showed all eight pages regardless of context. This broke basic orientation — users couldn't tell which section they were in without reading page content. Fixing it now because the Source Hub integration (PR #158) introduces a new entry point into the Action section that needs correct nav matching to be usable.

## How To Test

1. Sign in and navigate to `/app/job-os/sources` — header should read "JobSprint OS", Action tab should be highlighted, secondary nav should show only "Sources"
2. Navigate to `/app/job-os/roles` — Pipeline tab active, secondary nav shows Roles / Applications / Outreach
3. Navigate to `/app/job-os/companies` — System tab active, secondary nav shows Target Companies / Assets / CV Optimizer / AfA Compliance / Settings
4. Navigate to `/app` (Dashboard) — Action tab active
5. Navigate to `/app/cv-optimizer` — System tab active
6. Confirm page titles appear in the content area, not in the header

## Evidence

- Issue: #159
- Demo artifact: N/A — navigation-only refactor, verifiable via local dev server

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit 5903456

## Checklist

- [x] Linked to an issue with clear acceptance criteria
- [x] Scope is limited to the issue
- [x] Local checks pass (`npm run lint && npm run build`)
- [x] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated — nav-only refactor, no user-visible feature; will update if requested
- [x] Demo artifact attached

Closes #159