### PR TITLE
refactor(ux): Source Hub tabs, simplified interface, single role entry point

### DIFF
--- a/src/app/components/AppNavbar.tsx
+++ b/src/app/components/AppNavbar.tsx
@@ -55,7 +55,7 @@ const NAV_ITEMS = [
   },
   {
     to: appPath("/job-os/companies"),
-    label: "System",
+    label: "Companies & System",
     icon: FolderOpen,
     matches: (pathname: string) =>
       pathname.startsWith(appPath("/job-os/companies")) ||

--- a/src/app/components/job-os/JobOsLayout.tsx
+++ b/src/app/components/job-os/JobOsLayout.tsx
@@ -45,7 +45,7 @@ const SECTION_NAV = {
     { to: appPath("/job-os/outreach"), label: "Outreach", icon: Megaphone },
   ],
   system: [
-    { to: appPath("/job-os/companies"), label: "Target Companies", icon: Building2 },
+    { to: appPath("/job-os/companies"), label: "Companies", icon: Building2 },
     { to: appPath("/job-os/assets"), label: "Assets", icon: FolderOpen },
     { to: appPath("/cv-optimizer"), label: "CV Optimizer", icon: WandSparkles },
     { to: appPath("/compliance/afa"), label: "AfA Compliance", icon: ShieldCheck },

--- a/src/app/components/job-os/JobOsLayout.tsx
+++ b/src/app/components/job-os/JobOsLayout.tsx
@@ -6,6 +6,7 @@ import {
   FileSpreadsheet,
   FileText,
   FolderOpen,
+  LayoutDashboard,
   Megaphone,
   Settings,
   ShieldCheck,
@@ -35,6 +36,7 @@ function getActiveSection(pathname: string): "action" | "pipeline" | "system" {
 
 const SECTION_NAV = {
   action: [
+    { to: appPath(), label: "Command Center", icon: LayoutDashboard },
     { to: appPath("/job-os/sources"), label: "Sources", icon: Compass },
   ],
   pipeline: [

--- a/src/app/pages/dashboard/DashboardPage.tsx
+++ b/src/app/pages/dashboard/DashboardPage.tsx
@@ -3,7 +3,7 @@ import { NavLink, useNavigate } from "react-router";
 import { ChevronDown, ChevronUp, Compass, LayoutDashboard, Layers3 } from "lucide-react";
 import { useApp } from "../../context";
 import { useJobOs } from "../../hooks/useJobOs";
-import { UnifiedAddModal } from "../../components/job-os/UnifiedAddModal";
+
 import { useJobOsSyncSnapshot } from "../../services/jobOsSync";
 import {
   getNextActions,
@@ -20,7 +20,7 @@ import { TodayPanel } from "../../components/dashboard/TodayPanel";
 import { HotOpportunities } from "../../components/dashboard/HotOpportunities";
 import { PipelineStats } from "../../components/dashboard/PipelineStats";
 import { ProbabilityPanel } from "../../components/dashboard/ProbabilityPanel";
-import { QuickActions } from "../../components/dashboard/QuickActions";
+
 import { FirstRunScreen } from "../../components/dashboard/FirstRunScreen";
 import { AppPageShell } from "../../components/layout/AppPageShell";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../../components/ui/collapsible";
@@ -32,7 +32,6 @@ export function DashboardPage() {
   const navigate = useNavigate();
   const jobOsSync = useJobOsSyncSnapshot();
   const [supportOpen, setSupportOpen] = useState(false);
-  const [addModalOpen, setAddModalOpen] = useState(false);
   const {
     companies,
     roles,
@@ -182,7 +181,6 @@ export function DashboardPage() {
 
             <div className="min-w-0 lg:self-start">
               <div className="space-y-4 lg:sticky lg:top-24">
-                <QuickActions onAddRole={() => setAddModalOpen(true)} />
                 <WeeklyExecutionPanel applications={applications} />
                 <PipelineStats stats={stats} isLoading={loading} />
                 <ProbabilityPanel stats={stats} isLoading={loading} />
@@ -223,14 +221,6 @@ export function DashboardPage() {
         </AppPageShell>
       </main>
 
-      <UnifiedAddModal
-        open={addModalOpen}
-        onClose={() => setAddModalOpen(false)}
-        companies={companies}
-        addCompany={addCompany}
-        addRole={addRole}
-        addApplication={addApplication}
-      />
     </div>
   );
 }

--- a/src/app/pages/dashboard/DashboardPage.tsx
+++ b/src/app/pages/dashboard/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
-import { useNavigate } from "react-router";
-import { ChevronDown, ChevronUp, Layers3 } from "lucide-react";
+import { NavLink, useNavigate } from "react-router";
+import { ChevronDown, ChevronUp, Compass, LayoutDashboard, Layers3 } from "lucide-react";
 import { useApp } from "../../context";
 import { useJobOs } from "../../hooks/useJobOs";
 import { UnifiedAddModal } from "../../components/job-os/UnifiedAddModal";
@@ -116,6 +116,32 @@ export function DashboardPage() {
         showSync
         settingsContent={settingsContent}
       />
+      <div className="border-b border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
+        <div className="max-w-[1800px] mx-auto px-6 py-3">
+          <nav className="flex flex-wrap gap-2">
+            {[
+              { to: appPath(), label: "Command Center", icon: LayoutDashboard, end: true },
+              { to: appPath("/job-os/sources"), label: "Sources", icon: Compass, end: false },
+            ].map(({ to, label, icon: Icon, end }) => (
+              <NavLink
+                key={to}
+                to={to}
+                end={end}
+                className={({ isActive }) =>
+                  `text-xs px-3 py-1.5 rounded-md border transition-colors inline-flex items-center gap-1.5 ${
+                    isActive
+                      ? "bg-neutral-900 text-white border-neutral-900 dark:bg-neutral-100 dark:text-black dark:border-neutral-100"
+                      : "bg-white text-neutral-600 border-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:border-neutral-700 dark:hover:bg-neutral-800"
+                  }`
+                }
+              >
+                <Icon className="w-3.5 h-3.5" />
+                {label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+      </div>
 
       <main className="mx-auto max-w-[1800px] px-4 py-5 sm:px-6">
         {holdDashboard ? (

--- a/src/app/pages/job-os/JobOsCompaniesPage.tsx
+++ b/src/app/pages/job-os/JobOsCompaniesPage.tsx
@@ -549,8 +549,8 @@ export default function JobOsCompaniesPage() {
 
   return (
     <JobOsLayout
-      title="Company Engine"
-      subtitle="Account-based target company tracking"
+      title="Companies"
+      subtitle="Track companies by status — Research, Target, Active — and route them into roles"
       notice={syncNotice}
       settingsFooter={<JobOsTransferControls getExportState={exportState} onImportState={replaceState} />}
     >

--- a/src/app/pages/job-os/JobOsRolesPage.tsx
+++ b/src/app/pages/job-os/JobOsRolesPage.tsx
@@ -24,6 +24,8 @@ import {
   ChevronRight,
   Pencil,
   Rocket,
+  Search,
+  SlidersHorizontal,
   Trash2,
   WandSparkles,
   X,
@@ -114,6 +116,8 @@ export default function JobOsRolesPage() {
     fitMin: "all",
     status: "all",
   });
+  const [unifiedSearch, setUnifiedSearch] = useState("");
+  const [showMoreFilters, setShowMoreFilters] = useState(false);
   const [selectedJdRoleId, setSelectedJdRoleId] = useState<string | null>(null);
   const [draft, setDraft] = useState<Omit<JobOsRole, "id" | "createdAt" | "updatedAt">>({
     companyId: "",
@@ -144,15 +148,16 @@ export default function JobOsRolesPage() {
   }, [companies, companySearch]);
 
   const filtered = useMemo(() => {
-    const companyQuery = tableFilters.company.trim().toLowerCase();
-    const titleQuery = tableFilters.title.trim().toLowerCase();
+    const searchQuery = unifiedSearch.trim().toLowerCase();
     const locationQuery = tableFilters.location.trim().toLowerCase();
 
     return roles.filter((role) => {
       const companyName = companiesById.get(role.companyId)?.name ?? "";
 
-      if (companyQuery && !companyName.toLowerCase().includes(companyQuery)) return false;
-      if (titleQuery && !role.title.toLowerCase().includes(titleQuery)) return false;
+      if (searchQuery) {
+        const haystack = `${companyName} ${role.title}`.toLowerCase();
+        if (!haystack.includes(searchQuery)) return false;
+      }
       if (locationQuery && !role.location.toLowerCase().includes(locationQuery)) return false;
       if (
         tableFilters.seniority !== "all" &&
@@ -168,7 +173,7 @@ export default function JobOsRolesPage() {
 
       return true;
     });
-  }, [companiesById, roles, tableFilters]);
+  }, [companiesById, roles, tableFilters, unifiedSearch]);
 
   const sortedRoles = useMemo(() => {
     const statusRank: Record<RoleStatus, number> = {
@@ -235,7 +240,7 @@ export default function JobOsRolesPage() {
 
   useEffect(() => {
     resetRolesPage();
-  }, [resetRolesPage, sortDir, sortKey, tableFilters]);
+  }, [resetRolesPage, sortDir, sortKey, tableFilters, unifiedSearch]);
 
   const applicationRoleIds = useMemo(
     () => new Set(applications.map((application) => application.roleId).filter(Boolean)),
@@ -552,6 +557,94 @@ export default function JobOsRolesPage() {
         ) : null}
       </Card>
 
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-[200px] flex-1">
+          <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            className="h-9 pl-8 text-sm"
+            placeholder="Search company or title…"
+            value={unifiedSearch}
+            onChange={(e) => setUnifiedSearch(e.target.value)}
+          />
+        </div>
+        <Select value={tableFilters.status} onValueChange={(value) => updateTableFilter("status", value)}>
+          <SelectTrigger className="h-9 w-[150px] text-sm">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            {ROLE_STATUSES.map((status) => (
+              <SelectItem key={status} value={status}>{status}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setShowMoreFilters((v) => !v)}
+          className={`gap-1.5 text-xs ${showMoreFilters ? "text-foreground" : "text-muted-foreground"}`}
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+          {showMoreFilters ? "Fewer filters" : "More filters"}
+        </Button>
+        {(unifiedSearch || tableFilters.status !== "all" || tableFilters.location || tableFilters.seniority !== "all" || tableFilters.track !== "all" || tableFilters.fitMin !== "all") && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-xs text-muted-foreground"
+            onClick={() => {
+              setUnifiedSearch("");
+              setTableFilters({ company: "", title: "", location: "", seniority: "all", track: "all", fitMin: "all", status: "all" });
+            }}
+          >
+            Clear
+          </Button>
+        )}
+      </div>
+      {showMoreFilters && (
+        <div className="flex flex-wrap gap-2">
+          <Input
+            value={tableFilters.location}
+            onChange={(event) => updateTableFilter("location", event.target.value)}
+            placeholder="Location"
+            className="h-9 w-[150px] text-sm"
+          />
+          <Select value={tableFilters.seniority} onValueChange={(value) => updateTableFilter("seniority", value)}>
+            <SelectTrigger className="h-9 w-[130px] text-sm">
+              <SelectValue placeholder="Seniority" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All seniority</SelectItem>
+              {SENIORITY_OPTIONS.map((option) => (
+                <SelectItem key={option} value={option}>{option}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={tableFilters.track} onValueChange={(value) => updateTableFilter("track", value)}>
+            <SelectTrigger className="h-9 w-[160px] text-sm">
+              <SelectValue placeholder="All tracks" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All tracks</SelectItem>
+              <SelectItem value="TPM">TPM</SelectItem>
+              <SelectItem value="Product Engineer">Product Engineer</SelectItem>
+              <SelectItem value="Systems PM">Systems PM</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={tableFilters.fitMin} onValueChange={(value) => updateTableFilter("fitMin", value)}>
+            <SelectTrigger className="h-9 w-[110px] text-sm">
+              <SelectValue placeholder="Fit score" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All fit</SelectItem>
+              {FIT_FILTER_VALUES.filter((value) => value !== "all").map((value) => (
+                <SelectItem key={value} value={value}>{value}+ fit</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
       <Card>
         <CardHeader>
           <CardTitle className="text-sm">Roles Pipeline</CardTitle>
@@ -582,105 +675,6 @@ export default function JobOsRolesPage() {
                 <TableHead>{renderSortHeader("Added", "createdAt")}</TableHead>
                 <TableHead>JD</TableHead>
                 <TableHead className="text-right">Actions</TableHead>
-              </TableRow>
-              <TableRow className="bg-muted/20 hover:bg-muted/20">
-                <TableHead>
-                  <Input
-                    value={tableFilters.company}
-                    onChange={(event) => updateTableFilter("company", event.target.value)}
-                    placeholder="Filter company"
-                    className="h-8 min-w-[140px]"
-                  />
-                </TableHead>
-                <TableHead>
-                  <Input
-                    value={tableFilters.title}
-                    onChange={(event) => updateTableFilter("title", event.target.value)}
-                    placeholder="Filter title"
-                    className="h-8 min-w-[160px]"
-                  />
-                </TableHead>
-                <TableHead>
-                  <Input
-                    value={tableFilters.location}
-                    onChange={(event) => updateTableFilter("location", event.target.value)}
-                    placeholder="Filter location"
-                    className="h-8 min-w-[130px]"
-                  />
-                </TableHead>
-                <TableHead>
-                  <Select
-                    value={tableFilters.seniority}
-                    onValueChange={(value) => updateTableFilter("seniority", value)}
-                  >
-                    <SelectTrigger className="h-8 min-w-[120px]">
-                      <SelectValue placeholder="All" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All</SelectItem>
-                      {SENIORITY_OPTIONS.map((option) => (
-                        <SelectItem key={option} value={option}>
-                          {option}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </TableHead>
-                <TableHead>
-                  <Select
-                    value={tableFilters.track}
-                    onValueChange={(value) => updateTableFilter("track", value)}
-                  >
-                    <SelectTrigger className="h-8 min-w-[140px]">
-                      <SelectValue placeholder="All tracks" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All tracks</SelectItem>
-                      <SelectItem value="TPM">TPM</SelectItem>
-                      <SelectItem value="Product Engineer">Product Engineer</SelectItem>
-                      <SelectItem value="Systems PM">Systems PM</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </TableHead>
-                <TableHead>
-                  <Select
-                    value={tableFilters.fitMin}
-                    onValueChange={(value) => updateTableFilter("fitMin", value)}
-                  >
-                    <SelectTrigger className="h-8 min-w-[96px]">
-                      <SelectValue placeholder="All" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All</SelectItem>
-                      {FIT_FILTER_VALUES.filter((value) => value !== "all").map((value) => (
-                        <SelectItem key={value} value={value}>
-                          {value}+
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </TableHead>
-                <TableHead>
-                  <Select
-                    value={tableFilters.status}
-                    onValueChange={(value) => updateTableFilter("status", value)}
-                  >
-                    <SelectTrigger className="h-8 min-w-[130px]">
-                      <SelectValue placeholder="All statuses" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All statuses</SelectItem>
-                      {ROLE_STATUSES.map((status) => (
-                        <SelectItem key={status} value={status}>
-                          {status}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </TableHead>
-                <TableHead />
-                <TableHead />
-                <TableHead />
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/src/app/pages/job-os/JobOsRolesPage.tsx
+++ b/src/app/pages/job-os/JobOsRolesPage.tsx
@@ -1,6 +1,5 @@
 import { Link } from "react-router";
 import { useEffect, useMemo, useState } from "react";
-import { useUnsavedChanges } from "../../hooks/useUnsavedChanges";
 import { toast } from "sonner";
 import {
   AlertDialog,
@@ -18,10 +17,7 @@ import {
   ArrowUp,
   ArrowUpDown,
   BriefcaseBusiness,
-  Check,
   CheckCircle2,
-  ChevronDown,
-  ChevronRight,
   Pencil,
   Rocket,
   Search,
@@ -89,7 +85,6 @@ export default function JobOsRolesPage() {
     applications,
     assets,
     cvProfiles,
-    addRole,
     updateRole,
     addApplication,
     removeRole,
@@ -98,12 +93,8 @@ export default function JobOsRolesPage() {
     replaceState,
   } = useJobOsContext();
 
-  const [addFormOpen, setAddFormOpen] = useState(false);
-  const [companySearch, setCompanySearch] = useState("");
-  const [companyOptionsOpen, setCompanyOptionsOpen] = useState(false);
   const [editingRoleId, setEditingRoleId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState<Omit<JobOsRole, "id" | "createdAt" | "updatedAt"> | null>(null);
-  const [formNotice, setFormNotice] = useState<string | null>(null);
   const [actionNotice, setActionNotice] = useState<{ tone: "success" | "error"; message: string } | null>(null);
   const [sortKey, setSortKey] = useState<RoleSortKey>("createdAt");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
@@ -119,33 +110,11 @@ export default function JobOsRolesPage() {
   const [unifiedSearch, setUnifiedSearch] = useState("");
   const [showMoreFilters, setShowMoreFilters] = useState(false);
   const [selectedJdRoleId, setSelectedJdRoleId] = useState<string | null>(null);
-  const [draft, setDraft] = useState<Omit<JobOsRole, "id" | "createdAt" | "updatedAt">>({
-    companyId: "",
-    title: "",
-    url: "",
-    location: "",
-    seniority: "",
-    track: "TPM",
-    fitScore: 3,
-    status: "to_apply",
-    origin: "self_sourced",
-    jobDescription: "",
-    jobDescriptionUpdatedAt: undefined,
-  });
 
   const companiesById = useMemo(
     () => new Map(companies.map((company) => [company.id, company])),
     [companies]
   );
-  const selectedDraftCompany = draft.companyId ? companiesById.get(draft.companyId) : null;
-  const filteredCompanyOptions = useMemo(() => {
-    const query = companySearch.trim().toLowerCase();
-    const matches = query
-      ? companies.filter((company) => company.name.toLowerCase().includes(query))
-      : companies;
-
-    return matches.slice(0, 50);
-  }, [companies, companySearch]);
 
   const filtered = useMemo(() => {
     const searchQuery = unifiedSearch.trim().toLowerCase();
@@ -316,51 +285,6 @@ export default function JobOsRolesPage() {
     toast.success("Role updated");
   }
 
-  async function handleAddRole(): Promise<void> {
-    const missingFields: string[] = [];
-    if (!draft.companyId) missingFields.push("company");
-    if (!draft.title.trim()) missingFields.push("role title");
-
-    if (missingFields.length > 0) {
-      setFormNotice(`Add a ${missingFields.join(" and ")} before creating the role.`);
-      return;
-    }
-
-    try {
-      setFormNotice("Saving role...");
-      const createdId = await addRole({
-        ...draft,
-        title: draft.title.trim(),
-        seniority: normalizeSeniority(draft.seniority),
-        jobDescriptionUpdatedAt: draft.jobDescription?.trim() ? new Date().toISOString() : undefined,
-      });
-
-      if (!createdId) {
-        setFormNotice("Role could not be created.");
-        return;
-      }
-
-      setDraft({
-        companyId: "",
-        title: "",
-        url: "",
-        location: "",
-        seniority: "",
-        track: "TPM",
-        fitScore: 3,
-        status: "to_apply",
-        origin: "self_sourced",
-        jobDescription: "",
-        jobDescriptionUpdatedAt: undefined,
-      });
-      setCompanySearch("");
-      setFormNotice("");
-      toast.success("Role added");
-    } catch (error) {
-      setFormNotice(error instanceof Error ? error.message : "Role could not be created.");
-    }
-  }
-
   async function handleAddApplication(role: JobOsRole): Promise<void> {
     if (applicationRoleIds.has(role.id)) {
       setActionNotice({
@@ -401,21 +325,6 @@ export default function JobOsRolesPage() {
     }
   }
 
-  const isAddFormDirty =
-    addFormOpen &&
-    (draft.companyId !== "" ||
-      draft.title.trim() !== "" ||
-      (draft.url ?? "").trim() !== "" ||
-      (draft.location ?? "").trim() !== "" ||
-      (draft.jobDescription ?? "").trim() !== "");
-  const { confirmDiscard: confirmAddFormDiscard } = useUnsavedChanges(isAddFormDirty);
-
-  function handleToggleAddForm() {
-    if (addFormOpen && !confirmAddFormDiscard()) return;
-    setAddFormOpen((value) => !value);
-    setCompanyOptionsOpen(false);
-  }
-
   return (
     <JobOsLayout
       title="Roles"
@@ -423,140 +332,6 @@ export default function JobOsRolesPage() {
       notice={syncNotice}
       settingsFooter={<JobOsTransferControls getExportState={exportState} onImportState={replaceState} />}
     >
-      <Card>
-        <CardHeader className="pb-0">
-          <button
-            type="button"
-            onClick={handleToggleAddForm}
-            className="flex items-center gap-1.5 group"
-          >
-            {addFormOpen ? (
-              <ChevronDown className="h-4 w-4 text-neutral-400 transition-colors group-hover:text-foreground" />
-            ) : (
-              <ChevronRight className="h-4 w-4 text-neutral-400 transition-colors group-hover:text-foreground" />
-            )}
-            <CardTitle className="text-sm select-none">Add Role</CardTitle>
-          </button>
-        </CardHeader>
-        {addFormOpen ? (
-          <CardContent className="grid gap-3 pt-4 md:grid-cols-4">
-            <div className="relative">
-              <Input
-                value={companyOptionsOpen ? companySearch : selectedDraftCompany?.name ?? companySearch}
-                onChange={(event) => {
-                  setCompanySearch(event.target.value);
-                  setCompanyOptionsOpen(true);
-                  setDraft((current) => ({ ...current, companyId: "" }));
-                }}
-                onFocus={() => {
-                  setCompanySearch(selectedDraftCompany?.name ?? companySearch);
-                  setCompanyOptionsOpen(true);
-                }}
-                onBlur={() => {
-                  window.setTimeout(() => setCompanyOptionsOpen(false), 120);
-                }}
-                placeholder="Company"
-                autoComplete="off"
-              />
-              {companyOptionsOpen ? (
-                <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-64 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md">
-                  {filteredCompanyOptions.length > 0 ? (
-                    filteredCompanyOptions.map((company) => (
-                      <button
-                        key={company.id}
-                        type="button"
-                        className="flex w-full items-center gap-2 rounded-sm px-2 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-                        onMouseDown={(event) => event.preventDefault()}
-                        onClick={() => {
-                          setDraft((current) => ({ ...current, companyId: company.id }));
-                          setCompanySearch(company.name);
-                          setCompanyOptionsOpen(false);
-                        }}
-                      >
-                        <Check
-                          className={`h-4 w-4 ${
-                            draft.companyId === company.id ? "opacity-100" : "opacity-0"
-                          }`}
-                        />
-                        <span className="truncate">{company.name}</span>
-                      </button>
-                    ))
-                  ) : (
-                    <div className="px-2 py-3 text-sm text-muted-foreground">
-                      No company found.
-                    </div>
-                  )}
-                </div>
-              ) : null}
-            </div>
-            <Input value={draft.title} onChange={(event) => setDraft((current) => ({ ...current, title: event.target.value }))} placeholder="Role title" />
-            <Select value={draft.origin ?? "self_sourced"} onValueChange={(value) => setDraft((current) => ({ ...current, origin: value as RoleOrigin }))}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="self_sourced">Self-sourced</SelectItem>
-                <SelectItem value="recruiter">Recruiter contacted me</SelectItem>
-              </SelectContent>
-            </Select>
-            <Input
-              value={draft.url}
-              onChange={(event) => setDraft((current) => ({ ...current, url: event.target.value }))}
-              placeholder={draft.origin === "recruiter" ? "Posting URL (optional)" : "Role URL"}
-            />
-            <Input
-              list="role-location-suggestions"
-              value={draft.location}
-              onChange={(event) => setDraft((current) => ({ ...current, location: event.target.value }))}
-              placeholder="Location"
-            />
-            <datalist id="role-location-suggestions">
-              {LOCATION_SUGGESTIONS.map((option) => (
-                <option key={option} value={option} />
-              ))}
-            </datalist>
-            <Select
-              value={draft.seniority}
-              onValueChange={(value) => setDraft((current) => ({ ...current, seniority: value }))}
-            >
-              <SelectTrigger><SelectValue placeholder="Seniority" /></SelectTrigger>
-              <SelectContent>
-                {SENIORITY_OPTIONS.map((option) => <SelectItem key={option} value={option}>{option}</SelectItem>)}
-              </SelectContent>
-            </Select>
-            <Select value={draft.track} onValueChange={(value) => setDraft((current) => ({ ...current, track: value as JobTrack }))}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="TPM">TPM</SelectItem>
-                <SelectItem value="Product Engineer">Product Engineer</SelectItem>
-                <SelectItem value="Systems PM">Systems PM</SelectItem>
-              </SelectContent>
-            </Select>
-            <Select value={String(draft.fitScore)} onValueChange={(value) => setDraft((current) => ({ ...current, fitScore: Number(value) as 1 | 2 | 3 | 4 | 5 }))}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
-              <SelectContent>{[1, 2, 3, 4, 5].map((value) => <SelectItem key={value} value={String(value)}>{value}</SelectItem>)}</SelectContent>
-            </Select>
-            <Button onClick={() => void handleAddRole()} disabled={!draft.companyId || !draft.title.trim()}>
-              Add Role
-            </Button>
-            <div className="text-xs text-muted-foreground md:col-span-4">
-              Company and role title are required before adding a role.
-            </div>
-            {formNotice ? (
-              <div className="rounded-md border border-border bg-muted/20 px-3 py-2 text-sm text-muted-foreground md:col-span-4">
-                {formNotice}
-              </div>
-            ) : null}
-            <div className="md:col-span-4">
-              <Textarea
-                value={draft.jobDescription ?? ""}
-                onChange={(event) => setDraft((current) => ({ ...current, jobDescription: event.target.value }))}
-                rows={4}
-                placeholder="Optional: store the job description here so CV tailoring can sync directly from the role."
-              />
-            </div>
-          </CardContent>
-        ) : null}
-      </Card>
-
       <div className="flex flex-wrap items-center gap-2">
         <div className="relative min-w-[200px] flex-1">
           <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />

--- a/src/app/pages/job-os/JobOsSourcesPage.tsx
+++ b/src/app/pages/job-os/JobOsSourcesPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router";
 import { useMemo, useState } from "react";
-import { Archive, CheckCheck, Compass, ExternalLink, Globe2, ListChecks, Plus, Search } from "lucide-react";
+import { Archive, CheckCheck, Compass, ExternalLink, Globe2, HelpCircle, ListChecks, Plus, Search } from "lucide-react";
 import { toast } from "sonner";
 import { AppPageShell } from "../../components/layout/AppPageShell";
 import { JobOsLayout } from "../../components/job-os/JobOsLayout";
@@ -14,6 +14,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "../../components/ui/sheet";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../components/ui/tooltip";
 import { Textarea } from "../../components/ui/textarea";
 import { useJobOsContext } from "../../context/JobOsContext";
 import { appPath } from "../../routing";
@@ -270,6 +271,9 @@ export default function JobOsSourcesPage() {
   const [queueSearch, setQueueSearch] = useState("");
   const [queueFitFilter, setQueueFitFilter] = useState("all");
   const [queueStatusFilter, setQueueStatusFilter] = useState<DiscoveryStatus | "all">("all");
+  const [dueSearch, setDueSearch] = useState("");
+  const [duePriorityFilter, setDuePriorityFilter] = useState<JobSourcePriority | "all">("all");
+  const [dueTypeFilter, setDueTypeFilter] = useState<"all" | "source" | "savedSearch">("all");
 
   const companiesById = useMemo(
     () => new Map(companies.map((company) => [company.id, company])),
@@ -332,6 +336,16 @@ export default function JobOsSourcesPage() {
     () => scanItems.filter((entry) => isDue(entry.item.lastCheckedAt, entry.item.cadence)),
     [scanItems]
   );
+
+  const filteredDueItems = useMemo(() => {
+    const base = showAllDue ? scanItems : dueScanItems;
+    return base.filter((entry) => {
+      if (dueSearch && !entry.item.name.toLowerCase().includes(dueSearch.toLowerCase())) return false;
+      if (duePriorityFilter !== "all" && entry.item.priority !== duePriorityFilter) return false;
+      if (dueTypeFilter !== "all" && entry.kind !== dueTypeFilter) return false;
+      return true;
+    });
+  }, [showAllDue, scanItems, dueScanItems, dueSearch, duePriorityFilter, dueTypeFilter]);
 
   const filteredSavedSearchOptions = useMemo(() => {
     if (!captureDraft.sourceId) return activeSavedSearches;
@@ -676,42 +690,106 @@ export default function JobOsSourcesPage() {
           </section>
 
           <Tabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsList className="h-auto flex-wrap gap-1 p-1">
-              <TabsTrigger value="due-today">
-                Due Today{dueScanItems.length > 0 ? ` (${dueScanItems.length})` : ""}
-              </TabsTrigger>
-              <TabsTrigger value="sources">
-                Sources ({activeSources.length}/{sources.length})
-              </TabsTrigger>
-              <TabsTrigger value="saved-searches">
-                Saved Searches ({activeSavedSearches.length}/{savedSearches.length})
-              </TabsTrigger>
-              <TabsTrigger value="queue">
-                Queue{qualificationQueue.length > 0 ? ` (${qualificationQueue.length})` : ""}
-              </TabsTrigger>
-            </TabsList>
+            <div className="flex items-center gap-2">
+              <TabsList className="h-auto flex-wrap gap-1 p-1">
+                <TabsTrigger value="due-today">
+                  Due Today{dueScanItems.length > 0 ? ` (${dueScanItems.length})` : ""}
+                </TabsTrigger>
+                <TabsTrigger value="sources">
+                  Sources ({activeSources.length}/{sources.length})
+                </TabsTrigger>
+                <TabsTrigger value="saved-searches">
+                  Saved Searches ({activeSavedSearches.length}/{savedSearches.length})
+                </TabsTrigger>
+                <TabsTrigger value="queue">
+                  Queue{qualificationQueue.length > 0 ? ` (${qualificationQueue.length})` : ""}
+                </TabsTrigger>
+              </TabsList>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+                    aria-label="Tab guide"
+                  >
+                    <HelpCircle className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs">
+                  <div className="space-y-1.5">
+                    <div><span className="font-semibold">Due Today</span> — sources and saved searches overdue for their scan cadence, sorted by priority. Filter by type or priority.</div>
+                    <div><span className="font-semibold">Sources</span> — your full discovery stack. Add, edit, enable or disable sources.</div>
+                    <div><span className="font-semibold">Saved Searches</span> — keyword searches tied to specific sources. Filter by source or track.</div>
+                    <div><span className="font-semibold">Queue</span> — roles captured from sources awaiting qualification before applying.</div>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </div>
 
             <TabsContent value="due-today" className="mt-4">
               <Card>
-                <CardContent className="space-y-3 pt-5">
+                <CardHeader className="pb-3">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <div className="relative min-w-[180px] flex-1">
+                      <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+                      <Input
+                        className="h-9 pl-8 text-sm"
+                        placeholder="Search items…"
+                        value={dueSearch}
+                        onChange={(e) => setDueSearch(e.target.value)}
+                      />
+                    </div>
+                    <Select
+                      value={duePriorityFilter}
+                      onValueChange={(v) => setDuePriorityFilter(v as JobSourcePriority | "all")}
+                    >
+                      <SelectTrigger className="h-9 w-[120px] text-sm">
+                        <SelectValue placeholder="Priority" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All priorities</SelectItem>
+                        {SOURCE_PRIORITIES.map((p) => (
+                          <SelectItem key={p} value={p}>Priority {p}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Select
+                      value={dueTypeFilter}
+                      onValueChange={(v) => setDueTypeFilter(v as "all" | "source" | "savedSearch")}
+                    >
+                      <SelectTrigger className="h-9 w-[150px] text-sm">
+                        <SelectValue placeholder="Type" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All types</SelectItem>
+                        <SelectItem value="source">Sources only</SelectItem>
+                        <SelectItem value="savedSearch">Saved searches only</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setShowAllDue((v) => !v)}
+                      className="text-xs text-muted-foreground"
+                    >
+                      {showAllDue ? "Due only" : `All (${scanItems.length})`}
+                    </Button>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-3">
                   {scanItems.length === 0 ? (
                     <div className="rounded-xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
                       Source Hub is ready. Your default source stack should appear here as soon as sync finishes.
                     </div>
-                  ) : dueScanItems.length === 0 && !showAllDue ? (
-                    <div className="space-y-3">
-                      <div className="rounded-xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
-                        Nothing is due right now. Check back when cadences reset.
-                      </div>
-                      <div className="flex justify-center">
-                        <Button variant="ghost" size="sm" onClick={() => setShowAllDue(true)}>
-                          Show all {scanItems.length} scan items
-                        </Button>
-                      </div>
+                  ) : filteredDueItems.length === 0 ? (
+                    <div className="rounded-xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
+                      {dueScanItems.length === 0 && !showAllDue
+                        ? "Nothing is due right now."
+                        : "No items match the current filters."}
                     </div>
                   ) : (
                     <>
-                      {(showAllDue ? scanItems : dueScanItems.slice(0, 10)).map((entry) => {
+                      {filteredDueItems.map((entry) => {
                         const isSource = entry.kind === "source";
                         const sourceName = isSource
                           ? entry.item.name
@@ -785,15 +863,13 @@ export default function JobOsSourcesPage() {
                           </div>
                         );
                       })}
-                      <div className="flex items-center justify-between pt-1 text-xs text-muted-foreground">
-                        <span>
-                          {showAllDue
-                            ? `Showing all ${scanItems.length} scan items`
-                            : `${dueScanItems.length} item${dueScanItems.length !== 1 ? "s" : ""} due`}
-                        </span>
-                        <Button variant="ghost" size="sm" onClick={() => setShowAllDue((v) => !v)}>
-                          {showAllDue ? "Show due only" : `Show all ${scanItems.length}`}
-                        </Button>
+                      <div className="pt-1 text-xs text-muted-foreground">
+                        {showAllDue
+                          ? `All ${scanItems.length} scan items`
+                          : `${dueScanItems.length} item${dueScanItems.length !== 1 ? "s" : ""} due`}
+                        {filteredDueItems.length !== (showAllDue ? scanItems : dueScanItems).length
+                          ? ` · ${filteredDueItems.length} shown after filtering`
+                          : ""}
                       </div>
                     </>
                   )}

--- a/src/app/pages/job-os/JobOsSourcesPage.tsx
+++ b/src/app/pages/job-os/JobOsSourcesPage.tsx
@@ -7,12 +7,13 @@ import { JobOsLayout } from "../../components/job-os/JobOsLayout";
 import { JobOsTransferControls } from "../../components/job-os/JobOsTransferControls";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { Card, CardContent, CardHeader } from "../../components/ui/card";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog";
 import { Input } from "../../components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "../../components/ui/sheet";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../components/ui/tabs";
 import { Textarea } from "../../components/ui/textarea";
 import { useJobOsContext } from "../../context/JobOsContext";
 import { appPath } from "../../routing";
@@ -256,6 +257,19 @@ export default function JobOsSourcesPage() {
   const [sourceEditDraft, setSourceEditDraft] = useState<SourceEditDraft | null>(null);
   const [editingSavedSearch, setEditingSavedSearch] = useState<SavedSearch | null>(null);
   const [savedSearchEditDraft, setSavedSearchEditDraft] = useState<SavedSearchEditDraft | null>(null);
+  const [activeTab, setActiveTab] = useState("due-today");
+  const [showAllDue, setShowAllDue] = useState(false);
+  const [sourcesSearch, setSourcesSearch] = useState("");
+  const [sourcesPriorityFilter, setSourcesPriorityFilter] = useState<JobSourcePriority | "all">("all");
+  const [sourcesCategoryFilter, setSourcesCategoryFilter] = useState<JobSourceCategory | "all">("all");
+  const [sourcesActiveFilter, setSourcesActiveFilter] = useState<"all" | "active" | "inactive">("all");
+  const [searchesSearch, setSearchesSearch] = useState("");
+  const [searchesPriorityFilter, setSearchesPriorityFilter] = useState<JobSourcePriority | "all">("all");
+  const [searchesSourceFilter, setSearchesSourceFilter] = useState("all");
+  const [searchesActiveFilter, setSearchesActiveFilter] = useState<"all" | "active" | "inactive">("all");
+  const [queueSearch, setQueueSearch] = useState("");
+  const [queueFitFilter, setQueueFitFilter] = useState("all");
+  const [queueStatusFilter, setQueueStatusFilter] = useState<DiscoveryStatus | "all">("all");
 
   const companiesById = useMemo(
     () => new Map(companies.map((company) => [company.id, company])),
@@ -314,15 +328,58 @@ export default function JobOsSourcesPage() {
     [roles]
   );
 
-  const searchesDueToday = useMemo(
-    () => activeSavedSearches.filter((savedSearch) => isDue(savedSearch.lastCheckedAt, savedSearch.cadence)).length,
-    [activeSavedSearches]
+  const dueScanItems = useMemo(
+    () => scanItems.filter((entry) => isDue(entry.item.lastCheckedAt, entry.item.cadence)),
+    [scanItems]
   );
 
   const filteredSavedSearchOptions = useMemo(() => {
     if (!captureDraft.sourceId) return activeSavedSearches;
     return activeSavedSearches.filter((savedSearch) => savedSearch.sourceId === captureDraft.sourceId);
   }, [activeSavedSearches, captureDraft.sourceId]);
+
+  const filteredSources = useMemo(() => {
+    return sources.filter((source) => {
+      if (
+        sourcesSearch &&
+        !source.name.toLowerCase().includes(sourcesSearch.toLowerCase()) &&
+        !source.bestFor.toLowerCase().includes(sourcesSearch.toLowerCase())
+      ) return false;
+      if (sourcesPriorityFilter !== "all" && source.priority !== sourcesPriorityFilter) return false;
+      if (sourcesCategoryFilter !== "all" && source.category !== sourcesCategoryFilter) return false;
+      if (sourcesActiveFilter === "active" && !source.active) return false;
+      if (sourcesActiveFilter === "inactive" && source.active) return false;
+      return true;
+    });
+  }, [sources, sourcesSearch, sourcesPriorityFilter, sourcesCategoryFilter, sourcesActiveFilter]);
+
+  const filteredSavedSearches = useMemo(() => {
+    return savedSearches.filter((savedSearch) => {
+      if (
+        searchesSearch &&
+        !savedSearch.name.toLowerCase().includes(searchesSearch.toLowerCase()) &&
+        !savedSearch.query.toLowerCase().includes(searchesSearch.toLowerCase())
+      ) return false;
+      if (searchesPriorityFilter !== "all" && savedSearch.priority !== searchesPriorityFilter) return false;
+      if (searchesSourceFilter !== "all" && savedSearch.sourceId !== searchesSourceFilter) return false;
+      if (searchesActiveFilter === "active" && !savedSearch.active) return false;
+      if (searchesActiveFilter === "inactive" && savedSearch.active) return false;
+      return true;
+    });
+  }, [savedSearches, searchesSearch, searchesPriorityFilter, searchesSourceFilter, searchesActiveFilter]);
+
+  const filteredQueue = useMemo(() => {
+    return qualificationQueue.filter((role) => {
+      if (queueSearch) {
+        const company = companiesById.get(role.companyId);
+        const searchText = `${role.title} ${company?.name ?? ""}`.toLowerCase();
+        if (!searchText.includes(queueSearch.toLowerCase())) return false;
+      }
+      if (queueFitFilter !== "all" && String(role.fitScore) !== queueFitFilter) return false;
+      if (queueStatusFilter !== "all" && role.discoveryStatus !== queueStatusFilter) return false;
+      return true;
+    });
+  }, [qualificationQueue, queueSearch, queueFitFilter, queueStatusFilter, companiesById]);
 
   function openUrl(url?: string): void {
     if (!url) return;
@@ -568,9 +625,9 @@ export default function JobOsSourcesPage() {
     >
       <AppPageShell
         title="Source Hub"
-        subtitle="Use this as the top of the funnel: keep your sources sharp, work through due searches, then capture only the roles worth qualifying."
+        subtitle="Work through today's due scans, then capture only the roles worth qualifying."
       >
-        <div className="space-y-6">
+        <div className="space-y-5">
           <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
             <Card>
               <CardContent className="flex items-center justify-between py-5">
@@ -587,9 +644,9 @@ export default function JobOsSourcesPage() {
               <CardContent className="flex items-center justify-between py-5">
                 <div>
                   <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Searches Due Today
+                    Due Today
                   </div>
-                  <div className="mt-2 text-2xl font-semibold">{searchesDueToday}</div>
+                  <div className="mt-2 text-2xl font-semibold">{dueScanItems.length}</div>
                 </div>
                 <Search className="h-5 w-5 text-muted-foreground" />
               </CardContent>
@@ -618,415 +675,573 @@ export default function JobOsSourcesPage() {
             </Card>
           </section>
 
-          <section className="grid gap-6 2xl:grid-cols-[1.2fr_1fr]">
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base">Today&apos;s Scan</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {scanItems.length > 0 ? (
-                  scanItems.map((entry) => {
-                    const isSource = entry.kind === "source";
-                    const sourceName = isSource
-                      ? entry.item.name
-                      : sourcesById.get(entry.item.sourceId)?.name ?? "Unknown source";
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="h-auto flex-wrap gap-1 p-1">
+              <TabsTrigger value="due-today">
+                Due Today{dueScanItems.length > 0 ? ` (${dueScanItems.length})` : ""}
+              </TabsTrigger>
+              <TabsTrigger value="sources">
+                Sources ({activeSources.length}/{sources.length})
+              </TabsTrigger>
+              <TabsTrigger value="saved-searches">
+                Saved Searches ({activeSavedSearches.length}/{savedSearches.length})
+              </TabsTrigger>
+              <TabsTrigger value="queue">
+                Queue{qualificationQueue.length > 0 ? ` (${qualificationQueue.length})` : ""}
+              </TabsTrigger>
+            </TabsList>
 
-                    return (
-                      <div
-                        key={`${entry.kind}-${entry.item.id}`}
-                        className="rounded-xl border border-border bg-background/80 p-4"
-                      >
-                        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                          <div className="space-y-2">
-                            <div className="flex flex-wrap items-center gap-2">
-                              <div className="font-medium text-foreground">{entry.item.name}</div>
-                              <Badge variant="outline" className={getPriorityBadgeClass(entry.item.priority)}>
-                                {entry.item.priority}
-                              </Badge>
-                              <Badge variant="outline">
-                                {isSource ? "Source" : "Saved Search"}
-                              </Badge>
-                              {isDue(entry.item.lastCheckedAt, entry.item.cadence) ? (
-                                <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
-                                  Due
-                                </Badge>
-                              ) : null}
-                            </div>
-                            <div className="text-sm text-muted-foreground">
-                              {isSource ? (entry.item as JobSource).bestFor : sourceName}
-                            </div>
-                            <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
-                              <span>Cadence: {CADENCE_LABELS[entry.item.cadence]}</span>
-                              <span>Last checked: {formatDateLabel(entry.item.lastCheckedAt)}</span>
+            <TabsContent value="due-today" className="mt-4">
+              <Card>
+                <CardContent className="space-y-3 pt-5">
+                  {scanItems.length === 0 ? (
+                    <div className="rounded-xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
+                      Source Hub is ready. Your default source stack should appear here as soon as sync finishes.
+                    </div>
+                  ) : dueScanItems.length === 0 && !showAllDue ? (
+                    <div className="space-y-3">
+                      <div className="rounded-xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
+                        Nothing is due right now. Check back when cadences reset.
+                      </div>
+                      <div className="flex justify-center">
+                        <Button variant="ghost" size="sm" onClick={() => setShowAllDue(true)}>
+                          Show all {scanItems.length} scan items
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      {(showAllDue ? scanItems : dueScanItems.slice(0, 10)).map((entry) => {
+                        const isSource = entry.kind === "source";
+                        const sourceName = isSource
+                          ? entry.item.name
+                          : sourcesById.get(entry.item.sourceId)?.name ?? "Unknown source";
+
+                        return (
+                          <div
+                            key={`${entry.kind}-${entry.item.id}`}
+                            className="rounded-xl border border-border bg-background/80 p-4"
+                          >
+                            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                              <div className="space-y-2">
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <div className="font-medium text-foreground">{entry.item.name}</div>
+                                  <Badge variant="outline" className={getPriorityBadgeClass(entry.item.priority)}>
+                                    {entry.item.priority}
+                                  </Badge>
+                                  <Badge variant="outline">
+                                    {isSource ? "Source" : "Saved Search"}
+                                  </Badge>
+                                  {isDue(entry.item.lastCheckedAt, entry.item.cadence) ? (
+                                    <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
+                                      Due
+                                    </Badge>
+                                  ) : null}
+                                </div>
+                                <div className="text-sm text-muted-foreground">
+                                  {isSource ? (entry.item as JobSource).bestFor : sourceName}
+                                </div>
+                                <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
+                                  <span>Cadence: {CADENCE_LABELS[entry.item.cadence]}</span>
+                                  <span>Last checked: {formatDateLabel(entry.item.lastCheckedAt)}</span>
+                                </div>
+                              </div>
+                              <div className="flex flex-wrap gap-2">
+                                <Button variant="outline" size="sm" onClick={() => openUrl(entry.item.url)}>
+                                  <ExternalLink className="mr-1 h-3.5 w-3.5" />
+                                  Open
+                                </Button>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() =>
+                                    isSource
+                                      ? void handleMarkSourceChecked(entry.item as JobSource)
+                                      : void handleMarkSavedSearchChecked(entry.item as SavedSearch)
+                                  }
+                                >
+                                  <CheckCheck className="mr-1 h-3.5 w-3.5" />
+                                  Mark checked
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  onClick={() =>
+                                    openCapture(
+                                      isSource
+                                        ? { sourceId: entry.item.id, sourceUrl: entry.item.url }
+                                        : {
+                                            sourceId: (entry.item as SavedSearch).sourceId,
+                                            savedSearchId: entry.item.id,
+                                            sourceUrl: entry.item.url,
+                                          }
+                                    )
+                                  }
+                                >
+                                  <Plus className="mr-1 h-3.5 w-3.5" />
+                                  Capture role
+                                </Button>
+                              </div>
                             </div>
                           </div>
-                          <div className="flex flex-wrap gap-2">
-                            <Button variant="outline" size="sm" onClick={() => openUrl(entry.item.url)}>
-                              <ExternalLink className="mr-1 h-3.5 w-3.5" />
-                              Open
-                            </Button>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() =>
-                                isSource
-                                  ? void handleMarkSourceChecked(entry.item as JobSource)
-                                  : void handleMarkSavedSearchChecked(entry.item as SavedSearch)
-                              }
-                            >
-                              <CheckCheck className="mr-1 h-3.5 w-3.5" />
-                              Mark checked
-                            </Button>
-                            <Button
-                              size="sm"
-                              onClick={() =>
-                                openCapture(
-                                  isSource
-                                    ? {
-                                        sourceId: entry.item.id,
-                                        sourceUrl: entry.item.url,
-                                      }
-                                    : {
-                                        sourceId: (entry.item as SavedSearch).sourceId,
-                                        savedSearchId: entry.item.id,
-                                        sourceUrl: entry.item.url,
-                                      }
-                                )
-                              }
-                            >
-                              <Plus className="mr-1 h-3.5 w-3.5" />
-                              Capture role
-                            </Button>
+                        );
+                      })}
+                      <div className="flex items-center justify-between pt-1 text-xs text-muted-foreground">
+                        <span>
+                          {showAllDue
+                            ? `Showing all ${scanItems.length} scan items`
+                            : `${dueScanItems.length} item${dueScanItems.length !== 1 ? "s" : ""} due`}
+                        </span>
+                        <Button variant="ghost" size="sm" onClick={() => setShowAllDue((v) => !v)}>
+                          {showAllDue ? "Show due only" : `Show all ${scanItems.length}`}
+                        </Button>
+                      </div>
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            <TabsContent value="sources" className="mt-4">
+              <Card>
+                <CardHeader className="pb-3">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <div className="relative min-w-[180px] flex-1">
+                      <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+                      <Input
+                        className="h-9 pl-8 text-sm"
+                        placeholder="Search sources…"
+                        value={sourcesSearch}
+                        onChange={(e) => setSourcesSearch(e.target.value)}
+                      />
+                    </div>
+                    <Select
+                      value={sourcesPriorityFilter}
+                      onValueChange={(v) => setSourcesPriorityFilter(v as JobSourcePriority | "all")}
+                    >
+                      <SelectTrigger className="h-9 w-[120px] text-sm">
+                        <SelectValue placeholder="Priority" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All priorities</SelectItem>
+                        {SOURCE_PRIORITIES.map((p) => (
+                          <SelectItem key={p} value={p}>Priority {p}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Select
+                      value={sourcesCategoryFilter}
+                      onValueChange={(v) => setSourcesCategoryFilter(v as JobSourceCategory | "all")}
+                    >
+                      <SelectTrigger className="h-9 w-[140px] text-sm">
+                        <SelectValue placeholder="Category" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All categories</SelectItem>
+                        {SOURCE_CATEGORIES.map((c) => (
+                          <SelectItem key={c} value={c}>{SOURCE_CATEGORY_LABELS[c]}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Select
+                      value={sourcesActiveFilter}
+                      onValueChange={(v) => setSourcesActiveFilter(v as "all" | "active" | "inactive")}
+                    >
+                      <SelectTrigger className="h-9 w-[110px] text-sm">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All</SelectItem>
+                        <SelectItem value="active">Active</SelectItem>
+                        <SelectItem value="inactive">Inactive</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="hidden md:block">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Source</TableHead>
+                          <TableHead>Category</TableHead>
+                          <TableHead>Best for</TableHead>
+                          <TableHead>Priority</TableHead>
+                          <TableHead>Cadence</TableHead>
+                          <TableHead>Last checked</TableHead>
+                          <TableHead className="text-right">Actions</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {filteredSources.map((source) => (
+                          <TableRow key={source.id} className={source.active ? "" : "opacity-50"}>
+                            <TableCell className="font-medium">{source.name}</TableCell>
+                            <TableCell>{SOURCE_CATEGORY_LABELS[source.category]}</TableCell>
+                            <TableCell className="max-w-[340px] text-muted-foreground">{source.bestFor}</TableCell>
+                            <TableCell>
+                              <Badge variant="outline" className={getPriorityBadgeClass(source.priority)}>
+                                {source.priority}
+                              </Badge>
+                            </TableCell>
+                            <TableCell>{CADENCE_LABELS[source.cadence]}</TableCell>
+                            <TableCell>{formatDateLabel(source.lastCheckedAt)}</TableCell>
+                            <TableCell>
+                              <div className="flex justify-end gap-2">
+                                <Button size="sm" variant="outline" onClick={() => openUrl(source.url)}>Open</Button>
+                                <Button size="sm" variant="outline" onClick={() => void handleMarkSourceChecked(source)}>Mark checked</Button>
+                                <Button size="sm" variant="outline" onClick={() => openSourceEditor(source)}>Edit</Button>
+                                <Button size="sm" variant="ghost" onClick={() => void handleToggleSource(source)}>
+                                  {source.active ? "Disable" : "Enable"}
+                                </Button>
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                        {filteredSources.length === 0 && (
+                          <TableRow>
+                            <TableCell colSpan={7} className="py-8 text-center text-sm text-muted-foreground">
+                              No sources match the current filters.
+                            </TableCell>
+                          </TableRow>
+                        )}
+                      </TableBody>
+                    </Table>
+                  </div>
+                  <div className="grid gap-3 md:hidden">
+                    {filteredSources.map((source) => (
+                      <div key={source.id} className={`rounded-xl border border-border p-4 ${source.active ? "" : "opacity-50"}`}>
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <div className="font-medium">{source.name}</div>
+                            <div className="text-sm text-muted-foreground">{source.bestFor}</div>
                           </div>
+                          <Badge variant="outline" className={getPriorityBadgeClass(source.priority)}>{source.priority}</Badge>
+                        </div>
+                        <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
+                          <span>{SOURCE_CATEGORY_LABELS[source.category]}</span>
+                          <span>{CADENCE_LABELS[source.cadence]}</span>
+                          <span>{formatDateLabel(source.lastCheckedAt)}</span>
+                        </div>
+                        <div className="mt-4 flex flex-wrap gap-2">
+                          <Button size="sm" variant="outline" onClick={() => openUrl(source.url)}>Open</Button>
+                          <Button size="sm" variant="outline" onClick={() => void handleMarkSourceChecked(source)}>Mark checked</Button>
+                          <Button size="sm" variant="outline" onClick={() => openSourceEditor(source)}>Edit</Button>
+                          <Button size="sm" variant="ghost" onClick={() => void handleToggleSource(source)}>
+                            {source.active ? "Disable" : "Enable"}
+                          </Button>
                         </div>
                       </div>
-                    );
-                  })
-                ) : (
-                  <div className="rounded-xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
-                    Source Hub is ready. Your default source stack should appear here as soon as sync finishes.
+                    ))}
+                    {filteredSources.length === 0 && (
+                      <div className="rounded-xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
+                        No sources match the current filters.
+                      </div>
+                    )}
                   </div>
-                )}
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+            </TabsContent>
 
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base">Qualification Queue</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {qualificationQueue.length > 0 ? (
-                  qualificationQueue.map((role) => {
-                    const company = companiesById.get(role.companyId);
-                    const sourceName =
-                      (role.savedSearchId
-                        ? sourcesById.get(savedSearchesById.get(role.savedSearchId)?.sourceId ?? "")
-                        : undefined)?.name ??
-                      (role.sourceId ? sourcesById.get(role.sourceId)?.name : undefined) ??
-                      "Manual capture";
+            <TabsContent value="saved-searches" className="mt-4">
+              <Card>
+                <CardHeader className="pb-3">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <div className="relative min-w-[180px] flex-1">
+                      <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+                      <Input
+                        className="h-9 pl-8 text-sm"
+                        placeholder="Search saved searches…"
+                        value={searchesSearch}
+                        onChange={(e) => setSearchesSearch(e.target.value)}
+                      />
+                    </div>
+                    <Select
+                      value={searchesPriorityFilter}
+                      onValueChange={(v) => setSearchesPriorityFilter(v as JobSourcePriority | "all")}
+                    >
+                      <SelectTrigger className="h-9 w-[120px] text-sm">
+                        <SelectValue placeholder="Priority" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All priorities</SelectItem>
+                        {SOURCE_PRIORITIES.map((p) => (
+                          <SelectItem key={p} value={p}>Priority {p}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Select value={searchesSourceFilter} onValueChange={setSearchesSourceFilter}>
+                      <SelectTrigger className="h-9 w-[150px] text-sm">
+                        <SelectValue placeholder="Source" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All sources</SelectItem>
+                        {sources.map((s) => (
+                          <SelectItem key={s.id} value={s.id}>{s.name}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Select
+                      value={searchesActiveFilter}
+                      onValueChange={(v) => setSearchesActiveFilter(v as "all" | "active" | "inactive")}
+                    >
+                      <SelectTrigger className="h-9 w-[110px] text-sm">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All</SelectItem>
+                        <SelectItem value="active">Active</SelectItem>
+                        <SelectItem value="inactive">Inactive</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="hidden md:block">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Search name</TableHead>
+                          <TableHead>Source</TableHead>
+                          <TableHead>Target track</TableHead>
+                          <TableHead>Priority</TableHead>
+                          <TableHead>Cadence</TableHead>
+                          <TableHead>Last checked</TableHead>
+                          <TableHead className="text-right">Actions</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {filteredSavedSearches.map((savedSearch) => (
+                          <TableRow key={savedSearch.id} className={savedSearch.active ? "" : "opacity-50"}>
+                            <TableCell className="font-medium">{savedSearch.name}</TableCell>
+                            <TableCell>{sourcesById.get(savedSearch.sourceId)?.name ?? "Unknown source"}</TableCell>
+                            <TableCell>{savedSearch.targetTrack}</TableCell>
+                            <TableCell>
+                              <Badge variant="outline" className={getPriorityBadgeClass(savedSearch.priority)}>
+                                {savedSearch.priority}
+                              </Badge>
+                            </TableCell>
+                            <TableCell>{CADENCE_LABELS[savedSearch.cadence]}</TableCell>
+                            <TableCell>{formatDateLabel(savedSearch.lastCheckedAt)}</TableCell>
+                            <TableCell>
+                              <div className="flex justify-end gap-2">
+                                <Button size="sm" variant="outline" onClick={() => openUrl(savedSearch.url)}>Open</Button>
+                                <Button size="sm" variant="outline" onClick={() => void handleMarkSavedSearchChecked(savedSearch)}>Mark checked</Button>
+                                <Button size="sm" onClick={() => openCapture({ sourceId: savedSearch.sourceId, savedSearchId: savedSearch.id, sourceUrl: savedSearch.url })}>Capture role</Button>
+                                <Button size="sm" variant="outline" onClick={() => openSavedSearchEditor(savedSearch)}>Edit</Button>
+                                <Button size="sm" variant="ghost" onClick={() => void handleToggleSavedSearch(savedSearch)}>
+                                  {savedSearch.active ? "Disable" : "Enable"}
+                                </Button>
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                        {filteredSavedSearches.length === 0 && (
+                          <TableRow>
+                            <TableCell colSpan={7} className="py-8 text-center text-sm text-muted-foreground">
+                              No saved searches match the current filters.
+                            </TableCell>
+                          </TableRow>
+                        )}
+                      </TableBody>
+                    </Table>
+                  </div>
+                  <div className="grid gap-3 md:hidden">
+                    {filteredSavedSearches.map((savedSearch) => (
+                      <div key={savedSearch.id} className={`rounded-xl border border-border p-4 ${savedSearch.active ? "" : "opacity-50"}`}>
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <div className="font-medium">{savedSearch.name}</div>
+                            <div className="text-sm text-muted-foreground">
+                              {sourcesById.get(savedSearch.sourceId)?.name ?? "Unknown source"} · {savedSearch.targetTrack}
+                            </div>
+                          </div>
+                          <Badge variant="outline" className={getPriorityBadgeClass(savedSearch.priority)}>{savedSearch.priority}</Badge>
+                        </div>
+                        <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
+                          <span>{CADENCE_LABELS[savedSearch.cadence]}</span>
+                          <span>{formatDateLabel(savedSearch.lastCheckedAt)}</span>
+                        </div>
+                        <div className="mt-4 flex flex-wrap gap-2">
+                          <Button size="sm" variant="outline" onClick={() => openUrl(savedSearch.url)}>Open</Button>
+                          <Button size="sm" variant="outline" onClick={() => void handleMarkSavedSearchChecked(savedSearch)}>Mark checked</Button>
+                          <Button size="sm" onClick={() => openCapture({ sourceId: savedSearch.sourceId, savedSearchId: savedSearch.id, sourceUrl: savedSearch.url })}>Capture role</Button>
+                          <Button size="sm" variant="outline" onClick={() => openSavedSearchEditor(savedSearch)}>Edit</Button>
+                          <Button size="sm" variant="ghost" onClick={() => void handleToggleSavedSearch(savedSearch)}>
+                            {savedSearch.active ? "Disable" : "Enable"}
+                          </Button>
+                        </div>
+                      </div>
+                    ))}
+                    {filteredSavedSearches.length === 0 && (
+                      <div className="rounded-xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
+                        No saved searches match the current filters.
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
 
-                    return (
-                      <div
-                        key={role.id}
-                        className={`rounded-xl border p-4 ${
-                          role.fitScore >= 4
-                            ? "border-foreground/20 bg-neutral-100/70 dark:bg-neutral-900/60"
-                            : "border-border bg-background/80"
-                        }`}
-                      >
-                        <div className="flex flex-col gap-3">
-                          <div className="flex flex-wrap items-start justify-between gap-3">
-                            <div>
-                              <div className="font-medium text-foreground">{role.title}</div>
-                              <div className="text-sm text-muted-foreground">
-                                {company?.name ?? "Unknown company"} · {sourceName}
+            <TabsContent value="queue" className="mt-4">
+              <Card>
+                <CardHeader className="pb-3">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <div className="relative min-w-[180px] flex-1">
+                      <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+                      <Input
+                        className="h-9 pl-8 text-sm"
+                        placeholder="Search roles…"
+                        value={queueSearch}
+                        onChange={(e) => setQueueSearch(e.target.value)}
+                      />
+                    </div>
+                    <Select value={queueFitFilter} onValueChange={setQueueFitFilter}>
+                      <SelectTrigger className="h-9 w-[120px] text-sm">
+                        <SelectValue placeholder="Fit score" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All fit scores</SelectItem>
+                        {[1, 2, 3, 4, 5].map((n) => (
+                          <SelectItem key={n} value={String(n)}>Fit {n}/5</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Select
+                      value={queueStatusFilter}
+                      onValueChange={(v) => setQueueStatusFilter(v as DiscoveryStatus | "all")}
+                    >
+                      <SelectTrigger className="h-9 w-[140px] text-sm">
+                        <SelectValue placeholder="Status" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All statuses</SelectItem>
+                        {DISCOVERY_QUEUE_STATUSES.map((s) => (
+                          <SelectItem key={s} value={s}>{DISCOVERY_STATUS_LABELS[s]}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {filteredQueue.length > 0 ? (
+                    filteredQueue.map((role) => {
+                      const company = companiesById.get(role.companyId);
+                      const sourceName =
+                        (role.savedSearchId
+                          ? sourcesById.get(savedSearchesById.get(role.savedSearchId)?.sourceId ?? "")
+                          : undefined)?.name ??
+                        (role.sourceId ? sourcesById.get(role.sourceId)?.name : undefined) ??
+                        "Manual capture";
+
+                      return (
+                        <div
+                          key={role.id}
+                          className={`rounded-xl border p-4 ${
+                            role.fitScore >= 4
+                              ? "border-foreground/20 bg-neutral-100/70 dark:bg-neutral-900/60"
+                              : "border-border bg-background/80"
+                          }`}
+                        >
+                          <div className="flex flex-col gap-3">
+                            <div className="flex flex-wrap items-start justify-between gap-3">
+                              <div>
+                                <div className="font-medium text-foreground">{role.title}</div>
+                                <div className="text-sm text-muted-foreground">
+                                  {company?.name ?? "Unknown company"} · {sourceName}
+                                </div>
+                              </div>
+                              <div className="flex flex-wrap gap-2">
+                                <Badge variant="outline">Fit {role.fitScore}/5</Badge>
+                                <Badge
+                                  variant="outline"
+                                  className={
+                                    role.discoveryStatus === "to_apply"
+                                      ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300"
+                                      : undefined
+                                  }
+                                >
+                                  {DISCOVERY_STATUS_LABELS[role.discoveryStatus ?? "discovered"]}
+                                </Badge>
+                                <Badge variant="outline">{role.track}</Badge>
+                              </div>
+                            </div>
+                            <div className="grid gap-2 text-sm text-muted-foreground md:grid-cols-2">
+                              <div>
+                                <span className="font-medium text-foreground">Notes:</span>{" "}
+                                {role.qualificationNotes || "No qualification notes yet."}
+                              </div>
+                              <div>
+                                <span className="font-medium text-foreground">Next step:</span>{" "}
+                                {role.nextStep || "Clarify next move."}
                               </div>
                             </div>
                             <div className="flex flex-wrap gap-2">
-                              <Badge variant="outline">Fit {role.fitScore}/5</Badge>
-                              <Badge
+                              <Button
+                                size="sm"
                                 variant="outline"
-                                className={
-                                  role.discoveryStatus === "to_apply"
-                                    ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300"
-                                    : undefined
+                                onClick={() =>
+                                  void handleQueueAction(
+                                    role,
+                                    { discoveryStatus: "qualified" },
+                                    `${role.title} marked qualified`
+                                  )
                                 }
                               >
-                                {DISCOVERY_STATUS_LABELS[role.discoveryStatus ?? "discovered"]}
-                              </Badge>
-                              <Badge variant="outline">{role.track}</Badge>
+                                Qualify
+                              </Button>
+                              <Button
+                                size="sm"
+                                onClick={() =>
+                                  void handleQueueAction(
+                                    role,
+                                    { discoveryStatus: "to_apply", status: "to_apply" },
+                                    `${role.title} moved to apply queue`
+                                  )
+                                }
+                              >
+                                Move to Apply Queue
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="text-muted-foreground"
+                                onClick={() =>
+                                  void handleQueueAction(
+                                    role,
+                                    { discoveryStatus: "archived", status: "closed" },
+                                    `${role.title} archived`
+                                  )
+                                }
+                              >
+                                <Archive className="mr-1 h-3.5 w-3.5" />
+                                Archive
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={!role.url}
+                                onClick={() => openUrl(role.url)}
+                              >
+                                Open role URL
+                              </Button>
+                              <Button asChild size="sm" variant="outline">
+                                <Link to={appPath("/cv-optimizer")}>Open CV Optimizer</Link>
+                              </Button>
                             </div>
-                          </div>
-                          <div className="grid gap-2 text-sm text-muted-foreground md:grid-cols-2">
-                            <div>
-                              <span className="font-medium text-foreground">Notes:</span>{" "}
-                              {role.qualificationNotes || "No qualification notes yet."}
-                            </div>
-                            <div>
-                              <span className="font-medium text-foreground">Next step:</span>{" "}
-                              {role.nextStep || "Clarify next move."}
-                            </div>
-                          </div>
-                          <div className="flex flex-wrap gap-2">
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() =>
-                                void handleQueueAction(
-                                  role,
-                                  { discoveryStatus: "qualified" },
-                                  `${role.title} marked qualified`
-                                )
-                              }
-                            >
-                              Qualify
-                            </Button>
-                            <Button
-                              size="sm"
-                              onClick={() =>
-                                void handleQueueAction(
-                                  role,
-                                  { discoveryStatus: "to_apply", status: "to_apply" },
-                                  `${role.title} moved to apply queue`
-                                )
-                              }
-                            >
-                              Move to Apply Queue
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="text-muted-foreground"
-                              onClick={() =>
-                                void handleQueueAction(
-                                  role,
-                                  { discoveryStatus: "archived", status: "closed" },
-                                  `${role.title} archived`
-                                )
-                              }
-                            >
-                              <Archive className="mr-1 h-3.5 w-3.5" />
-                              Archive
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              disabled={!role.url}
-                              onClick={() => openUrl(role.url)}
-                            >
-                              Open role URL
-                            </Button>
-                            <Button asChild size="sm" variant="outline">
-                              <Link to={appPath("/cv-optimizer")}>Open CV Optimizer</Link>
-                            </Button>
                           </div>
                         </div>
-                      </div>
-                    );
-                  })
-                ) : (
-                  <div className="rounded-xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
-                    Captured roles that are still worth qualifying will show up here.
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </section>
-
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between gap-3 pb-3">
-              <CardTitle className="text-base">Source Library</CardTitle>
-              <Button size="sm" variant="outline" onClick={() => setAddSourceOpen(true)} className="gap-2">
-                <Plus className="h-4 w-4" />
-                Add Source
-              </Button>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="hidden md:block">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Source</TableHead>
-                      <TableHead>Category</TableHead>
-                      <TableHead>Best for</TableHead>
-                      <TableHead>Priority</TableHead>
-                      <TableHead>Cadence</TableHead>
-                      <TableHead>Last checked</TableHead>
-                      <TableHead className="text-right">Actions</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {sources.map((source) => (
-                      <TableRow key={source.id}>
-                        <TableCell className="font-medium">{source.name}</TableCell>
-                        <TableCell>{SOURCE_CATEGORY_LABELS[source.category]}</TableCell>
-                        <TableCell className="max-w-[340px] text-muted-foreground">{source.bestFor}</TableCell>
-                        <TableCell>
-                          <Badge variant="outline" className={getPriorityBadgeClass(source.priority)}>
-                            {source.priority}
-                          </Badge>
-                        </TableCell>
-                        <TableCell>{CADENCE_LABELS[source.cadence]}</TableCell>
-                        <TableCell>{formatDateLabel(source.lastCheckedAt)}</TableCell>
-                        <TableCell>
-                          <div className="flex justify-end gap-2">
-                            <Button size="sm" variant="outline" onClick={() => openUrl(source.url)}>
-                              Open
-                            </Button>
-                            <Button size="sm" variant="outline" onClick={() => void handleMarkSourceChecked(source)}>
-                              Mark checked
-                            </Button>
-                            <Button size="sm" variant="outline" onClick={() => openSourceEditor(source)}>
-                              Edit
-                            </Button>
-                            <Button size="sm" variant="ghost" onClick={() => void handleToggleSource(source)}>
-                              {source.active ? "Disable" : "Enable"}
-                            </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-              <div className="grid gap-3 md:hidden">
-                {sources.map((source) => (
-                  <div key={source.id} className="rounded-xl border border-border p-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <div className="font-medium">{source.name}</div>
-                        <div className="text-sm text-muted-foreground">{source.bestFor}</div>
-                      </div>
-                      <Badge variant="outline" className={getPriorityBadgeClass(source.priority)}>
-                        {source.priority}
-                      </Badge>
+                      );
+                    })
+                  ) : (
+                    <div className="rounded-xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
+                      {qualificationQueue.length === 0
+                        ? "Captured roles that are still worth qualifying will show up here."
+                        : "No roles match the current filters."}
                     </div>
-                    <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
-                      <span>{SOURCE_CATEGORY_LABELS[source.category]}</span>
-                      <span>{CADENCE_LABELS[source.cadence]}</span>
-                      <span>{formatDateLabel(source.lastCheckedAt)}</span>
-                    </div>
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      <Button size="sm" variant="outline" onClick={() => openUrl(source.url)}>
-                        Open
-                      </Button>
-                      <Button size="sm" variant="outline" onClick={() => void handleMarkSourceChecked(source)}>
-                        Mark checked
-                      </Button>
-                      <Button size="sm" variant="outline" onClick={() => openSourceEditor(source)}>
-                        Edit
-                      </Button>
-                      <Button size="sm" variant="ghost" onClick={() => void handleToggleSource(source)}>
-                        {source.active ? "Disable" : "Enable"}
-                      </Button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base">Saved Searches</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="hidden md:block">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Search name</TableHead>
-                      <TableHead>Source</TableHead>
-                      <TableHead>Target track</TableHead>
-                      <TableHead>Priority</TableHead>
-                      <TableHead>Cadence</TableHead>
-                      <TableHead>Last checked</TableHead>
-                      <TableHead className="text-right">Actions</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {savedSearches.map((savedSearch) => (
-                      <TableRow key={savedSearch.id}>
-                        <TableCell className="font-medium">{savedSearch.name}</TableCell>
-                        <TableCell>
-                          {sourcesById.get(savedSearch.sourceId)?.name ?? "Unknown source"}
-                        </TableCell>
-                        <TableCell>{savedSearch.targetTrack}</TableCell>
-                        <TableCell>
-                          <Badge variant="outline" className={getPriorityBadgeClass(savedSearch.priority)}>
-                            {savedSearch.priority}
-                          </Badge>
-                        </TableCell>
-                        <TableCell>{CADENCE_LABELS[savedSearch.cadence]}</TableCell>
-                        <TableCell>{formatDateLabel(savedSearch.lastCheckedAt)}</TableCell>
-                        <TableCell>
-                          <div className="flex justify-end gap-2">
-                            <Button size="sm" variant="outline" onClick={() => openUrl(savedSearch.url)}>
-                              Open
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => void handleMarkSavedSearchChecked(savedSearch)}
-                            >
-                              Mark checked
-                            </Button>
-                            <Button size="sm" onClick={() => openCapture({ sourceId: savedSearch.sourceId, savedSearchId: savedSearch.id, sourceUrl: savedSearch.url })}>
-                              Capture role
-                            </Button>
-                            <Button size="sm" variant="outline" onClick={() => openSavedSearchEditor(savedSearch)}>
-                              Edit
-                            </Button>
-                            <Button size="sm" variant="ghost" onClick={() => void handleToggleSavedSearch(savedSearch)}>
-                              {savedSearch.active ? "Disable" : "Enable"}
-                            </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-              <div className="grid gap-3 md:hidden">
-                {savedSearches.map((savedSearch) => (
-                  <div key={savedSearch.id} className="rounded-xl border border-border p-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <div className="font-medium">{savedSearch.name}</div>
-                        <div className="text-sm text-muted-foreground">
-                          {sourcesById.get(savedSearch.sourceId)?.name ?? "Unknown source"} · {savedSearch.targetTrack}
-                        </div>
-                      </div>
-                      <Badge variant="outline" className={getPriorityBadgeClass(savedSearch.priority)}>
-                        {savedSearch.priority}
-                      </Badge>
-                    </div>
-                    <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
-                      <span>{CADENCE_LABELS[savedSearch.cadence]}</span>
-                      <span>{formatDateLabel(savedSearch.lastCheckedAt)}</span>
-                    </div>
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      <Button size="sm" variant="outline" onClick={() => openUrl(savedSearch.url)}>
-                        Open
-                      </Button>
-                      <Button size="sm" variant="outline" onClick={() => void handleMarkSavedSearchChecked(savedSearch)}>
-                        Mark checked
-                      </Button>
-                      <Button size="sm" onClick={() => openCapture({ sourceId: savedSearch.sourceId, savedSearchId: savedSearch.id, sourceUrl: savedSearch.url })}>
-                        Capture role
-                      </Button>
-                      <Button size="sm" variant="outline" onClick={() => openSavedSearchEditor(savedSearch)}>
-                        Edit
-                      </Button>
-                      <Button size="sm" variant="ghost" onClick={() => void handleToggleSavedSearch(savedSearch)}>
-                        {savedSearch.active ? "Disable" : "Enable"}
-                      </Button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+                  )}
+                </CardContent>
+              </Card>
+            </TabsContent>
+          </Tabs>
         </div>
       </AppPageShell>
 

--- a/src/app/pages/job-os/JobOsSourcesPage.tsx
+++ b/src/app/pages/job-os/JobOsSourcesPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router";
 import { useMemo, useState } from "react";
-import { Archive, CheckCheck, Compass, ExternalLink, Globe2, HelpCircle, ListChecks, Plus, Search } from "lucide-react";
+import { Archive, CheckCheck, ExternalLink, HelpCircle, Plus, Search, WandSparkles } from "lucide-react";
 import { toast } from "sonner";
 import { AppPageShell } from "../../components/layout/AppPageShell";
 import { JobOsLayout } from "../../components/job-os/JobOsLayout";
@@ -642,52 +642,23 @@ export default function JobOsSourcesPage() {
         subtitle="Work through today's due scans, then capture only the roles worth qualifying."
       >
         <div className="space-y-5">
-          <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-            <Card>
-              <CardContent className="flex items-center justify-between py-5">
-                <div>
-                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Active Sources
-                  </div>
-                  <div className="mt-2 text-2xl font-semibold">{activeSources.length}</div>
-                </div>
-                <Compass className="h-5 w-5 text-muted-foreground" />
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="flex items-center justify-between py-5">
-                <div>
-                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Due Today
-                  </div>
-                  <div className="mt-2 text-2xl font-semibold">{dueScanItems.length}</div>
-                </div>
-                <Search className="h-5 w-5 text-muted-foreground" />
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="flex items-center justify-between py-5">
-                <div>
-                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Captured Roles
-                  </div>
-                  <div className="mt-2 text-2xl font-semibold">{capturedRolesCount}</div>
-                </div>
-                <Globe2 className="h-5 w-5 text-muted-foreground" />
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="flex items-center justify-between py-5">
-                <div>
-                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Qualified Queue
-                  </div>
-                  <div className="mt-2 text-2xl font-semibold">{qualificationQueue.length}</div>
-                </div>
-                <ListChecks className="h-5 w-5 text-muted-foreground" />
-              </CardContent>
-            </Card>
-          </section>
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-1 rounded-xl border border-border bg-background/80 px-4 py-2.5 text-sm">
+            <span className="text-muted-foreground">
+              <span className="font-semibold text-foreground">{activeSources.length}</span> active sources
+            </span>
+            <span className="hidden text-muted-foreground/40 sm:inline">·</span>
+            <span className="text-muted-foreground">
+              <span className="font-semibold text-foreground">{dueScanItems.length}</span> due today
+            </span>
+            <span className="hidden text-muted-foreground/40 sm:inline">·</span>
+            <span className="text-muted-foreground">
+              <span className="font-semibold text-foreground">{capturedRolesCount}</span> captured roles
+            </span>
+            <span className="hidden text-muted-foreground/40 sm:inline">·</span>
+            <span className="text-muted-foreground">
+              <span className="font-semibold text-foreground">{qualificationQueue.length}</span> in queue
+            </span>
+          </div>
 
           <Tabs value={activeTab} onValueChange={setActiveTab}>
             <div className="flex items-center gap-2">
@@ -824,23 +795,7 @@ export default function JobOsSourcesPage() {
                                   <span>Last checked: {formatDateLabel(entry.item.lastCheckedAt)}</span>
                                 </div>
                               </div>
-                              <div className="flex flex-wrap gap-2">
-                                <Button variant="outline" size="sm" onClick={() => openUrl(entry.item.url)}>
-                                  <ExternalLink className="mr-1 h-3.5 w-3.5" />
-                                  Open
-                                </Button>
-                                <Button
-                                  variant="outline"
-                                  size="sm"
-                                  onClick={() =>
-                                    isSource
-                                      ? void handleMarkSourceChecked(entry.item as JobSource)
-                                      : void handleMarkSavedSearchChecked(entry.item as SavedSearch)
-                                  }
-                                >
-                                  <CheckCheck className="mr-1 h-3.5 w-3.5" />
-                                  Mark checked
-                                </Button>
+                              <div className="flex flex-wrap items-center gap-2">
                                 <Button
                                   size="sm"
                                   onClick={() =>
@@ -858,6 +813,26 @@ export default function JobOsSourcesPage() {
                                   <Plus className="mr-1 h-3.5 w-3.5" />
                                   Capture role
                                 </Button>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() =>
+                                    isSource
+                                      ? void handleMarkSourceChecked(entry.item as JobSource)
+                                      : void handleMarkSavedSearchChecked(entry.item as SavedSearch)
+                                  }
+                                >
+                                  <CheckCheck className="mr-1 h-3.5 w-3.5" />
+                                  Mark checked
+                                </Button>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button size="icon" variant="ghost" onClick={() => openUrl(entry.item.url)} aria-label="Open in browser">
+                                      <ExternalLink className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="top">Open in browser</TooltipContent>
+                                </Tooltip>
                               </div>
                             </div>
                           </div>
@@ -961,13 +936,20 @@ export default function JobOsSourcesPage() {
                             <TableCell>{CADENCE_LABELS[source.cadence]}</TableCell>
                             <TableCell>{formatDateLabel(source.lastCheckedAt)}</TableCell>
                             <TableCell>
-                              <div className="flex justify-end gap-2">
-                                <Button size="sm" variant="outline" onClick={() => openUrl(source.url)}>Open</Button>
-                                <Button size="sm" variant="outline" onClick={() => void handleMarkSourceChecked(source)}>Mark checked</Button>
+                              <div className="flex items-center justify-end gap-1">
                                 <Button size="sm" variant="outline" onClick={() => openSourceEditor(source)}>Edit</Button>
+                                <Button size="sm" variant="ghost" onClick={() => void handleMarkSourceChecked(source)}>Mark checked</Button>
                                 <Button size="sm" variant="ghost" onClick={() => void handleToggleSource(source)}>
                                   {source.active ? "Disable" : "Enable"}
                                 </Button>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button size="icon" variant="ghost" onClick={() => openUrl(source.url)} aria-label="Open source">
+                                      <ExternalLink className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="top">Open source</TooltipContent>
+                                </Tooltip>
                               </div>
                             </TableCell>
                           </TableRow>
@@ -998,11 +980,14 @@ export default function JobOsSourcesPage() {
                           <span>{formatDateLabel(source.lastCheckedAt)}</span>
                         </div>
                         <div className="mt-4 flex flex-wrap gap-2">
-                          <Button size="sm" variant="outline" onClick={() => openUrl(source.url)}>Open</Button>
-                          <Button size="sm" variant="outline" onClick={() => void handleMarkSourceChecked(source)}>Mark checked</Button>
                           <Button size="sm" variant="outline" onClick={() => openSourceEditor(source)}>Edit</Button>
+                          <Button size="sm" variant="ghost" onClick={() => void handleMarkSourceChecked(source)}>Mark checked</Button>
                           <Button size="sm" variant="ghost" onClick={() => void handleToggleSource(source)}>
                             {source.active ? "Disable" : "Enable"}
+                          </Button>
+                          <Button size="sm" variant="ghost" onClick={() => openUrl(source.url)}>
+                            <ExternalLink className="mr-1 h-3.5 w-3.5" />
+                            Open
                           </Button>
                         </div>
                       </div>
@@ -1098,14 +1083,21 @@ export default function JobOsSourcesPage() {
                             <TableCell>{CADENCE_LABELS[savedSearch.cadence]}</TableCell>
                             <TableCell>{formatDateLabel(savedSearch.lastCheckedAt)}</TableCell>
                             <TableCell>
-                              <div className="flex justify-end gap-2">
-                                <Button size="sm" variant="outline" onClick={() => openUrl(savedSearch.url)}>Open</Button>
-                                <Button size="sm" variant="outline" onClick={() => void handleMarkSavedSearchChecked(savedSearch)}>Mark checked</Button>
+                              <div className="flex items-center justify-end gap-1">
                                 <Button size="sm" onClick={() => openCapture({ sourceId: savedSearch.sourceId, savedSearchId: savedSearch.id, sourceUrl: savedSearch.url })}>Capture role</Button>
                                 <Button size="sm" variant="outline" onClick={() => openSavedSearchEditor(savedSearch)}>Edit</Button>
+                                <Button size="sm" variant="ghost" onClick={() => void handleMarkSavedSearchChecked(savedSearch)}>Mark checked</Button>
                                 <Button size="sm" variant="ghost" onClick={() => void handleToggleSavedSearch(savedSearch)}>
                                   {savedSearch.active ? "Disable" : "Enable"}
                                 </Button>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button size="icon" variant="ghost" onClick={() => openUrl(savedSearch.url)} aria-label="Open search">
+                                      <ExternalLink className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="top">Open search</TooltipContent>
+                                </Tooltip>
                               </div>
                             </TableCell>
                           </TableRow>
@@ -1137,12 +1129,15 @@ export default function JobOsSourcesPage() {
                           <span>{formatDateLabel(savedSearch.lastCheckedAt)}</span>
                         </div>
                         <div className="mt-4 flex flex-wrap gap-2">
-                          <Button size="sm" variant="outline" onClick={() => openUrl(savedSearch.url)}>Open</Button>
-                          <Button size="sm" variant="outline" onClick={() => void handleMarkSavedSearchChecked(savedSearch)}>Mark checked</Button>
                           <Button size="sm" onClick={() => openCapture({ sourceId: savedSearch.sourceId, savedSearchId: savedSearch.id, sourceUrl: savedSearch.url })}>Capture role</Button>
                           <Button size="sm" variant="outline" onClick={() => openSavedSearchEditor(savedSearch)}>Edit</Button>
+                          <Button size="sm" variant="ghost" onClick={() => void handleMarkSavedSearchChecked(savedSearch)}>Mark checked</Button>
                           <Button size="sm" variant="ghost" onClick={() => void handleToggleSavedSearch(savedSearch)}>
                             {savedSearch.active ? "Disable" : "Enable"}
+                          </Button>
+                          <Button size="sm" variant="ghost" onClick={() => openUrl(savedSearch.url)}>
+                            <ExternalLink className="mr-1 h-3.5 w-3.5" />
+                            Open
                           </Button>
                         </div>
                       </div>
@@ -1250,7 +1245,19 @@ export default function JobOsSourcesPage() {
                                 {role.nextStep || "Clarify next move."}
                               </div>
                             </div>
-                            <div className="flex flex-wrap gap-2">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <Button
+                                size="sm"
+                                onClick={() =>
+                                  void handleQueueAction(
+                                    role,
+                                    { discoveryStatus: "to_apply", status: "to_apply" },
+                                    `${role.title} moved to apply queue`
+                                  )
+                                }
+                              >
+                                Move to apply queue
+                              </Button>
                               <Button
                                 size="sm"
                                 variant="outline"
@@ -1263,18 +1270,6 @@ export default function JobOsSourcesPage() {
                                 }
                               >
                                 Qualify
-                              </Button>
-                              <Button
-                                size="sm"
-                                onClick={() =>
-                                  void handleQueueAction(
-                                    role,
-                                    { discoveryStatus: "to_apply", status: "to_apply" },
-                                    `${role.title} moved to apply queue`
-                                  )
-                                }
-                              >
-                                Move to Apply Queue
                               </Button>
                               <Button
                                 size="sm"
@@ -1291,17 +1286,24 @@ export default function JobOsSourcesPage() {
                                 <Archive className="mr-1 h-3.5 w-3.5" />
                                 Archive
                               </Button>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                disabled={!role.url}
-                                onClick={() => openUrl(role.url)}
-                              >
-                                Open role URL
-                              </Button>
-                              <Button asChild size="sm" variant="outline">
-                                <Link to={appPath("/cv-optimizer")}>Open CV Optimizer</Link>
-                              </Button>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button size="icon" variant="ghost" disabled={!role.url} onClick={() => openUrl(role.url)} aria-label="Open role URL">
+                                    <ExternalLink className="h-3.5 w-3.5" />
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent side="top">Open role URL</TooltipContent>
+                              </Tooltip>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button asChild size="icon" variant="ghost" aria-label="Open CV Optimizer">
+                                    <Link to={appPath("/cv-optimizer")}>
+                                      <WandSparkles className="h-3.5 w-3.5" />
+                                    </Link>
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent side="top">Open CV Optimizer</TooltipContent>
+                              </Tooltip>
                             </div>
                           </div>
                         </div>

--- a/tests/e2e/command-centre.spec.ts
+++ b/tests/e2e/command-centre.spec.ts
@@ -15,16 +15,13 @@ test.describe("Command Centre", () => {
     await expect(page.getByText("Pipeline Snapshot")).toBeVisible();
   });
 
-  test("renders Quick Actions", async ({ page }) => {
-    await expect(page.getByText("Quick Actions")).toBeVisible();
+  test("renders Weekly Execution panel", async ({ page }) => {
+    await expect(page.getByText("Weekly Execution")).toBeVisible();
   });
 
-  test("Quick Actions contains the expected actions", async ({ page }) => {
-    // "Add Role" is now a modal-trigger button (not a nav link)
-    await expect(page.getByRole("button", { name: /Add Role/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Log Application/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Tailor CV/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Browse Roles/i })).toBeVisible();
+  test("renders Pipeline Snapshot stats", async ({ page }) => {
+    await expect(page.getByText("To Apply")).toBeVisible();
+    await expect(page.getByText("Applied")).toBeVisible();
   });
 
   test("Probability Engine toggle expands the panel", async ({ page }) => {

--- a/tests/e2e/job-os-navigation.spec.ts
+++ b/tests/e2e/job-os-navigation.spec.ts
@@ -8,7 +8,7 @@ test.describe("Job OS navigation", () => {
 
   test("navigates to Companies page", async ({ page }) => {
     await page.goto("/job-os/companies");
-    await expect(page.getByText("Company Engine")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Companies" })).toBeVisible();
   });
 
   test("navigates to Roles page", async ({ page }) => {
@@ -24,7 +24,7 @@ test.describe("Job OS navigation", () => {
   test("AppNavbar contains all top-level navigation links", async ({ page }) => {
     await expect(page.getByRole("link", { name: "Action", exact: true })).toBeVisible();
     await expect(page.getByRole("link", { name: "Pipeline", exact: true })).toBeVisible();
-    await expect(page.getByRole("link", { name: "System", exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Companies & System", exact: true })).toBeVisible();
   });
 });
 

--- a/tests/e2e/job-os-navigation.spec.ts
+++ b/tests/e2e/job-os-navigation.spec.ts
@@ -8,7 +8,7 @@ test.describe("Job OS navigation", () => {
 
   test("navigates to Companies page", async ({ page }) => {
     await page.goto("/job-os/companies");
-    await expect(page.getByRole("heading", { name: "Companies" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Companies", exact: true })).toBeVisible();
   });
 
   test("navigates to Roles page", async ({ page }) => {


### PR DESCRIPTION
## What

- **Source Hub**: rewrote `JobOsSourcesPage` as a 4-tab execution dashboard (Due Today, Sources, Saved Searches, Queue) with per-tab filters and a hint tooltip. Replaced 4 KPI cards with a compact inline stat row.
- **Action hierarchy**: established primary/secondary/tertiary button hierarchy across all Source Hub tabs — Capture Role = primary (filled), Mark Checked = secondary (outline), Open = ghost icon+tooltip.
- **Roles page**: removed 7 per-column inline filters from the table header; replaced with a filter bar above the table (search + status visible by default, location/seniority/track/fit behind "More filters").
- **Single entry point for roles**: removed Quick Actions widget from Dashboard and the collapsible Add Role form from Roles page. Source Hub Capture Role is now the sole way to add roles.
- **Companies rename**: "Target Companies" → "Companies" in nav and page header; "Target" remains a `CompanyStatus` value, not the collection name. Top-nav "System" tab renamed "Companies & System".
- **Command Center nav**: restored Sources link to Dashboard secondary nav.

## Why

The previous interface had multiple competing ways to add roles (Quick Actions, Add Role card, Capture Role), equal-weight buttons on every card, 7 always-visible column filters on the Roles table, and a misleading "Target Companies" label. This PR enforces a single source of truth (Sources → Capture Role) and reduces visual noise so the next action stays the focus.

## How To Test

1. Dashboard → confirm Quick Actions widget is gone; side rail goes Weekly Execution → Pipeline Snapshot
2. Sources tab → Due Today: confirm "Capture role" is the prominent filled button; "Mark checked" is outline; Open is icon-only
3. Sources tab → Saved Searches: "Capture role" is primary; table action order correct
4. Sources tab → Queue: "Move to apply queue" is first and filled
5. Roles page → confirm no Add Role card; filter bar shows search + status; "More filters" reveals location/seniority/track/fit; search covers both company name and title
6. Nav → System section secondary nav shows "Companies" (not "Target Companies")
7. Top nav → "System" tab now reads "Companies & System"

## Evidence

- Issue: #166
- Demo artifact: N/A — label and layout changes visible immediately on load

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commits on this branch — no DB schema changes, pure UI

## Checklist

- [x] Linked to an issue with clear acceptance criteria
- [x] Scope is limited to the issue
- [x] Local checks pass (`npm run build`)
- [ ] `CHANGELOG.md` updated — UI-only refactor, no API surface changed
- [x] Demo artifact attached

Closes #166