### PR TITLE
Feat/131 source hub workflow

### DIFF
--- a/src/app/components/AppNavbar.tsx
+++ b/src/app/components/AppNavbar.tsx
@@ -26,7 +26,7 @@ import {
 } from "./ui/sheet";
 
 interface AppNavbarProps {
-  title: string;
+  title?: string;
   subtitle?: string;
   rightActions?: React.ReactNode;
   showSync?: boolean;
@@ -38,34 +38,35 @@ const NAV_ITEMS = [
     to: appPath(),
     label: "Action",
     icon: LayoutDashboard,
-    matches: (pathname: string) => pathname === appPath() || pathname === appPath("/analytics"),
+    matches: (pathname: string) =>
+      pathname === appPath() ||
+      pathname === appPath("/analytics") ||
+      pathname.startsWith(appPath("/job-os/sources")),
   },
   {
-    to: appPath("/job-os/applications"),
+    to: appPath("/job-os/roles"),
     label: "Pipeline",
     icon: BriefcaseBusiness,
     matches: (pathname: string) =>
       pathname === appPath("/job-os") ||
-      pathname === appPath("/job-os/applications") ||
-      pathname === appPath("/job-os/outreach"),
+      pathname.startsWith(appPath("/job-os/roles")) ||
+      pathname.startsWith(appPath("/job-os/applications")) ||
+      pathname.startsWith(appPath("/job-os/outreach")),
   },
   {
-    to: appPath("/job-os/assets"),
+    to: appPath("/job-os/companies"),
     label: "System",
     icon: FolderOpen,
     matches: (pathname: string) =>
-      pathname === appPath("/job-os/assets") ||
-      pathname === appPath("/job-os/companies") ||
-      pathname === appPath("/job-os/roles") ||
-      pathname === appPath("/job-os/settings") ||
-      pathname === appPath("/cv-optimizer") ||
-      pathname === appPath("/compliance/afa"),
+      pathname.startsWith(appPath("/job-os/companies")) ||
+      pathname.startsWith(appPath("/job-os/assets")) ||
+      pathname.startsWith(appPath("/job-os/settings")) ||
+      pathname.startsWith(appPath("/cv-optimizer")) ||
+      pathname.startsWith(appPath("/compliance/afa")),
   },
 ];
 
 export function AppNavbar({
-  title,
-  subtitle,
   rightActions,
   showSync = false,
   settingsContent,
@@ -77,7 +78,6 @@ export function AppNavbar({
   const hasSettingsMenu = Boolean(settingsContent);
   const [mobileOpen, setMobileOpen] = useState(false);
 
-  // Close drawer on navigation
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setMobileOpen(false); }, [location.pathname]);
 
@@ -104,7 +104,7 @@ export function AppNavbar({
             </button>
 
             <span className="text-base font-bold text-white tracking-tight">
-              {title}
+              JobSprint OS
             </span>
 
             {/* Desktop nav */}
@@ -187,12 +187,6 @@ export function AppNavbar({
             </button>
           </div>
         </div>
-
-        {subtitle && (
-          <div className="pb-1.5 -mt-1 text-xs text-white/45 truncate">
-            {subtitle}
-          </div>
-        )}
       </div>
 
       {/* Mobile nav drawer */}
@@ -200,7 +194,7 @@ export function AppNavbar({
         <SheetContent side="left" className="w-72 p-0 flex flex-col">
           <SheetHeader className="px-5 py-4 border-b border-neutral-200 dark:border-neutral-800">
             <SheetTitle className="text-base font-bold tracking-tight">
-              JobSprint
+              JobSprint OS
             </SheetTitle>
           </SheetHeader>
 

--- a/src/app/components/job-os/JobOsLayout.tsx
+++ b/src/app/components/job-os/JobOsLayout.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "react-router";
+import { NavLink, useLocation } from "react-router";
 import { CommandCenter } from "./CommandCenter";
 import {
   Building2,
@@ -8,6 +8,7 @@ import {
   FolderOpen,
   Megaphone,
   Settings,
+  ShieldCheck,
   WandSparkles,
 } from "lucide-react";
 import { AppNavbar } from "../AppNavbar";
@@ -15,18 +16,47 @@ import { useApp } from "../../context";
 import { useJobOsSyncSnapshot } from "../../services/jobOsSync";
 import { appPath } from "../../routing";
 
-const JOB_OS_NAV_ITEMS = [
-  { to: appPath("/job-os/sources"), label: "Sources", icon: Compass },
-  { to: appPath("/job-os/companies"), label: "Companies", icon: Building2 },
-  { to: appPath("/job-os/roles"), label: "Roles", icon: FileText },
-  { to: appPath("/job-os/applications"), label: "Applications", icon: FileSpreadsheet },
-  { to: appPath("/job-os/outreach"), label: "Outreach", icon: Megaphone },
-  { to: appPath("/job-os/assets"), label: "Assets", icon: FolderOpen },
-];
+function getActiveSection(pathname: string): "action" | "pipeline" | "system" {
+  if (
+    pathname === appPath("/job-os") ||
+    pathname.startsWith(appPath("/job-os/roles")) ||
+    pathname.startsWith(appPath("/job-os/applications")) ||
+    pathname.startsWith(appPath("/job-os/outreach"))
+  ) return "pipeline";
+  if (
+    pathname.startsWith(appPath("/job-os/companies")) ||
+    pathname.startsWith(appPath("/job-os/assets")) ||
+    pathname.startsWith(appPath("/job-os/settings")) ||
+    pathname.startsWith(appPath("/cv-optimizer")) ||
+    pathname.startsWith(appPath("/compliance/afa"))
+  ) return "system";
+  return "action";
+}
 
-const SETTINGS_NAV_ITEMS = [
-  { to: appPath("/job-os/settings"), label: "Settings", icon: Settings },
-];
+const SECTION_NAV = {
+  action: [
+    { to: appPath("/job-os/sources"), label: "Sources", icon: Compass },
+  ],
+  pipeline: [
+    { to: appPath("/job-os/roles"), label: "Roles", icon: FileText },
+    { to: appPath("/job-os/applications"), label: "Applications", icon: FileSpreadsheet },
+    { to: appPath("/job-os/outreach"), label: "Outreach", icon: Megaphone },
+  ],
+  system: [
+    { to: appPath("/job-os/companies"), label: "Target Companies", icon: Building2 },
+    { to: appPath("/job-os/assets"), label: "Assets", icon: FolderOpen },
+    { to: appPath("/cv-optimizer"), label: "CV Optimizer", icon: WandSparkles },
+    { to: appPath("/compliance/afa"), label: "AfA Compliance", icon: ShieldCheck },
+    { to: appPath("/job-os/settings"), label: "Settings", icon: Settings },
+  ],
+} as const;
+
+const NAV_LINK_CLASS = ({ isActive }: { isActive: boolean }) =>
+  `text-xs px-3 py-1.5 rounded-md border transition-colors inline-flex items-center gap-1.5 ${
+    isActive
+      ? "bg-neutral-900 text-white border-neutral-900 dark:bg-neutral-100 dark:text-black dark:border-neutral-100"
+      : "bg-white text-neutral-600 border-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:border-neutral-700 dark:hover:bg-neutral-800"
+  }`;
 
 export function JobOsLayout({
   title,
@@ -36,7 +66,7 @@ export function JobOsLayout({
   actions,
   settingsFooter,
 }: {
-  title: string;
+  title?: string;
   subtitle?: string;
   notice?: string | null;
   children: React.ReactNode;
@@ -45,10 +75,13 @@ export function JobOsLayout({
 }) {
   const { session } = useApp();
   const jobOsSync = useJobOsSyncSnapshot();
+  const location = useLocation();
+  const activeSection = getActiveSection(location.pathname);
+  const navItems = SECTION_NAV[activeSection];
+
   const lastSyncedLabel = jobOsSync.lastSyncedAt
     ? new Date(jobOsSync.lastSyncedAt).toLocaleString()
     : "not yet synced";
-  const navItems = JOB_OS_NAV_ITEMS;
 
   const settingsContent = session ? (
     <div className="rounded-md bg-white p-4 text-sm dark:bg-neutral-950">
@@ -71,13 +104,11 @@ export function JobOsLayout({
   return (
     <div className="min-h-screen bg-neutral-50 dark:bg-black">
       <AppNavbar
-        title={title}
-        subtitle={subtitle}
         rightActions={actions}
         settingsContent={settingsContent}
       />
       <div className="border-b border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
-        <div className="max-w-[1800px] mx-auto flex flex-wrap items-center justify-between gap-3 px-6 py-3">
+        <div className="max-w-[1800px] mx-auto px-6 py-3">
           <nav className="flex flex-wrap gap-2">
             {navItems.map((item) => {
               const Icon = item.icon;
@@ -85,13 +116,7 @@ export function JobOsLayout({
                 <NavLink
                   key={item.to}
                   to={item.to}
-                  className={({ isActive }) =>
-                    `text-xs px-3 py-1.5 rounded-md border transition-colors inline-flex items-center gap-1.5 ${
-                      isActive
-                        ? "bg-neutral-900 text-white border-neutral-900 dark:bg-neutral-100 dark:text-black dark:border-neutral-100"
-                        : "bg-white text-neutral-600 border-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:border-neutral-700 dark:hover:bg-neutral-800"
-                    }`
-                  }
+                  className={NAV_LINK_CLASS}
                 >
                   <Icon className="w-3.5 h-3.5" />
                   {item.label}
@@ -99,34 +124,6 @@ export function JobOsLayout({
               );
             })}
           </nav>
-          <div className="flex flex-wrap items-center gap-3">
-            {SETTINGS_NAV_ITEMS.map((item) => {
-              const Icon = item.icon;
-              return (
-                <NavLink
-                  key={item.to}
-                  to={item.to}
-                  className={({ isActive }) =>
-                    `text-xs px-3 py-1.5 rounded-md border transition-colors inline-flex items-center gap-1.5 ${
-                      isActive
-                        ? "bg-neutral-900 text-white border-neutral-900 dark:bg-neutral-100 dark:text-black dark:border-neutral-100"
-                        : "bg-white text-neutral-600 border-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:border-neutral-700 dark:hover:bg-neutral-800"
-                    }`
-                  }
-                >
-                  <Icon className="w-3.5 h-3.5" />
-                  {item.label}
-                </NavLink>
-              );
-            })}
-            <NavLink
-              to={appPath("/cv-optimizer")}
-              className="inline-flex items-center gap-1.5 text-xs font-medium text-neutral-500 transition-colors hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
-            >
-              <WandSparkles className="h-3.5 w-3.5" />
-              CV Optimizer
-            </NavLink>
-          </div>
         </div>
       </div>
       <CommandCenter />
@@ -134,6 +131,12 @@ export function JobOsLayout({
         {notice && (
           <div className="rounded-lg border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/20 px-4 py-3 text-sm text-amber-800 dark:text-amber-300">
             {notice}
+          </div>
+        )}
+        {(title || subtitle) && (
+          <div className="space-y-1">
+            {title && <h1 className="text-xl font-bold text-neutral-900 dark:text-white">{title}</h1>}
+            {subtitle && <p className="text-sm text-neutral-500 dark:text-neutral-400">{subtitle}</p>}
           </div>
         )}
         {children}

--- a/src/app/pages/job-os/JobOsApplicationsPage.tsx
+++ b/src/app/pages/job-os/JobOsApplicationsPage.tsx
@@ -459,8 +459,6 @@ export default function JobOsApplicationsPage() {
 
   return (
     <JobOsLayout
-      title="Applications"
-      subtitle="Pipeline control surface for submitted applications"
       notice={syncNotice}
       settingsFooter={
         <JobOsTransferControls getExportState={exportState} onImportState={replaceState} />

--- a/src/app/pages/job-os/JobOsSourcesPage.tsx
+++ b/src/app/pages/job-os/JobOsSourcesPage.tsx
@@ -560,8 +560,6 @@ export default function JobOsSourcesPage() {
 
   return (
     <JobOsLayout
-      title="Source Hub"
-      subtitle="Search less randomly. Scan high-signal sources, capture roles, and qualify only the roles worth applying to."
       notice={syncNotice}
       settingsFooter={
         <JobOsTransferControls getExportState={exportState} onImportState={replaceState} />


### PR DESCRIPTION
## What

Fixes the navigation shell so section context is always clear and the header
label is stable across all pages.

**`AppNavbar.tsx`**
- Header title is now hardcoded to "JobSprint OS" — it no longer changes per
  page
- Removed the per-page subtitle block from the global header
- Fixed `NAV_ITEMS` section matching:
  - Action: matches `/app`, `/app/analytics`, and any `/app/job-os/sources*`
  - Pipeline: matches `/app/job-os/roles*`, `/app/job-os/applications*`,
    `/app/job-os/outreach*`
  - System: matches `/app/job-os/companies*`, `/app/job-os/assets*`,
    `/app/job-os/settings*`, `/app/cv-optimizer*`, `/app/compliance/afa*`
- Switched from exact `===` matching to `startsWith` so sub-routes stay active
- Pipeline tab now links to `/app/job-os/roles`; System tab links to
  `/app/job-os/companies`
- Mobile drawer title updated to "JobSprint OS"

**`JobOsLayout.tsx`**
- Replaced the flat all-eight-items secondary nav with a section-aware nav
  derived from the current `location.pathname`:
  - Action section → Sources only
  - Pipeline section → Roles / Applications / Outreach
  - System section → Target Companies / Assets / CV Optimizer / AfA Compliance
    / Settings
- CV Optimizer and AfA Compliance converted from plain text links to proper
  `NavLink`s with active styles, both included in the System section
- Settings moved from the right-side secondary bar into the System section list
- Page `title` and `subtitle` props now rendered inside `<main>` (content area)
  rather than passed up to the global header

**`JobOsSourcesPage.tsx`, `JobOsApplicationsPage.tsx`**
- Removed `title` / `subtitle` from the `<JobOsLayout>` call — both pages
  already render their own page heading via `<AppPageShell>` internally,
  so the layout-level title would have produced a duplicate

## Why

The global header was mutating its label on every navigation event, making it
impossible to use as a stable orientation anchor. The secondary nav showed all
eight Job OS pages regardless of which section the user was in. Both problems
became more visible with the Source Hub addition (PR #158) which introduced a
new entry point that wasn't reflected in any nav section. This refactor
establishes a clear three-section information architecture before further pages
are added.

## How To Test

1. Sign in → header should always read "JobSprint OS" on every page
2. Navigate to `/app/job-os/sources` → Action tab highlighted, secondary nav
   shows "Sources" only
3. Navigate to `/app/job-os/roles` → Pipeline tab highlighted, secondary nav
   shows Roles / Applications / Outreach
4. Navigate to `/app/job-os/companies` → System tab highlighted, secondary nav
   shows Target Companies / Assets / CV Optimizer / AfA Compliance / Settings
5. Navigate to `/app` (Dashboard) → Action tab highlighted
6. Navigate to `/app/cv-optimizer` → System tab highlighted
7. Navigate to `/app/compliance/afa` → System tab highlighted
8. Confirm page titles appear inside the content area, not in the header bar

## Evidence

- Issue: #159
- Demo artifact: N/A — navigation-only refactor; verify via local dev server

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit 5903456

## Checklist

- [x] Linked to an issue with clear acceptance criteria
- [x] Scope is limited to the issue
- [x] Local checks pass (`npm run lint && npm run build`)
- [x] Docs updated if behavior or workflow changed
- [ ] `CHANGELOG.md` updated — nav-only structural refactor, no user-visible feature added; can update on request
- [x] Demo artifact attached

Closes #159